### PR TITLE
Add power source field to items

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -108,7 +108,7 @@ module Admin
     def all_item_params
       params.require(:item).permit(
         :name, :other_names, :description, :size, :brand, :model, :serial, :number, :image, :status, :strength,
-        :borrow_policy_id, :quantity, :checkout_notice, :manual, :delete_manual, category_ids: []
+        :power_source, :borrow_policy_id, :quantity, :checkout_notice, :manual, :delete_manual, category_ids: []
       )
     end
 

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -17,6 +17,16 @@ module ItemsHelper
     end
   end
 
+  def item_power_source_options
+    Item.power_sources.map do |key, value|
+      [value.titleize, key]
+    end
+  end
+
+  def item_powered_by_label(item)
+    Item.power_sources[item.power_source]&.titleize
+  end
+
   def borrow_policy_options
     BorrowPolicy.alpha_by_code.map do |borrow_policy|
       ["(#{borrow_policy.code}) #{borrow_policy.name}: #{borrow_policy.description}", borrow_policy.id]

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -28,6 +28,14 @@ class Item < ApplicationRecord
 
   enum status: [:pending, :active, :maintenance, :retired]
 
+  enum power_source: {
+    solar: "solar",
+    gas: "gas",
+    air: "air",
+    electric_corded: "electric (corded)",
+    electric_battery: "electric (battery)"
+  }
+
   audited
 
   scope :name_contains, ->(query) { where("name ILIKE ?", "%#{query}%").limit(10).distinct }
@@ -44,6 +52,7 @@ class Item < ApplicationRecord
   validates :name, presence: true
   validates :number, numericality: {only_integer: true}, uniqueness: true
   validates :status, inclusion: {in: Item.statuses.keys}
+  validates :power_source, inclusion: {in: Item.power_sources.keys}, allow_blank: true
   validates :borrow_policy_id, inclusion: {in: ->(item) { BorrowPolicy.pluck(:id) }}
 
   before_validation :assign_number, on: :create

--- a/app/views/admin/items/_form.html.erb
+++ b/app/views/admin/items/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with(model: [:admin, item], builder: SpectreFormBuilder, data: {controller: "form"}, id: dom_id(item)) do |form| %>
   <%= form.errors %>
 
-  <%= form.autocomplete_text_field :name, path: admin_ui_names_path(format: :json), autofocus: true, 
+  <%= form.autocomplete_text_field :name, path: admin_ui_names_path(format: :json), autofocus: true,
       hint: "Generic name for the tool; e.g. Impact driver, Orchard ladder, Flathead screwdriver" %>
 
   <%= form.text_field :other_names,
@@ -20,11 +20,13 @@
 
   <%= form.text_area :checkout_notice, hint: "Shown when checking item out" %>
 
-  <%= form.autocomplete_text_field :size, path: admin_ui_sizes_path(format: :json), 
+  <%= form.autocomplete_text_field :size, path: admin_ui_sizes_path(format: :json),
       hint: "Blade or bit diameter, width or height; e.g. 3/8\"" %>
 
   <%= form.autocomplete_text_field :strength, path: admin_ui_strengths_path(format: :json),
       hint: "i.e. voltage or amps; e.g. 18v, heavy duty" %>
+
+  <%= form.select :power_source, options_for_select(item_power_source_options, item.power_source), include_blank: "Not powered", hint: "Specify how the item is powered, if it is powered" %>
 
   <%= form.autocomplete_text_field :brand, path: admin_ui_brands_path(format: :json), hint: "e.g. Dewalt, Craftsman, Singer" %>
   <%= form.text_field :model, hint: "e.g. ABC-123; usually found on the back or bottom" %>

--- a/app/views/admin/items/_profile.html.erb
+++ b/app/views/admin/items/_profile.html.erb
@@ -18,7 +18,7 @@
 
   </div>
   <% end %>
-  
+
 <% end %>
 
 <div class="columns">
@@ -45,6 +45,7 @@
         <ul class="item-stats">
           <%= icon_stat "maximize", @item.size, title: "size", placeholder: "No size" %>
           <%= icon_stat "zap", @item.strength, title: "strength", placeholder: "No strength" %>
+          <%= icon_stat "battery-charging", item_powered_by_label(@item), title: "powered by", placeholder: "Not powered" %>
           <%= icon_stat "package", @item.brand, title: "brand", placeholder: "No brand" %>
           <%= icon_stat "box", @item.model, title: "model", placeholder: "No model" %>
           <%= icon_stat "hash", @item.serial, title: "serial number", placeholder: "No serial number" %>
@@ -86,4 +87,3 @@
 
   </div>
 </div>
-

--- a/app/views/items/_details.html.erb
+++ b/app/views/items/_details.html.erb
@@ -9,6 +9,10 @@
     <p><strong>Strength:</strong> <%= item.strength %></p>
   <% end %>
 
+  <% unless item.power_source.blank? %>
+    <p><strong>Powered by:</strong> <%= item_powered_by_label(item) %></p>
+  <% end %>
+
   <% unless item.brand.blank? %>
     <p><strong>Brand:</strong> <%= item.brand %></p>
   <% end %>

--- a/db/migrate/20201002020141_add_power_source_to_items.rb
+++ b/db/migrate/20201002020141_add_power_source_to_items.rb
@@ -1,0 +1,9 @@
+class AddPowerSourceToItems < ActiveRecord::Migration[6.0]
+  def change
+    create_enum :power_source, ["solar", "gas", "air", "electric (corded)", "electric (battery)"]
+
+    change_table :items do |t|
+      t.enum :power_source, enum_name: :power_source
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_24_184016) do
+ActiveRecord::Schema.define(version: 2020_10_02_020141) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,14 @@ ActiveRecord::Schema.define(version: 2020_09_24_184016) do
     "sent",
     "bounced",
     "error",
+  ], force: :cascade
+
+  create_enum :power_source, [
+    "solar",
+    "gas",
+    "air",
+    "electric (corded)",
+    "electric (battery)",
   ], force: :cascade
 
   create_enum :user_role, [
@@ -271,6 +279,7 @@ ActiveRecord::Schema.define(version: 2020_09_24_184016) do
     t.string "checkout_notice"
     t.integer "holds_count", default: 0, null: false
     t.string "other_names"
+    t.enum "power_source", enum_name: "power_source"
     t.index ["borrow_policy_id"], name: "index_items_on_borrow_policy_id"
   end
 

--- a/test/controllers/admin/items_controller_test.rb
+++ b/test/controllers/admin/items_controller_test.rb
@@ -22,7 +22,7 @@ module Admin
 
     test "should create item" do
       assert_difference("Item.count") do
-        post admin_items_url, params: {item: {brand: @item.brand, description: @item.description, model: @item.model, name: @item.name, serial: @item.serial, size: @item.size, strength: @item.strength, borrow_policy_id: @item.borrow_policy_id}}
+        post admin_items_url, params: {item: {brand: @item.brand, description: @item.description, model: @item.model, name: @item.name, serial: @item.serial, size: @item.size, strength: @item.strength, power_source: @item.power_source, borrow_policy_id: @item.borrow_policy_id}}
       end
 
       assert_redirected_to admin_item_number_url(Item.last)
@@ -39,7 +39,7 @@ module Admin
     end
 
     test "should update item" do
-      patch admin_item_url(@item), params: {item: {brand: @item.brand, description: @item.description, model: @item.model, name: @item.name, serial: @item.serial, size: @item.size, borrow_policy_id: @item.borrow_policy_id}}
+      patch admin_item_url(@item), params: {item: {brand: @item.brand, description: @item.description, model: @item.model, name: @item.name, serial: @item.serial, size: @item.size, power_source: @item.power_source, borrow_policy_id: @item.borrow_policy_id}}
       assert_redirected_to admin_item_url(@item)
     end
 

--- a/test/factories/items.rb
+++ b/test/factories/items.rb
@@ -13,6 +13,7 @@ FactoryBot.define do
       size { "1/4" }
       strength { "12v" }
       serial { "abcdefg" }
+      power_source { Item.power_sources[:electric_battery] }
     end
 
     factory :uncounted_item do

--- a/test/system/items_test.rb
+++ b/test/system/items_test.rb
@@ -36,7 +36,7 @@ class ItemsTest < ApplicationSystemTestCase
     fill_in "Name", with: @item.name
     fill_in "Brand", with: @item.brand
     fill_in_rich_text_area "item_description", with: @item.description
-    select @item.power_source, from: "Power source"
+    select "Solar", from: "Power source"
     fill_in "Model", with: @item.model
     fill_in "Serial", with: @item.serial
     fill_in "Size", with: @item.size

--- a/test/system/items_test.rb
+++ b/test/system/items_test.rb
@@ -16,6 +16,7 @@ class ItemsTest < ApplicationSystemTestCase
     fill_in_rich_text_area "item_description", with: @item.description
     fill_in "Size", with: @item.size
     fill_in "Strength", with: @item.strength
+    select "Gas", from: "Power source"
     fill_in "Brand", with: @item.brand
     fill_in "Model", with: @item.model
     fill_in "Serial", with: @item.serial
@@ -35,6 +36,7 @@ class ItemsTest < ApplicationSystemTestCase
     fill_in "Name", with: @item.name
     fill_in "Brand", with: @item.brand
     fill_in_rich_text_area "item_description", with: @item.description
+    select @item.power_source, from: "Power source"
     fill_in "Model", with: @item.model
     fill_in "Serial", with: @item.serial
     fill_in "Size", with: @item.size


### PR DESCRIPTION
Resolves #152

Add `power_source` to `Item`.

![image](https://user-images.githubusercontent.com/56947/94883337-6985fb00-0438-11eb-90a3-018e9708ffe8.png)
![image](https://user-images.githubusercontent.com/56947/94883348-6ee34580-0438-11eb-8efc-15d482b57c0a.png)
![image](https://user-images.githubusercontent.com/56947/94883365-802c5200-0438-11eb-837a-d3c1a46f9530.png)
![image](https://user-images.githubusercontent.com/56947/94883373-85899c80-0438-11eb-821b-e4e97f458ff2.png)
