### PR TITLE
Add `webdrivers` gem to automatically install `chromedriver`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,6 +82,7 @@ group :test do
   # Adds support for Capybara system testing and selenium driver
   gem "capybara", ">= 2.15"
   gem "selenium-webdriver"
+  gem 'webdrivers', '~> 4.0', require: false
   gem "minitest-ci"
   gem "rails-controller-testing"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -384,6 +384,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webdrivers (4.4.1)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     webpacker (5.2.1)
       activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
@@ -445,6 +449,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   turbolinks_render
   web-console (>= 3.3.0)
+  webdrivers (~> 4.0)
   webpacker (>= 4.0.0.rc.3)
 
 RUBY VERSION

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ There is content and information hard-coded in many of the views that is specifi
 
 Circulate is a fairly basic Rails application. The main application requires a recent version of Ruby, a PostgreSQL database, and a modern version of Node and Yarn to build assets.
 
-* A version of chromium (Google Chrome is fine) and a compatible `chromedriver` are required to run application tests.
+* A version of chromium (Google Chrome is fine) and a compatible `chromedriver` are required to run application tests. This will be downloaded automatically for you when running system tests.
 * Imagemagick needs to be installed for gift memberships and item thumbnails to be generated.
 
 ## Integrations

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require 'webdrivers/chromedriver'
 
 # Backported from Rails 6.1
 Capybara.add_selector :rich_text_area do


### PR DESCRIPTION
# What 

This gem will automatically install webdrives needed to run Selenium
tests.

Since the test setup only uses `chromedriver`, we only `require` that in
our `application_system_test_case` setup.

# Why

When getting set up and creating #291, I ran into system test failures because
I didn't have chromedriver installed. I thought this gem could help make it easier 
for other developers to get set up to contribute more quickly.