### PR TITLE
Ensure that single category changees are saved in audit history

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -103,7 +103,7 @@ class Item < ApplicationRecord
 
   # called when item is updated
   def audited_changes
-    if @current_category_ids.present? && @current_category_ids != category_ids.sort
+    if (@current_category_ids.present? || category_ids.present?) && @current_category_ids != category_ids.sort
       super.merge("category_ids" => [@current_category_ids, category_ids.sort])
     else
       super

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -47,4 +47,14 @@ class ItemTest < ActiveSupport::TestCase
     assert_equal "a bc", item.serial
     assert_equal "heavy", item.strength
   end
+
+  test "adding a single category is saved in the audit history" do
+    @item = create(:complete_item)
+    @category = create(:category)
+
+    @item.categories << @category
+    @item.save!
+
+    assert_equal @category.id, @item.audits.last.audited_changes["category_ids"].flatten.first
+  end
 end


### PR DESCRIPTION
When an item has no categories (whether on creation or if the categories are all cleared), the audit history will not include an entry when a category is subsequently added. Two changes must be made before it is saved. This is because there is a check for presence of cached category ids before initiating the audit addition. This PR updates the logic to ensure that an entry is created anytime the new category ids do not match the cached category ids.

Co-authored with @johnksawers 

Finished in 5.790894s, 29.5291 runs/s, 96.8762 assertions/s.
171 runs, 561 assertions, 0 failures, 0 errors, 2 skips