### PR TITLE
Add password confirmation when user edits password

### DIFF
--- a/app/controllers/member_profiles/passwords_controller.rb
+++ b/app/controllers/member_profiles/passwords_controller.rb
@@ -5,7 +5,7 @@ class MemberProfiles::PasswordsController < ApplicationController
 
   def update
     @user = current_user
-    if @user.update(user_params)
+    if @user.update_with_password(user_params)
       bypass_sign_in(@user)
       redirect_to member_profile_url, success: "Your password has been updated."
     else
@@ -16,6 +16,6 @@ class MemberProfiles::PasswordsController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:password, :password_confirmation)
+    params.require(:user).permit(:current_password, :password, :password_confirmation)
   end
 end

--- a/app/views/member_profiles/passwords/edit.html.erb
+++ b/app/views/member_profiles/passwords/edit.html.erb
@@ -1,7 +1,8 @@
 <%= form_with(model: @user, :url => { :action => "update" }, builder: SpectreFormBuilder ) do |f| %>
-  <%= f.password_field :password, :autocomplete => "off"  %>
-  <%= f.password_field :password_confirmation %>
+  <%= f.password_field :current_password, :autocomplete => "off" %>
+  <%= f.password_field :password, label: "New password", :autocomplete => "off" %>
+  <%= f.password_field :password_confirmation, label: "Confirm new password" %>
   <%= f.actions do %>
-    <%= f.submit %>
+    <%= f.submit "Update Password" %>
   <% end %>
 <% end %>

--- a/test/controllers/member_profiles/password_controller_test.rb
+++ b/test/controllers/member_profiles/password_controller_test.rb
@@ -8,6 +8,12 @@ class MemberProfiles::PasswordsControllerTest < ActionDispatch::IntegrationTest
     @member = create(:member, user: @user)
 
     sign_in @user
+
+    @user_password_edit = {
+      current_password: @user.password,
+      password: "new_password",
+      password_confirmation: "new_password"
+    }
   end
 
   test "member views password" do
@@ -16,19 +22,29 @@ class MemberProfiles::PasswordsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "member updates password" do
-    put member_profiles_password_url, params: {user: {password: "new_password", password_confirmation: "new_password"}}
+    put member_profiles_password_url, params: { user: @user_password_edit }
     assert_redirected_to member_profile_url
   end
 
   test "member enters mismatched password" do
-    put member_profiles_password_url, params: {user: {password: "new_password", password_confirmation: "word"}}
+    @user_password_edit[:password_confirmation] = "mismatched"
+    put member_profiles_password_url, params: { user: @user_password_edit }
     assert_redirected_to edit_member_profiles_password_url
     assert @user.errors.full_messages.include?("Password confirmation doesn't match Password")
   end
 
   test "member enters short password" do
-    put member_profiles_password_url, params: {user: {password: "word", password_confirmation: "word"}}
+    @user_password_edit[:password] = "short"
+    @user_password_edit[:password_confirmation] = "short"
+    put member_profiles_password_url, params: { user: @user_password_edit }
     assert_redirected_to edit_member_profiles_password_url
     assert @user.errors.full_messages.include?("Password is too short (minimum is 6 characters)")
+  end
+
+  test "member enters incorrect current password" do
+    @user_password_edit[:current_password] = "wrong_password"
+    put member_profiles_password_url, params: { user: @user_password_edit }
+    assert_redirected_to edit_member_profiles_password_url
+    assert @user.errors.full_messages.include?("Current password is invalid")
   end
 end


### PR DESCRIPTION
When members edit their password, they are now required to enter their current password.

Adds current password field, adjusts field labels for clarity (e.g. default Password -> New Password), and updates the password controller tests accordingly.

Linked to #167 