### PR TITLE
359-added rule to hide button

### DIFF
--- a/app/helpers/holds_helper.rb
+++ b/app/helpers/holds_helper.rb
@@ -28,6 +28,12 @@ module HoldsHelper
     end
   end
 
+  def render_remove_link(hold)
+    if not hold.appointments.present?
+      link_to("Remove", account_hold_path(hold), method: :delete, data: { confirm: 'Are you sure you want to remove this hold?' })
+    end
+  end
+
   private
 
   def format_date(date)

--- a/app/helpers/holds_helper.rb
+++ b/app/helpers/holds_helper.rb
@@ -30,7 +30,7 @@ module HoldsHelper
   end
 
   def render_remove_link(hold)
-    if not hold.appointments.present?
+    unless hold.appointments.present?
       link_to("Remove", account_hold_path(hold), method: :delete, data: { confirm: 'Are you sure you want to remove this hold?' })
     end
   end

--- a/app/models/hold.rb
+++ b/app/models/hold.rb
@@ -1,4 +1,7 @@
 class Hold < ApplicationRecord
+  has_many :appointment_holds
+  has_many :appointments, through: :appointment_holds
+
   belongs_to :member
   belongs_to :item, counter_cache: true
   belongs_to :creator, class_name: "User"

--- a/app/views/account/home/index.html.erb
+++ b/app/views/account/home/index.html.erb
@@ -79,7 +79,7 @@
             <td><%= link_to hold.item.name, item_path(hold.item) %></td>
             <td><%= hold.item.complete_number %></td>
             <td><%= render_place_in_queue(hold) %></td>
-            <td><%= link_to "Remove", account_hold_path(hold), method: :delete, data: { confirm: 'Are you sure you want to remove this hold?' } %>
+            <td><%= render_remove_link(hold) %>
           </tr>
         <% end %>
       


### PR DESCRIPTION
# What it does

Hide the "remove" link next to a hold after it's been scheduled for pick-up (i.e., associated with an appointment).

# Why it is important

issue: https://github.com/rubyforgood/circulate/issues/359

# Implementation notes

* Added appointment relation in Hold model
* Created a helper method to cover the rule in card.