### PR TITLE
update category nav helper and styles to make labels more readable

### DIFF
--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -36,10 +36,11 @@ module ItemsHelper
   def category_nav(categories, current_category = nil)
     return unless categories
 
-    tag.div class: "nav tag-nav" do
+    tag.ul class: "nav tag-nav" do
       categories.map { |category|
-        tag.li(class: "nav-item #{"active" if category.id == current_category&.id}") {
-          "&nbsp;&nbsp;".html_safe * category.path_ids.size + link_to(category.name, category: category.id)
+      is_parent = category.parent_id.nil?
+        tag.li(class: "nav-item #{"active" if category.id == current_category&.id} #{"parent" if is_parent }") {
+          is_parent ? link_to(category.name, category: category.id) : "&nbsp;&nbsp;".html_safe * category.path_ids.size + "-".html_safe + link_to(category.name, category: category.id)
         }
       }.join.html_safe
     end

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -249,9 +249,26 @@ $photo-width: 187px;
 }
 
 .tag-nav {
-  li a {
-    display: inline-block;
-    line-height: 1.2;
+  li {
+    margin: 0;
+    display: flex;
+
+    a {
+      display: inline-block;
+      line-height: 1.5;
+    }
+  }
+
+  .active a {
+    color: red;
+  }
+
+  .parent a {
+    font-weight: bold;
+
+    &:hover {
+      color: $primary-color;
+    }
   }
 }
 


### PR DESCRIPTION
This PR only updates styling to make labels more readable. It doesn't deal with the suggested dropdown, as the details of what that would look like were a bit hazy.

To look at implementing a dropdown menu a bit of design is needed, I think. At the moment, categories can allow any number of nested sub-categories. For that reason, we'd need to consider where we want the caret/arrow icon to be: only on the first parent or on all nested categories that in their turn have subcategories?

For the moment, I think a simple implementation like the one in this PR is cleaner and more readable.