### PR TITLE
Prevent the printed warning messages in system tests

### DIFF
--- a/test/factories/members.rb
+++ b/test/factories/members.rb
@@ -16,6 +16,7 @@ FactoryBot.define do
       address1 { "apt 3" }
 
       factory :verified_member do
+        sequence :number
         id_kind { 1 }
         address_verified { true }
         status { "verified" }

--- a/test/system/member_verification_test.rb
+++ b/test/system/member_verification_test.rb
@@ -17,9 +17,8 @@ class MemberVerificationTest < ApplicationSystemTestCase
     first("label", text: "Address verified").click
     click_on "Verify Member"
 
-    @member.reload
-
     within ".member-stats.member" do
+      @member.reload
       assert_content @member.number
     end
 


### PR DESCRIPTION
# Problem
There are _Checking for expected text of nil is confusing and/or pointless since it will always match. Please specify a string or regexp instead._ during the system tests. The problem is the member's number is nil in those tests.

# Solution
## for test/system/member_profile_test.rb "member can view profile"
add :number to verified_member factory

## for test/system/member_verification_test.rb "verify pending member without membership"
do @member.reload after page changed so that the controller has done its action