### PR TITLE
Fix btn-link naming conflict

### DIFF
--- a/app/javascript/stylesheets/globals.scss
+++ b/app/javascript/stylesheets/globals.scss
@@ -107,7 +107,7 @@ body {
   letter-spacing: $button-letter-spacing;
 }
 
-.btn-link {
+.btn-link-mint {
   font-weight: bold;
   color: $new-link-color !important;
   font-family: Proxima Nova, "Helvetica Neue", Helvetica, Arial, sans-serif;

--- a/app/javascript/stylesheets/globals.scss
+++ b/app/javascript/stylesheets/globals.scss
@@ -107,7 +107,7 @@ body {
   letter-spacing: $button-letter-spacing;
 }
 
-.btn-link-mint {
+.link-btn {
   font-weight: bold;
   color: $new-link-color !important;
   font-family: Proxima Nova, "Helvetica Neue", Helvetica, Arial, sans-serif;

--- a/app/views/admin/dev/styles.html.erb
+++ b/app/views/admin/dev/styles.html.erb
@@ -52,7 +52,7 @@
 
 <button class="primary-btn">New Primary</button>
 <button class="secondary-btn">New Secondary</button>
-<button class="btn-link">New Link</button>
+<button class="btn-link-mint">New Link</button>
 <br>
 <br>
 <br>

--- a/app/views/admin/dev/styles.html.erb
+++ b/app/views/admin/dev/styles.html.erb
@@ -52,7 +52,7 @@
 
 <button class="primary-btn">New Primary</button>
 <button class="secondary-btn">New Secondary</button>
-<button class="btn-link-mint">New Link</button>
+<button class="link-btn">New Link</button>
 <br>
 <br>
 <br>


### PR DESCRIPTION
#### What does this PR do?

Renamed custom link button class to avoid naming conflict with existing `.btn-link` class.