### PR TITLE
Disable button on submission

### DIFF
--- a/app/lib/spectre_form_builder.rb
+++ b/app/lib/spectre_form_builder.rb
@@ -132,7 +132,7 @@ class SpectreFormBuilder < ActionView::Helpers::FormBuilder
   end
 
   def submit(label = nil, options = {}, &block)
-    parent_button(label, options.merge(type: "submit", class: "btn btn-primary btn-lg btn-block"), &block)
+    parent_button(label, options.merge(type: "submit", class: "btn btn-primary btn-lg btn-block", data: { disable: true }), &block)
   end
 
   def errors

--- a/test/system/gift_memberships_test.rb
+++ b/test/system/gift_memberships_test.rb
@@ -73,4 +73,22 @@ class GiftMembershipsTest < ApplicationSystemTestCase
 
     assert_text "Gift membership was successfully destroyed"
   end
+
+  test "double clicking create gift membership does not create multiple gift memberships" do
+    visit admin_gift_memberships_url
+    click_on "New Gift Membership"
+
+    fill_in "Amount", with: "100"
+    fill_in "Purchaser email", with: "repeat_test@place.biz"
+    fill_in "Purchaser name", with: "repeat buyer"
+    fill_in "Recipient name", with: "repeat recipient"
+
+    perform_enqueued_jobs do
+      find("button", text: "Create Gift membership").double_click
+
+      assert_text "Gift membership was successfully created", wait: 10
+    end
+
+    assert_equal 1, GiftMembership.all.map(&:purchaser_email).count("repeat_test@place.biz")
+  end
 end

--- a/test/system/items_test.rb
+++ b/test/system/items_test.rb
@@ -140,4 +140,24 @@ class ItemsTest < ApplicationSystemTestCase
     assert_text "The manual was imported", wait: 10
     assert_text "Manual: C5200-20manual.pdf"
   end
+
+  test "double clicking create item doesn't create multiple items" do
+    @item = build(:item, name: "Repeated item name")
+
+    visit admin_items_url
+    click_on "New Item"
+
+    fill_in "Name", with: @item.name
+    find("summary", text: "Description").click
+    fill_in_rich_text_area "item_description", with: @item.description
+    fill_in "Size", with: @item.size
+    fill_in "Strength", with: @item.strength
+    fill_in "Brand", with: @item.brand
+    fill_in "Model", with: @item.model
+    fill_in "Serial", with: @item.serial
+    find("button", text: "Create Item").double_click
+
+    assert_text "Item was successfully created"
+    assert_equal 1, Item.all.map(&:name).count(@item.name)
+  end
 end


### PR DESCRIPTION
It's possible to click buttons multiple times and accidentally
create duplicate items. This PR updates the submit method to
utilize the data-disable HTML attribute. This will grey out the
button on submit to prevent unintentional multi clicks. Adds a
couple of tests to ensure that duplicate items aren't created
when double clicking (specifically for new items and gift
memberships). These tests should fail on current development but
pass on this branch.

Issue #157

rails test
208 runs, 624 assertions, 0 failures, 0 errors, 2 skips

rails test:system
58 runs, 249 assertions, 2 failures, 0 errors, 4 skips
(seemingly unrelated: test/system/holds/holds_test.rb:21 and test/system/holds/holds_test.rb:70)