### PR TITLE
include loan ending in item availability

### DIFF
--- a/app/helpers/holds_helper.rb
+++ b/app/helpers/holds_helper.rb
@@ -22,7 +22,7 @@ module HoldsHelper
     if appointment
       "Scheduled for pick-up at #{format_date(appointment.starts_at)} " +
       format_time_range(appointment.starts_at, appointment.ends_at)
-    elsif previous_holds_count == 0
+    elsif hold.ready_for_pickup?
       "Ready for pickup. Schedule by #{format_date(hold.created_at + 7.days)}"
     else
       "##{previous_holds_count} on wait list"

--- a/app/models/hold.rb
+++ b/app/models/hold.rb
@@ -27,7 +27,7 @@ class Hold < ApplicationRecord
   end
 
   def ready_for_pickup?
-    previous_active_holds.empty? #&& item.loans.last.ended?
+    previous_active_holds.empty? && item.available?
   end
 
   def upcoming_appointment

--- a/app/models/hold.rb
+++ b/app/models/hold.rb
@@ -27,7 +27,7 @@ class Hold < ApplicationRecord
   end
 
   def ready_for_pickup?
-    previous_active_holds.empty?
+    previous_active_holds.empty? #&& item.loans.last.ended?
   end
 
   def upcoming_appointment

--- a/app/views/account/home/index.html.erb
+++ b/app/views/account/home/index.html.erb
@@ -66,7 +66,7 @@
     </thead>
 
     <tbody>
-      
+
         <% @holds.each do |hold| %>
           <tr>
             <td>
@@ -82,11 +82,13 @@
             <td><%= link_to "Remove", account_hold_path(hold), method: :delete, data: { confirm: 'Are you sure you want to remove this hold?' } %>
           </tr>
         <% end %>
-      
+
     </tbody>
   </table>
   <div class="button">
-    <%= button_to 'Schedule a Pick Up', new_account_appointment_path, class: "btn btn-sm", method: :get %>
+    <% if @holds.any? {|hold| hold.ready_for_pickup? } %>
+      <%= button_to 'Schedule a Pick Up', new_account_appointment_path, class: "btn btn-sm", method: :get %>
+    <% end %>
   </div>
 <% else %>
   <%= empty_state "You have no items on hold" %>


### PR DESCRIPTION
# What it does

_Describe the changes that you've made to the application in this PR._
 
Closes https://github.com/rubyforgood/circulate/issues/343
This should prevent a Member from scheduling a pickup for a hold if an item has not been returned. 

# Why it is important

_Make a case for merging this work. This might include linking to a relevant issue._

This should provide a more consistent experience for the user. 

# UI Change Screenshot

_If this PR makes a change to the UI put a screenshot here. If you have before and after screenshots please add these._

<img width="673" alt="Screen Shot 2020-10-25 at 7 04 45 PM" src="https://user-images.githubusercontent.com/7292/97122355-a2de1d80-16fb-11eb-9287-a2c9ef326d2b.png">


# Implementation notes

* _Anything notable about the technical approach you took.

After spelunking, I needed a mechanism to test for pickup availability both in the holds helper and to control the schedule button in the account index view. So, I chose to update the `ready_for_pickup?` method on Hold versus pushing more duplicate logic into the helper and view. 

* _Any open questions you have about the PR or areas where you'd like specific feedback.

When testing locally, I found a test failure in loan_test that did not seem seem to be related. We'll see if it fails on CI
