### PR TITLE
Swap find for where to grab category names

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -67,7 +67,12 @@ module AdminHelper
       value = BorrowPolicy.find(value).complete_name
     when "category_ids"
       key = "categories"
-      value = Category.find(value).map(&:name).join(", ")
+      category_names = Category.where(id: value).map(&:name)
+      deleted_category_count = value.count - category_names.count
+      if deleted_category_count > 0
+        category_names << ['deleted category'] * deleted_category_count
+      end
+      value = category_names.join(", ")
     end
 
     if audit.action == "create" && value.blank?


### PR DESCRIPTION
Using `find` throws an error on an item's edit history page when the category has been deleted. Updates the query to use `where` instead. If the number of categories found is less than the number of keys, add the string `deleted category` to signify that there was also a now missing value associated with the item. Adds a test to exercise this behavior.

Issue #41

ruby -I ./test test/system/items_test.rb output:

Finished in 10.779663s, 0.6494 runs/s, 1.4843 assertions/s.
7 runs, 16 assertions, 0 failures, 0 errors, 1 skips