### PR TITLE
Update errors -> error in calendaring module

### DIFF
--- a/app/controllers/concerns/calendaring.rb
+++ b/app/controllers/concerns/calendaring.rb
@@ -9,7 +9,7 @@ module Calendaring
       @events = result.value
     else
       @events = []
-      flash.now[:error] = result.errors
+      flash.now[:error] = result.error
     end
   end
 
@@ -19,9 +19,9 @@ module Calendaring
     if result.success?
       redirect_to volunteer_shifts_url, success: "You have signed up for the shift."
     else
-      Rails.logger.error(result.errors)
-      Raven.capture_message(result.errors.inspect)
-      redirect_to new_volunteer_shift_url(event_id: event_id), error: result.errors
+      Rails.logger.error(result.error)
+      Raven.capture_message(result.error.inspect)
+      redirect_to new_volunteer_shift_url(event_id: event_id), error: result.error
     end
   end
 

--- a/test/system/holds/holds_test.rb
+++ b/test/system/holds/holds_test.rb
@@ -48,7 +48,7 @@ module Holds
           perform_enqueued_jobs do
             click_button "Submit Request"
 
-            assert_text "Hold Request Complete"
+            assert_text "Hold Request Complete", wait: 10
             assert_text @drill1.complete_number
             assert_text "Saturday, August 15, between 10am & 11am"
           end
@@ -111,7 +111,7 @@ module Holds
           perform_enqueued_jobs do
             click_button "Submit Request"
 
-            assert_text "Hold Request Complete"
+            assert_text "Hold Request Complete", wait: 10
             assert_text @drill1.complete_number
             assert_text "email you when they are ready"
           end


### PR DESCRIPTION
In https://github.com/rubyforgood/circulate/commit/826da0b35259a506811a67616e4b7540332296ee, it looks like `Result#errors` was renamed `Result#error`. One 
spot that appears to have been missed is in `calendaring.rb`. Locally, I was
getting an error `Undefined method errors for <result...>` when trying
to access the volunteer shifts report. Updating to `error` allowed the
page to load and revealed a permissions error. This PR updates these
remaining calls to `.errors`. Potentially it might make sense to further
update the error text that is flashed, but I did not make that update as
yet.

before
<img width="1334" alt="Screen Shot 2020-10-05 at 6 42 49 PM" src="https://user-images.githubusercontent.com/6351806/95143553-65155700-0744-11eb-9bc5-5080601f4d60.png">

after
<img width="1671" alt="Screen Shot 2020-10-05 at 7 48 52 PM" src="https://user-images.githubusercontent.com/6351806/95143561-69da0b00-0744-11eb-9ab3-395e70c5d85b.png">


(I also updated two unrelated system tests in this commit, as without
the `wait` they occasionally fail for me locally. Can back that out if 
desired though!)

unit tests:
208 runs, 624 assertions, 0 failures, 0 errors, 2 skips

system tests:
58 runs, 278 assertions, 0 failures, 0 errors, 4 skips