### PR TITLE
CSS fixes

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -1066,3 +1066,18 @@ ul.hold-items {
     p { margin-bottom: .2rem; }
   }
 }
+
+.account-settings-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.account-settings-btn {
+  margin-bottom: 18px;
+}
+
+.btn-margin {
+  margin-left: 20px;
+}

--- a/app/javascript/stylesheets/globals.scss
+++ b/app/javascript/stylesheets/globals.scss
@@ -109,7 +109,7 @@ body {
 
 .btn-link {
   font-weight: bold;
-  color: $link-color !important;
+  color: $new-link-color !important;
   font-family: Proxima Nova, "Helvetica Neue", Helvetica, Arial, sans-serif;
   background-color: transparent;
   border: none;
@@ -157,7 +157,7 @@ body {
   @include title_uppercase_weight;
   font-size: 12px;
   letter-spacing: $title-letter-spacing;
-  opacity: 60%;
+  opacity: .5;
 }
 
 .caption_lg {
@@ -165,7 +165,7 @@ body {
   @include title_uppercase_weight;
   font-size: 20px;
   letter-spacing: $button-letter-spacing;
-  opacity: 60%;
+  opacity: .5;
 }
 
 .caption_xs {
@@ -202,4 +202,11 @@ body {
   &:hover {
     color: #000 !important;
   }
+}
+
+.card-container {
+  background-color: white;
+  border-radius: 7px;
+  border: #E4E8F0 solid 1px;
+  padding: 20px;
 }

--- a/app/javascript/stylesheets/mixins.scss
+++ b/app/javascript/stylesheets/mixins.scss
@@ -3,7 +3,7 @@ $text-color: #4a4a4a !important;
 $title-size: 36px;
 $button-letter-spacing: .1em;
 $title-letter-spacing: .07em;
-$link-color: #36b3a8;
+$new-link-color: #36b3a8;
 
 
 @mixin standard_font {

--- a/app/views/admin/dev/styles.html.erb
+++ b/app/views/admin/dev/styles.html.erb
@@ -56,11 +56,17 @@
 <br>
 <br>
 <br>
+
+<div class="card-container">
+  Card
+</div>
+<br>
+<br>
 <span>Typography styles</span>
 <br>
 <span class="new_title">Title</span>
 <br>
-<span class="title_bold">Title Bold a</span>
+<span class="title_bold">Title Bold</span>
 <br>
 <span class="body">Body</span>
 <br>

--- a/app/views/member_profiles/show.html.erb
+++ b/app/views/member_profiles/show.html.erb
@@ -1,9 +1,16 @@
-<div class="d-flex">
+<div class="account-settings-heading">
   <h2 class="new_title">Account Settings</h2>
   <div class="d-flex justify-content-end">
+    <button class="secondary-btn account-settings-btn">
+      <%= link_to "Edit Password", edit_member_profiles_password_url, class: "secondary-btn-text" %>
+    </button>
+    <br> <br>
+    <button class="primary-btn btn-margin">
+      <%= link_to "Edit Member Profile", edit_member_profile_path, class: "primary-btn-text" %>
+    </button>
   </div>
 </div>
-<div class="columns">
+<div class="columns card-container">
   <div class="column">
     <dl>
       <dt class="caption">Full Name</dt>
@@ -30,13 +37,7 @@
         <%= @member.postal_code %>
       </dd>
     </dl>
-    <button class="primary-btn">
-      <%= link_to "Edit Member Profile", edit_member_profile_path, class: "primary-btn-text" %>
-    </button>
-    <br> <br>
-    <button class="secondary-btn">
-      <%= link_to "Edit Password", edit_member_profiles_password_url, class: "secondary-btn-text" %>
-    </button>
+
   </div>
   <div class="column">
 


### PR DESCRIPTION
**This PR includes:**

- The renaming of the of the `$link-color` so it doesn't interfere with the old styling still in place

- Changing the opacity of `caption` and `caption_lg` from `60%` to `.5` so that it doesn't display weird in heroku

- The addition of `card` to the style guide

- Styling of Account Settings page

<img width="1676" alt="Screen Shot 2020-09-25 at 11 51 08 AM" src="https://user-images.githubusercontent.com/50629488/94288479-6fa24600-ff25-11ea-8d0c-ff537cc7db6c.png">


