### PR TITLE
make a new member's default role be "member"

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -42,12 +42,7 @@ class Member < ApplicationRecord
   before_validation :set_default_address_fields
 
   def roles
-    roles = [:member]
-    if user
-      roles.concat user.roles
-    end
-
-    roles
+    user ? user.roles : [:member]
   end
 
   def member?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,17 +5,23 @@ class User < ApplicationRecord
     :recoverable, :rememberable, :validatable,
     :lockable, :timeoutable, :trackable
 
+  # while the canonical list of roles is the "user_role" enum in the
+  # database, this enum exists to help display the list of roles
+  # elsewhere in the app
   enum role: {
+    member: "member",
     staff: "staff",
-    admin: "admin"
+    admin: "admin",
   }
 
   def roles
     case role
+    when 'member'
+      [:member]
     when 'staff'
-      [:staff]
+      [:member, :staff]
     when 'admin'
-      [:staff, :admin]
+      [:member, :staff, :admin]
     else
       []
     end

--- a/db/migrate/20200906142639_add_member_to_role_enum.rb
+++ b/db/migrate/20200906142639_add_member_to_role_enum.rb
@@ -1,0 +1,6 @@
+class AddMemberToRoleEnum < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+  def change
+    add_enum_value :user_role, "member"
+  end
+end

--- a/db/migrate/20200906142955_change_default_role_on_user.rb
+++ b/db/migrate/20200906142955_change_default_role_on_user.rb
@@ -1,0 +1,5 @@
+class ChangeDefaultRoleOnUser < ActiveRecord::Migration[6.0]
+  def change
+    change_column_default :users, :role, from: "staff", to: "member"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_05_185238) do
+ActiveRecord::Schema.define(version: 2020_09_06_142955) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define(version: 2020_09_05_185238) do
   create_enum :user_role, [
     "staff",
     "admin",
+    "member",
   ]
 
   create_table "action_text_rich_texts", force: :cascade do |t|
@@ -303,7 +304,7 @@ ActiveRecord::Schema.define(version: 2020_09_05_185238) do
     t.datetime "locked_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.enum "role", default: "staff", null: false, enum_name: "user_role"
+    t.enum "role", default: "member", null: false, enum_name: "user_role"
     t.bigint "member_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["member_id"], name: "index_users_on_member_id"

--- a/test/models/member_test.rb
+++ b/test/models/member_test.rb
@@ -33,9 +33,17 @@ class MemberTest < ActiveSupport::TestCase
     assert member.errors.messages.include?(:postal_code)
     assert member.errors.messages[:postal_code].include?("must be in Chicago")
   end
-  
+
   test "member without a user has a role 'member'" do
     member = Member.new
+
+    assert_equal [:member], member.roles
+    assert member.member?
+  end
+
+  test "member with a user has a default role of 'member'" do
+    user = User.new
+    member = Member.new(user: user)
 
     assert_equal [:member], member.roles
     assert member.member?


### PR DESCRIPTION
Fixes #135 

* adds a test for "member" being default
* updates the enums that define the list of known roles to include "member"
* `member.roles` simplified to delegate to `member.user.roles`