### PR TITLE
added form validation for appointment creation

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -4,6 +4,7 @@ class AppointmentsController < ApplicationController
   end
 
   def new
+    @appointment = Appointment.new
     @holds = Hold.active.where(member: current_user.member)
     @loans = current_user.member.loans.includes(:item).checked_out
   end
@@ -17,6 +18,7 @@ class AppointmentsController < ApplicationController
     @appointment.loans << Loan.where(id: appointment_params[:loan_ids], member: member)
 
     if appointment_params[:time_range_string].present?
+      @appointment.time_range_string = appointment_params[:time_range_string]
       appointment_times = appointment_params[:time_range_string].split("..")
       @appointment.starts_at = DateTime.parse appointment_times[0]
       @appointment.ends_at = DateTime.parse appointment_times[1]
@@ -25,6 +27,8 @@ class AppointmentsController < ApplicationController
     if @appointment.save
       redirect_to appointments_path, notice: "Appointment was successfully created."
     else
+      @holds = Hold.active.where(member: current_user.member)
+      @loans = current_user.member.loans.includes(:item).checked_out
       render :new, alert: @appointment.errors.full_messages
     end
   end

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -49,6 +49,10 @@ body {
   text-decoration: none;
 }
 
+ul.error {
+  color: red;
+}
+
 form details {
   margin-top: 1em;
 

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -5,13 +5,27 @@ class Appointment < ApplicationRecord
   has_many :loans, through: :appointment_loans
   belongs_to :member
 
-  validates :starts_at, :ends_at, presence: true
-
-  validate :ends_at_later_than_starts_at
+  validate :ends_at_later_than_starts_at, :item_present, :date_present
+  attr_accessor :time_range_string
 
   scope :upcoming, -> { where("starts_at > ?", Time.zone.now).order(:starts_at) }
 
   private
+
+
+  def item_present
+    puts "inside item_present"
+    puts holds.inspect
+    if holds.empty? and loans.empty?
+      errors.add(:base,"Please select an item to pick-up or return for your appointment")
+    end
+  end
+
+  def date_present
+    if starts_at.nil? or ends_at.nil?
+      errors.add(:base,"Please select a date and time for this appointment.")
+    end
+  end
 
   def ends_at_later_than_starts_at
     return if ends_at.blank? || starts_at.blank?

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -14,8 +14,6 @@ class Appointment < ApplicationRecord
 
 
   def item_present
-    puts "inside item_present"
-    puts holds.inspect
     if holds.empty? and loans.empty?
       errors.add(:base,"Please select an item to pick-up or return for your appointment")
     end

--- a/app/views/appointments/_form.html.erb
+++ b/app/views/appointments/_form.html.erb
@@ -1,3 +1,10 @@
+<% if @appointment.errors.any?  %>
+  <ul class="error">
+    <% @appointment.errors.full_messages.each do |message| %>
+      <li><%= message %></li>
+    <% end %>
+  </ul>
+<% end %>
 <%= form_for :appointment, url: appointments_path do |form| %>
   <% if loans.any? %>
     <h3 class="title_bold">Select Items to Return</h3>
@@ -17,7 +24,7 @@
       <tbody>
         <% loans.each do |loan| %>
           <tr>
-            <td><%= check_box_tag("appointment[loan_ids][]", loan.id) %></td>
+            <td><%= check_box_tag("appointment[loan_ids][]", loan.id, (@appointment.loans.include?(loan))) %></td>
             <td>
               <%= link_to item_path(loan.item) do %>
                 <% if loan.item.image.attached? %>
@@ -51,7 +58,7 @@
     <tbody>
       <% holds.each do |hold| %>
         <tr>
-          <td><%= check_box_tag("appointment[hold_ids][]", hold.id) if hold.ready_for_pickup? %></td>
+          <td><%= check_box_tag("appointment[hold_ids][]", hold.id, (@appointment.holds.include?(hold))) if hold.ready_for_pickup? %></td>
           <td>
             <%= link_to item_path(hold.item) do %>
               <% if hold.item.image.attached? %>
@@ -69,7 +76,7 @@
 
   <div class="form-group">
     <label class="form-label">Select a time to pick-up/return your items</label>
-    <%= select("appointment", "time_range_string", grouped_options_for_select(OpenDays.next_slots_for_select(weeks: 2)), { include_blank: '-- Select a Date --' }, class: "form-select") %>
+    <%= select("appointment", "time_range_string", grouped_options_for_select(OpenDays.next_slots_for_select(weeks: 2), @appointment.time_range_string), { include_blank: '-- Select a Date --'}, class: "form-select") %>
   </div>
 
   <div class="form-group mb-2">

--- a/test/models/appointment_hold_test.rb
+++ b/test/models/appointment_hold_test.rb
@@ -2,14 +2,17 @@ require "test_helper"
 
 class AppointmentHoldTest < ActiveSupport::TestCase
   test "creates an appointment hold for member appointment" do
-    appointment = FactoryBot.create(:appointment)
+    appointment = FactoryBot.build(:appointment)
     user = FactoryBot.create(:user)
     member = FactoryBot.create(:member, user: user)
     hold = FactoryBot.create(:hold, creator: member.user)
     hold_two = FactoryBot.create(:hold, creator: member.user)
-    appointment_hold = FactoryBot.create(:appointment_hold, appointment: appointment, hold: hold)
-    FactoryBot.create(:appointment_hold, appointment: appointment, hold: hold_two)
-    assert_equal "Ida B. Wells", appointment_hold.hold.member.full_name
+    appointment.holds << hold
+    appointment.holds << hold_two
+    appointment.starts_at = "2020-10-05 7:00AM"
+    appointment.ends_at = "2020-10-05 8:00AM"
+    appointment.save
+    assert_equal "Ida B. Wells", appointment.holds.first.member.full_name
     assert_equal 2, appointment.holds.length
   end
 end

--- a/test/models/appointment_test.rb
+++ b/test/models/appointment_test.rb
@@ -2,8 +2,21 @@ require "test_helper"
 
 class AppointmentTest < ActiveSupport::TestCase
   test "creates an appointment" do
-    appointment = FactoryBot.create(:appointment)
-
+    appointment = FactoryBot.build(:appointment)
+    user = FactoryBot.create(:user)
+    member = FactoryBot.create(:member, user: user)
+    hold = FactoryBot.create(:hold, creator: member.user)
+    appointment.holds << hold
+    appointment.starts_at = "2020-10-05 7:00AM"
+    appointment.ends_at = "2020-10-05 8:00AM"
+    appointment.save
+    assert_equal "Ida B. Wells", appointment.holds.first.member.full_name
     assert_equal "My Comment", appointment.comment
+  end
+
+  test "invalid without hold or loan selected and date not given" do
+    appointment = Appointment.new
+    appointment.save
+    assert_equal appointment.errors[:base], ["Please select an item to pick-up or return for your appointment", "Please select a date and time for this appointment."]
   end
 end


### PR DESCRIPTION
Fixes #276 

Please find the screenshots with the error messages displayed.

**Screen 1**: Appointment Form

<img width="1036" alt="Screenshot 2020-10-06 at 7 27 41 AM" src="https://user-images.githubusercontent.com/5791109/95152181-1bf7ee00-07aa-11eb-88bb-8fc2ff4c1add.png">

**Screen 2**: Form is submitted without selecting item and date. Shows respective error messages

<img width="1012" alt="Screenshot 2020-10-06 at 7 27 51 AM" src="https://user-images.githubusercontent.com/5791109/95152187-20240b80-07aa-11eb-8257-ae7dc3404e9a.png">

**Screen 3**: Form is submitted by selecting item and not selecting date. Shows error message only for date.

<img width="1037" alt="Screenshot 2020-10-06 at 7 28 05 AM" src="https://user-images.githubusercontent.com/5791109/95152201-23b79280-07aa-11eb-9c0d-3bffc7724b83.png">

**Screen 4**: Form is submitted by selecting date and not selecting item. Shows error message only for item.

<img width="1031" alt="Screenshot 2020-10-06 at 7 28 43 AM" src="https://user-images.githubusercontent.com/5791109/95152209-274b1980-07aa-11eb-89d9-67eb81895744.png">

**Screen 5**: Form is submitted by selecting date and selecting item. Appointment is saved successfully.

<img width="765" alt="Screenshot 2020-10-06 at 7 29 05 AM" src="https://user-images.githubusercontent.com/5791109/95152215-2a460a00-07aa-11eb-93d5-ba114daeb90e.png">
