### PR TITLE
Docker file owner

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -10,7 +10,7 @@ Dockerfile, or if gems or npm packages have been added or updated.
    https://github.com/rubyforgood/circulate.git` or create a fork in GitHub if
    you don't have permission to commit directly to this repo.
 4. Change into the application directory: `cd circulate`
-5. Run `docker-compose build` to build images for all services.
+5. Run `./docker-build.sh` to build images for all services.
 6. Run `docker-compose up -d database` to start the database service.
 7. Run `docker-compose run --rm web rails db:reset` to create the dev and test
    databases, load the schema, and run the seeds file.

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,5 @@ COPY --from=builder --chown=user:user /usr/local/bundle/ /usr/local/bundle/
 
 EXPOSE 3000
 
-
 ENTRYPOINT ["./docker-entrypoint.sh"]
 CMD ["bin/rails", "s", "-b", "0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ COPY . .
 FROM ruby:2.7.1-alpine
 
 ARG RAILS_ROOT=/usr/src/app/
+ARG USER_ID
 
 RUN apk update && apk upgrade && apk add --update --no-cache \
   bash \
@@ -45,12 +46,16 @@ RUN apk add --update --no-cache --virtual .ms-fonts msttcorefonts-installer && \
  fc-cache -f && \
  apk del .ms-fonts
 
+RUN adduser --disabled-password --gecos '' --uid $USER_ID user
+USER user
+
 WORKDIR $RAILS_ROOT
 
-COPY --from=builder $RAILS_ROOT $RAILS_ROOT
-COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
+COPY --from=builder --chown=user:user $RAILS_ROOT $RAILS_ROOT
+COPY --from=builder --chown=user:user /usr/local/bundle/ /usr/local/bundle/
 
 EXPOSE 3000
+
 
 ENTRYPOINT ["./docker-entrypoint.sh"]
 CMD ["bin/rails", "s", "-b", "0.0.0.0"]

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+
+env UID=$(id -u)\
+    docker-compose build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build: 
       context: .
       args:
-        USER_ID: ${UID}
+        USER_ID: ${UID-499}
     ports:
       - '3000:3000'
       - '4000:4000'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,10 @@ version: '3'
 
 services:
   web:
-    build: .
+    build: 
+      context: .
+      args:
+        USER_ID: ${UID}
     ports:
       - '3000:3000'
       - '4000:4000'


### PR DESCRIPTION
Changed the way the docker image is built so that the current user owns all created files. 

- The call to `docker-compose build` is now done through a wrapper, to capture the uid of the current user. This is documented in DOCKER.md.
- The application no longer runs as root. This is more secure, but existing dev environments will need to delete root-owned files in tmp

Addresses issue #330