### PR TITLE
Fix "no appointment" text

### DIFF
--- a/app/views/admin/appointments/index.html.erb
+++ b/app/views/admin/appointments/index.html.erb
@@ -40,16 +40,16 @@
           <% @appointments.each do |appointment| %>
             <tr>
               <td><%= l appointment.starts_at, format: :hour %> - <%= l appointment.ends_at, format: :hour %></td>
-              <td><%= appointment.member.full_name %></td>
+              <td><%= link_to appointment.member.full_name, member_profile_path(appointment.member) %></td>
               <td><%= appointment.member.pronouns.first %></td>
               <td>
                 <% appointment.holds.each do |hold| %>
                     pick-up
-                    <%= hold.item.name %> <br/>
+                    <%= link_to hold.item.name, hold.item %> <br/>
                 <% end %>
                 <% appointment.loans.each do |loan| %>
                     drop-off
-                    <%= loan.item.name %> <br/>
+                    <%= link_to loan.item.name, loan.item %> <br/>
                 <% end %>
               </td>
               <td><%= appointment.comment %></td>

--- a/app/views/admin/appointments/index.html.erb
+++ b/app/views/admin/appointments/index.html.erb
@@ -59,7 +59,7 @@
         </tbody>
       </table>
     <% else %>
-        <%= empty_state "No matching appointsments for this day!" %>
+        <%= empty_state "No matching appointments for this day!" %>
     <% end %>
   </div>
 </div>

--- a/test/system/admin/appointments_test.rb
+++ b/test/system/admin/appointments_test.rb
@@ -1,0 +1,24 @@
+require "application_system_test_case"
+
+class AppointmentsTest < ApplicationSystemTestCase
+  setup do
+    @appointment = FactoryBot.build(:appointment)
+    @user = FactoryBot.create(:user)
+    @member = FactoryBot.create(:member, user: @user)
+    @hold = FactoryBot.create(:hold, creator: @member.user)
+    @appointment.holds << @hold
+    @appointment.member = @member
+    @appointment.starts_at = "2020-10-05 7:00AM"
+    @appointment.ends_at = "2020-10-05 8:00AM"
+    @appointment.save
+    create(:admin_user)
+    sign_in_as_admin
+  end
+
+  test "index page includes links to item and member" do
+    day = @appointment.starts_at.strftime("%F")
+    visit "admin/appointments?day=#{day}"
+    assert page.html.include? "<a href=\"/items/#{@hold.item.id}"
+    assert page.html.include? "<a href=\"/member_profile.#{@appointment.member.id}"
+  end
+end

--- a/test/system/admin/appointments_test.rb
+++ b/test/system/admin/appointments_test.rb
@@ -21,4 +21,10 @@ class AppointmentsTest < ApplicationSystemTestCase
     assert page.html.include? "<a href=\"/items/#{@hold.item.id}"
     assert page.html.include? "<a href=\"/member_profile.#{@appointment.member.id}"
   end
+
+  test "displays correct text when there are no appointments" do
+    day = @appointment.starts_at.next_day.strftime("%F")
+    visit "admin/appointments?day=#{day}"
+    assert_text "No matching appointments for this day!"
+  end
 end


### PR DESCRIPTION
### Description

I noticed when working on #317 the message that appears on the admin appointments index page had a misspelling, "appointsments". 

Added tests to check this text in the future.

### Notes

This is build off of #317 so I could use the test file I created.