### PR TITLE
Hide Password Inputs on Member Profile Edit Page

### DIFF
--- a/app/views/account/members/_form.html.erb
+++ b/app/views/account/members/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_with(model: member, url: account_member_path, builder: SpectreFormBuilder) do |form| %>
 
-  <%= render 'admin/members/fields', form: form %>
+  <%= render partial: 'admin/members/fields', locals: { form: form, show_password_inputs: false } %>
 
   <%= form.actions do %>
     <%= form.submit %>

--- a/app/views/admin/members/_fields.html.erb
+++ b/app/views/admin/members/_fields.html.erb
@@ -15,14 +15,16 @@
   </div>
 </div>
 
-<div class="columns form-group">
-  <div class="column col-sm-12 col-6">
-    <%= form.password_field :password, hint: "Use at least 6 characters", required: true %>
+<% if show_password_inputs %>
+  <div class="columns form-group">
+    <div class="column col-sm-12 col-6">
+      <%= form.password_field :password, hint: "Use at least 6 characters", required: true %>
+    </div>
+    <div class="column col-sm-12 col-6">
+      <%= form.password_field :password_confirmation, hint: "Repeat your password here", required: true %>
+    </div>
   </div>
-  <div class="column col-sm-12 col-6">
-    <%= form.password_field :password_confirmation, hint: "Repeat your password here", required: true %>
-  </div>
-</div>
+<% end %>
 
 <div class="columns form-group">
   <div class="column col-sm-12 col-6">

--- a/app/views/admin/members/_form.html.erb
+++ b/app/views/admin/members/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_with(model: [:admin, member], builder: SpectreFormBuilder) do |form| %>
-  <%= render 'fields', form: form %>
+  <%= render partial: 'fields', locals: { form: form, show_password_inputs: true } %>
 
   <%= form.text_area :notes %>
   <%= form.select :status, options_for_select(member_status_options, member.status), prompt: true %>

--- a/app/views/signup/members/new.html.erb
+++ b/app/views/signup/members/new.html.erb
@@ -6,7 +6,7 @@
       <div class="divider"></div>
     </div>
     <%= form_with(model: @member, url: signup_members_url, builder: SpectreFormBuilder) do |form| %>
-      <%= render 'admin/members/fields', form: form %>
+      <%= render partial: 'admin/members/fields', locals: { form: form, show_password_inputs: true } %>
 
       <%= form.actions do %>
         <%= form.submit "Save and Continue" %>


### PR DESCRIPTION
Hey,
Added an additional parameter to the partial `admin/members/_fields.html.erb` which is rendered to show the form fields

The additional argument is used to filter the password inputs from the form

This parameter is set as `false` in case of Member profile edit page and true elsewhere

#347 