### PR TITLE
Create table, model for appointment and appointment holds

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -1,0 +1,7 @@
+class Appointment < ApplicationRecord
+  has_many :appointment_holds
+  has_many :holds, through: :appointment_holds
+  belongs_to :member
+
+  validates :starts_at, :ends_at, presence: true
+end

--- a/app/models/appointment_hold.rb
+++ b/app/models/appointment_hold.rb
@@ -1,0 +1,4 @@
+class AppointmentHold < ApplicationRecord
+  belongs_to :appointment
+  belongs_to :hold
+end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -3,6 +3,7 @@ class Member < ApplicationRecord
   has_many :adjustments
 
   has_many :loans, dependent: :destroy
+  has_many :appointments, dependent: :destroy
   has_many :loan_summaries
 
   has_many :holds, dependent: :destroy

--- a/db/migrate/20200923151427_create_appointments.rb
+++ b/db/migrate/20200923151427_create_appointments.rb
@@ -1,0 +1,12 @@
+class CreateAppointments < ActiveRecord::Migration[6.0]
+  def change
+    create_table :appointments do |t|
+      t.datetime :starts_at, null: false
+      t.datetime :ends_at, null: false
+      t.text :comment, null: false, default: ""
+      t.belongs_to :member
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200923152956_create_appointment_holds.rb
+++ b/db/migrate/20200923152956_create_appointment_holds.rb
@@ -1,0 +1,10 @@
+class CreateAppointmentHolds < ActiveRecord::Migration[6.0]
+  def change
+    create_table :appointment_holds do |t|
+      t.belongs_to :appointment
+      t.belongs_to :hold
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_06_182546) do
+ActiveRecord::Schema.define(version: 2020_09_23_152956) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -18,32 +19,32 @@ ActiveRecord::Schema.define(version: 2020_09_06_182546) do
     "fine",
     "membership",
     "donation",
-    "payment"
+    "payment",
   ], force: :cascade
 
   create_enum :adjustment_source, [
     "cash",
     "square",
-    "forgiveness"
+    "forgiveness",
   ], force: :cascade
 
   create_enum :hold_request_status, [
     "new",
     "completed",
-    "denied"
+    "denied",
   ], force: :cascade
 
   create_enum :notification_status, [
     "pending",
     "sent",
     "bounced",
-    "error"
+    "error",
   ], force: :cascade
 
   create_enum :user_role, [
     "staff",
     "admin",
-    "member"
+    "member",
   ], force: :cascade
 
   create_table "action_text_rich_texts", force: :cascade do |t|
@@ -97,6 +98,25 @@ ActiveRecord::Schema.define(version: 2020_09_06_182546) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["member_id"], name: "index_agreement_acceptances_on_member_id"
+  end
+
+  create_table "appointment_holds", force: :cascade do |t|
+    t.bigint "appointment_id"
+    t.bigint "hold_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["appointment_id"], name: "index_appointment_holds_on_appointment_id"
+    t.index ["hold_id"], name: "index_appointment_holds_on_hold_id"
+  end
+
+  create_table "appointments", force: :cascade do |t|
+    t.datetime "starts_at", null: false
+    t.datetime "ends_at", null: false
+    t.text "comment", default: "", null: false
+    t.bigint "member_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["member_id"], name: "index_appointments_on_member_id"
   end
 
   create_table "audits", force: :cascade do |t|

--- a/test/factories/appointment_holds.rb
+++ b/test/factories/appointment_holds.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :appointment_hold do
+    appointment
+    hold
+  end
+end

--- a/test/factories/appointments.rb
+++ b/test/factories/appointments.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :appointment do
+    starts_at { "2020-09-23 11:14:27" }
+    ends_at { "2020-09-23 12:14:27" }
+    comment { "My Comment" }
+    member
+  end
+end

--- a/test/models/appointment_hold_test.rb
+++ b/test/models/appointment_hold_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class AppointmentHoldTest < ActiveSupport::TestCase
+  test "creates an appointment hold for member appointment" do
+    appointment = FactoryBot.create(:appointment)
+    user = FactoryBot.create(:user)
+    member = FactoryBot.create(:member, user: user)
+    hold = FactoryBot.create(:hold, creator: member.user)
+    hold_two = FactoryBot.create(:hold, creator: member.user)
+    appointment_hold = FactoryBot.create(:appointment_hold, appointment: appointment, hold: hold)
+    appointment_hold_two = FactoryBot.create(:appointment_hold, appointment: appointment, hold: hold_two)
+    assert_equal "Ida B. Wells", appointment_hold.hold.member.full_name
+    assert_equal 2, appointment.holds.length
+  end
+end

--- a/test/models/appointment_test.rb
+++ b/test/models/appointment_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class AppointmentTest < ActiveSupport::TestCase
+  test "creates an appointment" do
+    appointment = FactoryBot.create(:appointment)
+
+    assert_equal "My Comment", appointment.comment
+  end
+end


### PR DESCRIPTION
This adds appointment and appointment holds tables and models with all the relationships.

We came up with the names for models and we can discuss it here if we want a different naming.

We currently have `appointment_holds` joint table to store multiple holds for an appointment. 

In conversation with Greg, we thought it would be ok for us to use this joint table for pickup and returns. We would need to check for `loan_id` on the hold and if nil, we assume it's a hold without loan yet, otherwise, we assume it's a loan and it's being returned.

All of these are open to discussion.

Story [link](https://github.com/rubyforgood/circulate/issues/227)