### PR TITLE
Validate Chicago postal code

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -22,6 +22,7 @@ class Member < ApplicationRecord
   validates :city, presence: true
   validates :region, presence: true
   validates :postal_code, length: {is: 5, blank: false, message: "must be 5 digits"}
+  validate :postal_code_must_be_in_chicago
 
   scope :matching, ->(query) {
     where("email ILIKE ? OR full_name ILIKE ? OR preferred_name ILIKE ? OR phone_number LIKE ?",
@@ -60,5 +61,13 @@ class Member < ApplicationRecord
   def set_default_address_fields
     self.city ||= "Chicago"
     self.region ||= "IL"
+  end
+
+  def postal_code_must_be_in_chicago
+    return true if postal_code.nil?
+
+    unless ["60707", "60827"].include?(postal_code) || postal_code.starts_with?("606")
+      errors.add :postal_code, "must be in Chicago"
+    end
   end
 end

--- a/test/models/member_test.rb
+++ b/test/models/member_test.rb
@@ -7,4 +7,30 @@ class MemberTest < ActiveSupport::TestCase
 
     assert_equal "1234567890", member.phone_number
   end
+
+  test "allows 606 postal codes" do
+    member = FactoryBot.build(:member)
+
+    assert member.valid?
+  end
+
+  test "allows 60707 postal code" do
+    member = FactoryBot.build(:member, postal_code: "60707")
+
+    assert member.valid?
+  end
+
+  test "allows 60827 postal code" do
+    member = FactoryBot.build(:member, postal_code: "60827")
+
+    assert member.valid?
+  end
+
+  test "rejects non-Chicago postal codes" do
+    member = FactoryBot.build(:member, postal_code: "90210")
+
+    assert member.invalid?
+    assert member.errors.messages.include?(:postal_code)
+    assert member.errors.messages[:postal_code].include?("must be in Chicago")
+  end
 end


### PR DESCRIPTION
If a Postal Code has been entered, validate that it is a Chicago postal
code defined as either 60707, 60827, or any 606 code. This will need
refactored for other areas once multi-tenancy decisions have been made.

fixes #73 