### PR TITLE
#182 Add a link on the non-admin navbar (including on Member pages) for librarians to get to the admin pages if logged in.

### DIFF
--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -139,6 +139,9 @@
             <% end %>
           </section>
           <%= render partial: "shared/time_override" if Rails.env.development? %>
+          <div class="dropdown">
+            <%= link_to "Members Page", root_path, class: "btn btn-link" %>
+          </div>
           <section class="navbar-section">
             <% if user_signed_in? %>
               <%= link_to "Sign out", destroy_user_session_path, method: :delete, class: "btn btn-link" %>
@@ -152,7 +155,7 @@
       <div class="app">
         <div class="header-header">
           <div class="container grid-lg">
-            <%= yield :header %>      
+            <%= yield :header %>
           </div>
         </div>
       </div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -55,6 +55,9 @@
             </ul>
           </li>
         </ul>
+        <div class="dropdown">
+            <%= link_to "Members Page", root_path, class: "btn btn-link" %>
+        </div>
 
         <ul class="nav">
           <% if user_signed_in? %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -51,9 +51,9 @@
             <ul class="nav">
               <li class="nav-item"><%= link_to "View Inventory", items_path %></li>
               <li class="nav-item"><%= link_to "Become a Member", signup_path %></li>
-              <% if current_user.admin?%>
+              <% if current_user.admin? %>
                 <li class="nav-item"><%= link_to "Admin Dashboard", admin_dashboard_path %></li>
-              <% end%>
+              <% end %>
             </ul>
 
             <%# Member Links -- Displayed if User is Signed in %>
@@ -89,7 +89,7 @@
           </span>
           <span class="navbar-brand  mr-2 ml-2"><%= link_to "View Inventory", items_path %></span>
           <span class="navbar-brand  mr-2 ml-2"><%= link_to "Become a Member", signup_path %></span>
-          <% if current_user.admin?%>
+          <% if current_user.admin? %>
             <span class="navbar-brand  mr-2 ml-2"><%= link_to "Admin Dashboard", admin_dashboard_path %></span>
           <% end %>
           |

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -51,8 +51,11 @@
             <ul class="nav">
               <li class="nav-item"><%= link_to "View Inventory", items_path %></li>
               <li class="nav-item"><%= link_to "Become a Member", signup_path %></li>
+              <% if current_user.admin?%>
+                <li class="nav-item"><%= link_to "Admin Dashboard", admin_dashboard_path %></li>
+              <% end%>
             </ul>
-            
+
             <%# Member Links -- Displayed if User is Signed in %>
             <% if user_signed_in? %>
               <span class="nav-category">Member Links</span>
@@ -84,14 +87,17 @@
             <%= image_pack_tag "logo_small.png" %>
             </a>
           </span>
-          <span class="navbar-brand new-menu-style mr-2 ml-2"><%= link_to "View Inventory", items_path %></span>
+          <span class="navbar-brand  mr-2 ml-2"><%= link_to "View Inventory", items_path %></span>
+          <span class="navbar-brand  mr-2 ml-2"><%= link_to "Become a Member", signup_path %></span>
+          <% if current_user.admin?%>
+            <span class="navbar-brand  mr-2 ml-2"><%= link_to "Admin Dashboard", admin_dashboard_path %></span>
+          <% end %>
+          |
           <%= form_with url: search_path, method: :get, class: "mr-2", local: true do |form| %>
             <div class="input-group input-inline">
               <%= form.text_field :query, class: "form-input input-sm", placeholder: "search items" %>
             </div>
           <% end %>
-          |
-          <span class="navbar-brand new-menu-style mr-2 ml-2"><%= link_to "Become a Member", signup_path %></span>
         </section>
         <%= render partial: 'layouts/user', object: @member, as: :member %>
       </header>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -51,7 +51,7 @@
             <ul class="nav">
               <li class="nav-item"><%= link_to "View Inventory", items_path %></li>
               <li class="nav-item"><%= link_to "Become a Member", signup_path %></li>
-              <% if current_user.admin? %>
+              <% if user_signed_in? && current_user.admin? %>
                 <li class="nav-item"><%= link_to "Admin Dashboard", admin_dashboard_path %></li>
               <% end %>
             </ul>
@@ -89,7 +89,7 @@
           </span>
           <span class="navbar-brand  mr-2 ml-2"><%= link_to "View Inventory", items_path %></span>
           <span class="navbar-brand  mr-2 ml-2"><%= link_to "Become a Member", signup_path %></span>
-          <% if current_user.admin? %>
+          <% if user_signed_in? && current_user.admin? %>
             <span class="navbar-brand  mr-2 ml-2"><%= link_to "Admin Dashboard", admin_dashboard_path %></span>
           <% end %>
           |


### PR DESCRIPTION
If a Member is a librarian, display a link to the admin pages in the general navbar. Possibly to the left of the member name? E.g., "Go to Admin display," though there's probably a shorter way of saying it. Maybe "Admin" with an arrow or other graphic?

Possibly also do similar on the admin pages, linking to the Member pages? (E.g., "Go to Member display," or something shorter.)

Closes https://github.com/rubyforgood/circulate/issues/182