### PR TITLE
Remove extra comma from pronouns

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -76,7 +76,7 @@ class Member < ApplicationRecord
   end
 
   def display_pronouns
-    pronouns.join(", ")
+    pronouns.reject(&:empty?).join(", ")
   end
 
   private


### PR DESCRIPTION
***Why?***
I am not sure if this is possible on production or if this is a glitch on my local dev database.

I updated my pronouns from `she/her` to `he/him` on my localhost and noticed an extra comma after `he/him`

***How?***
- Added a `.reject` to remove the empty values from the pronouns array

***Screenshots***

#### Before
<img width="1025" alt="Screen Shot 2020-10-19 at 9 32 45 PM" src="https://user-images.githubusercontent.com/3662050/96529288-c2d09580-1252-11eb-876e-6e67c9fa9a50.png">

#### After
<img width="1015" alt="Screen Shot 2020-10-19 at 9 33 53 PM" src="https://user-images.githubusercontent.com/3662050/96529303-cebc5780-1252-11eb-9928-c8a57c41a00a.png">
