### PR TITLE
fix admin fixture, use admin user, fix redirect

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -5,6 +5,7 @@ module Admin
     include ActiveSupport::Testing::TimeHelpers
 
     before_action :authenticate_user!
+    before_action :require_admin
     around_action :override_time_in_development, if: -> { Rails.env.development? }
 
     layout "admin"
@@ -23,7 +24,7 @@ module Admin
 
     def require_admin
       unless current_user.admin?
-        redirect_to admin_items_url, warning: "You do not have access to that page."
+        redirect_to root_url, warning: "You do not have access to that page."
       end
     end
   end

--- a/test/controllers/admin/borrow_policies_controller_test.rb
+++ b/test/controllers/admin/borrow_policies_controller_test.rb
@@ -6,7 +6,7 @@ module Admin
 
     setup do
       @borrow_policy = borrow_policies(:default)
-      @user = users(:admin)
+      @user = create(:admin_user)
       sign_in @user
     end
 

--- a/test/controllers/admin/categories_controller_test.rb
+++ b/test/controllers/admin/categories_controller_test.rb
@@ -6,7 +6,7 @@ module Admin
 
     setup do
       @category = create(:category)
-      @user = users(:admin)
+      @user = create(:admin_user)
       sign_in @user
     end
 

--- a/test/controllers/admin/dashboard_controller_test.rb
+++ b/test/controllers/admin/dashboard_controller_test.rb
@@ -4,7 +4,7 @@ class Admin::DashboardControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
   setup do
-    @user = users(:admin)
+    @user = create(:admin_user)
     sign_in @user
   end
 

--- a/test/controllers/admin/documents_controller_test.rb
+++ b/test/controllers/admin/documents_controller_test.rb
@@ -6,7 +6,7 @@ module Admin
 
     setup do
       @document = documents(:agreement)
-      @user = users(:admin)
+      @user = create(:admin_user)
       sign_in @user
     end
 

--- a/test/controllers/admin/gift_memberships_controller_test.rb
+++ b/test/controllers/admin/gift_memberships_controller_test.rb
@@ -6,7 +6,7 @@ module Admin
 
     setup do
       @item = items(:complete)
-      @user = users(:admin)
+      @user = create(:admin_user)
       sign_in @user
     end
 

--- a/test/controllers/admin/hold_loans_controller_test.rb
+++ b/test/controllers/admin/hold_loans_controller_test.rb
@@ -6,7 +6,7 @@ module Admin
 
     setup do
       @member = create(:member)
-      @user = users(:admin)
+      @user = create(:admin_user)
       sign_in @user
     end
 

--- a/test/controllers/admin/items_controller_test.rb
+++ b/test/controllers/admin/items_controller_test.rb
@@ -6,7 +6,7 @@ module Admin
 
     setup do
       @item = items(:complete)
-      @user = users(:admin)
+      @user = create(:admin_user)
       sign_in @user
     end
 

--- a/test/controllers/admin/loan_summaries_controller_test.rb
+++ b/test/controllers/admin/loan_summaries_controller_test.rb
@@ -5,7 +5,7 @@ module Admin
     include Devise::Test::IntegrationHelpers
 
     setup do
-      @user = users(:admin)
+      @user = create(:admin_user)
       sign_in @user
     end
 

--- a/test/controllers/admin/loan_summaries_controller_test.rb
+++ b/test/controllers/admin/loan_summaries_controller_test.rb
@@ -5,7 +5,7 @@ module Admin
     include Devise::Test::IntegrationHelpers
 
     setup do
-      @user = create(:user)
+      @user = users(:admin)
       sign_in @user
     end
 

--- a/test/controllers/admin/loans_controller_test.rb
+++ b/test/controllers/admin/loans_controller_test.rb
@@ -6,7 +6,7 @@ module Admin
 
     setup do
       @item = create(:item)
-      @user = create(:user)
+      @user = users(:admin)
       sign_in @user
     end
 

--- a/test/controllers/admin/loans_controller_test.rb
+++ b/test/controllers/admin/loans_controller_test.rb
@@ -6,7 +6,7 @@ module Admin
 
     setup do
       @item = create(:item)
-      @user = users(:admin)
+      @user = create(:admin_user)
       sign_in @user
     end
 

--- a/test/controllers/admin/member_requests_controller_test.rb
+++ b/test/controllers/admin/member_requests_controller_test.rb
@@ -8,7 +8,7 @@ module Admin
       3.times do
         create(:member)
       end
-      @user = users(:admin)
+      @user = create(:admin_user)
       sign_in @user
     end
 

--- a/test/controllers/admin/member_requests_controller_test.rb
+++ b/test/controllers/admin/member_requests_controller_test.rb
@@ -8,7 +8,7 @@ module Admin
       3.times do
         create(:member)
       end
-      @user = create(:user)
+      @user = users(:admin)
       sign_in @user
     end
 

--- a/test/controllers/admin/members/requests_controller_test.rb
+++ b/test/controllers/admin/members/requests_controller_test.rb
@@ -9,7 +9,7 @@ module Admin
         3.times do
           create(:member)
         end
-        @user = create(:user)
+        @user = users(:admin)
         sign_in @user
       end
 

--- a/test/controllers/admin/members/requests_controller_test.rb
+++ b/test/controllers/admin/members/requests_controller_test.rb
@@ -9,7 +9,7 @@ module Admin
         3.times do
           create(:member)
         end
-        @user = users(:admin)
+        @user = create(:admin_user)
         sign_in @user
       end
 

--- a/test/controllers/admin/members_controller_test.rb
+++ b/test/controllers/admin/members_controller_test.rb
@@ -6,7 +6,7 @@ module Admin
 
     setup do
       @member = create(:member)
-      @user = users(:admin)
+      @user = create(:admin_user)
       sign_in @user
     end
 

--- a/test/controllers/admin/memberships_controller_test.rb
+++ b/test/controllers/admin/memberships_controller_test.rb
@@ -5,7 +5,7 @@ module Admin
     include Devise::Test::IntegrationHelpers
 
     setup do
-      @admin = create(:user)
+      @admin = users(:admin)
       sign_in @admin
       @member = create(:verified_member)
     end

--- a/test/controllers/admin/memberships_controller_test.rb
+++ b/test/controllers/admin/memberships_controller_test.rb
@@ -5,7 +5,7 @@ module Admin
     include Devise::Test::IntegrationHelpers
 
     setup do
-      @admin = users(:admin)
+      @admin = create(:admin_user)
       sign_in @admin
       @member = create(:verified_member)
     end

--- a/test/controllers/admin/monthly_activities_controller_test.rb
+++ b/test/controllers/admin/monthly_activities_controller_test.rb
@@ -5,7 +5,7 @@ module Admin
     include Devise::Test::IntegrationHelpers
 
     setup do
-      @user = users(:admin)
+      @user = create(:admin_user)
       sign_in @user
     end
 

--- a/test/controllers/admin/monthly_adjustments_controller_test.rb
+++ b/test/controllers/admin/monthly_adjustments_controller_test.rb
@@ -5,7 +5,7 @@ module Admin
     include Devise::Test::IntegrationHelpers
 
     setup do
-      @user = users(:admin)
+      @user = create(:admin_user)
       sign_in @user
     end
 

--- a/test/controllers/admin/potential_volunteers_controller_test.rb
+++ b/test/controllers/admin/potential_volunteers_controller_test.rb
@@ -5,7 +5,7 @@ module Admin
     include Devise::Test::IntegrationHelpers
 
     setup do
-      @user = users(:admin)
+      @user = create(:admin_user)
       sign_in @user
     end
 

--- a/test/controllers/admin/renewals_controller_test.rb
+++ b/test/controllers/admin/renewals_controller_test.rb
@@ -5,7 +5,7 @@ module Admin
     include Devise::Test::IntegrationHelpers
 
     setup do
-      @user = users(:admin)
+      @user = create(:admin_user)
       sign_in @user
     end
 

--- a/test/controllers/admin/renewals_controller_test.rb
+++ b/test/controllers/admin/renewals_controller_test.rb
@@ -5,7 +5,7 @@ module Admin
     include Devise::Test::IntegrationHelpers
 
     setup do
-      @user = create(:user)
+      @user = users(:admin)
       sign_in @user
     end
 

--- a/test/controllers/admin/searches_controller_test.rb
+++ b/test/controllers/admin/searches_controller_test.rb
@@ -5,7 +5,7 @@ module Admin
     include Devise::Test::IntegrationHelpers
 
     setup do
-      @user = users(:admin)
+      @user = create(:admin_user)
       sign_in @user
     end
 

--- a/test/controllers/admin/searches_controller_test.rb
+++ b/test/controllers/admin/searches_controller_test.rb
@@ -5,7 +5,7 @@ module Admin
     include Devise::Test::IntegrationHelpers
 
     setup do
-      @user = create(:user)
+      @user = users(:admin)
       sign_in @user
     end
 

--- a/test/controllers/admin/ui_controller_test.rb
+++ b/test/controllers/admin/ui_controller_test.rb
@@ -5,7 +5,7 @@ module Admin
     include Devise::Test::IntegrationHelpers
 
     setup do
-      @user = users(:admin)
+      @user = create(:admin_user)
       sign_in @user
     end
 

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -5,7 +5,7 @@ module Admin
     include Devise::Test::IntegrationHelpers
 
     setup do
-      @user = create(:admin_user)
+      @user = users(:admin)
       sign_in @user
     end
 
@@ -80,7 +80,7 @@ module Admin
 
     test "should get index" do
       get admin_users_url
-      assert_redirected_to admin_items_url
+      assert_redirected_to root_url
     end
   end
 end

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -5,7 +5,7 @@ module Admin
     include Devise::Test::IntegrationHelpers
 
     setup do
-      @user = users(:admin)
+      @user = create(:admin_user)
       sign_in @user
     end
 

--- a/test/controllers/admin/verifications_controller_test.rb
+++ b/test/controllers/admin/verifications_controller_test.rb
@@ -4,7 +4,7 @@ class VerificationsControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
   setup do
-    @user = users(:admin)
+    @user = create(:admin_user)
     sign_in @user
   end
 

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -6,3 +6,4 @@
 #
 admin:
   email: admin@example.com
+  role: admin


### PR DESCRIPTION
### Issue

Fixes https://github.com/rubyforgood/circulate/issues/218


### Summary

1. Implement `require_admin` check at `app/controllers/admin/base_controller.rb`
2. When failed, it will redirect to root_url (tentative)
3. `test/fixtures/users.yml` the admin user is now an actual admin
4. Make admin tests actually use the admin-user.