### PR TITLE
Update setup script to run yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ After you have the application running, here are some places to explore:
 
 Use the standard Rails test commands: `rails test`, `rails test:system`, etc.
 
+Note, in order to get system tests to run, you will need `chromedriver` installed. See [Requirements section](#requirements) above.
+
 ### Setup pre-commit checks
 
 Circulate uses [Lefthook](https://github.com/Arkweid/lefthook) to run a few linters before creating commits, including [Standard](https://github.com/testdouble/standard). [Follow these instructions](https://github.com/Arkweid/lefthook/blob/master/docs/ruby.md) to configure your local git repository to run pre-commit checks.

--- a/README.md
+++ b/README.md
@@ -101,10 +101,9 @@ Close your Terminal window and open a new one so your changes take effect.
 Okay, at this point you've got a Ruby on Rails development environment set up and cloned the Circulate repo! Now you'll need to run the following commands one at a time in your terminal:
 
 ```console
-$ yarn install
-$ bundle install
-$ bundle exec rails db:setup
+$ bin/setup
 ```
+
 All right, almost there! In the terminal, type and run:
 
 `rails test`

--- a/bin/setup
+++ b/bin/setup
@@ -17,7 +17,7 @@ FileUtils.chdir APP_ROOT do
   system('bundle check') || system!('bundle install')
 
   # Install JavaScript dependencies
-  # system('bin/yarn')
+  system('bin/yarn')
 
   # puts "\n== Copying sample files =="
   # unless File.exist?('config/database.yml')


### PR DESCRIPTION
Running `bin/setup` on a new project was failing with the following
error:

```
error Couldn't find a binary named "mjml"
rails aborted!
Couldn't find the MJML 4. binary. Have you run $ yarn add mjml?
```

This was failing when attempting to create the database. I believe this
is related to bootsnap loading the environment and the `mjml-rails` app
expecting the `mjml` binary to exist.

By running `yarn` first the `mjml` npm package will be installed and the
binary will be available, enabling `bin/setup` to complete
successfully.