### PR TITLE
Fix puma config to work with debugging

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -16,7 +16,8 @@ port ENV.fetch("PORT", 3000)
 
 # Specifies the `environment` that Puma will run in.
 #
-environment ENV.fetch("RAILS_ENV", "development")
+environment_name = ENV.fetch("RAILS_ENV", "development")
+environment environment_name
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked web server processes. If using threads and workers together
@@ -24,7 +25,7 @@ environment ENV.fetch("RAILS_ENV", "development")
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-workers ENV.fetch("WEB_CONCURRENCY", 2)
+workers ENV.fetch("WEB_CONCURRENCY", 2) unless environment_name == "development"
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code


### PR DESCRIPTION
When workers are specified, Puma will run in a clustered mode. Worker
processes will be killed if they do not report back to the parent
process that manages the cluster. This makes using debugging tools very
frustrating and less than productive. When the worker processes is
killed the debugging session is broken, and the standard in is
closed.

To address this issue, only specify a worker configuration when the
environment is not development.