### PR TITLE
Fix item link on loans page

### DIFF
--- a/app/views/members/loans.html.erb
+++ b/app/views/members/loans.html.erb
@@ -27,7 +27,7 @@
             <% end %>
           <% end %>
         </td>
-        <td><%= link_to loan.item.name %></td>
+        <td><%= link_to loan.item.name, item_path(loan.item) %></td>
         <td><%= loan.item.complete_number %></td>
         <td class=<%= loan.due_at - Time.now < 3.days ? "warning" : "" %>><%= "Due #{humanize_due_date(loan)}" %></td>
         <td><%= loan.status %></td>

--- a/test/models/membership_test.rb
+++ b/test/models/membership_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class MembershipTest < ActiveSupport::TestCase
   test "creates a membership for a member" do
     member = create(:member)
-    now = Time.current.to_date
+    now = Time.current.beginning_of_day
 
     membership = assert_difference("Membership.count", 1) {
       assert_difference("Adjustment.count", 0) {
@@ -18,7 +18,7 @@ class MembershipTest < ActiveSupport::TestCase
 
   test "creates a membership for a member with a cash payment" do
     member = create(:member)
-    now = Time.current.to_date
+    now = Time.current.beginning_of_day
     amount = Money.new(12.34)
 
     membership = assert_difference("Membership.count", 1) {
@@ -43,7 +43,7 @@ class MembershipTest < ActiveSupport::TestCase
 
   test "creates a membership for a member with a square payment" do
     member = create(:member)
-    now = Time.current.to_date
+    now = Time.current.beginning_of_day
     amount = Money.new(12.34)
 
     membership = assert_difference("Membership.count", 1) {

--- a/test/system/member_checked_out_items_test.rb
+++ b/test/system/member_checked_out_items_test.rb
@@ -16,5 +16,8 @@ class MemberCheckedOutItemsTest < ApplicationSystemTestCase
     within "#loans-table" do
       assert_text @loan.item.name
     end
+
+    click_on @loan.item.name
+    assert_equal "/items/#{@loan.item.id}", current_path
   end
 end


### PR DESCRIPTION
Fix item link from `/members/loans` checkout table such that clicking
on it will take the member to that item's overview page.

Issue #253

`rails test`
208 runs, 624 assertions, 0 failures, 0 errors, 2 skips

`rails test test/system/member_checked_out_items_test.rb`
1 runs, 3 assertions, 0 failures, 0 errors, 0 skips
(getting a couple of errors for other system tests, but appear unrelated)