### PR TITLE
Set role for admin user seed to admin

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -34,7 +34,7 @@ admin_member = Member.create!(
   address1: "123 S. Streetname St.", address2: "Apt. 4", city: "Chicago", region: "IL", postal_code: "60666",
   reminders_via_email: true, reminders_via_text: true, receive_newsletter: true, volunteer_interest: true
 )
-User.create!(email: admin_member.email, password: "password", member: admin_member)
+User.create!(email: admin_member.email, password: "password", member: admin_member, role: "admin")
 
 BorrowPolicy.create!(code: "B", name: "Default", fine: Money.new(100), fine_period: 1, duration: 7)
 


### PR DESCRIPTION
After pulling latest development and attempting to login with the
admin@chicagotoollibrary.org user, I was unable to view the admin
dashboard. After checking in my console, I saw that this user did
not have the role of admin. This PR updates the seed to set its
role to admin.

(I could definitely be missing something, but this is the user I
had previously been logging in as when testing admin functionality!)

system tests:
58 runs, 278 assertions, 0 failures, 0 errors, 4 skips

unit tests:
208 runs, 624 assertions, 0 failures, 0 errors, 2 skips