### PR TITLE
Member can cancel appointment

### DIFF
--- a/app/controllers/account/appointments_controller.rb
+++ b/app/controllers/account/appointments_controller.rb
@@ -35,7 +35,7 @@ module Account
     end
 
     def destroy
-      Appointment.find(params[:id]).destroy
+       current_user.member.appointments.find(params[:id]).destroy
       redirect_to account_appointments_path, flash: {success: "Appointment cancelled."}
     end
 

--- a/app/controllers/account/appointments_controller.rb
+++ b/app/controllers/account/appointments_controller.rb
@@ -34,6 +34,11 @@ module Account
       end
     end
 
+    def destroy
+      Appointment.find(params[:id]).destroy
+      redirect_to account_appointments_path, flash: {success: "Appointment cancelled."}
+    end
+
     private
 
     def appointment_params

--- a/app/views/account/appointments/index.html.erb
+++ b/app/views/account/appointments/index.html.erb
@@ -11,6 +11,10 @@
 
   <% @appointments.each_with_index do |appointment, index| %>
     <section class="appointment">
+      <div class="float-right d-flex">        
+        <%= button_to "Cancel", account_appointment_path(appointment), class: "btn btn-primary", method: :delete, data: { disabled_with: "Cancelling appointment...", confirm: "Are you sure to cancel this appointment?" }%>
+        
+      </div>
       <div class="appointment-date">
         <h2 class="title_bold"><%= index + 1 %>.</h2>
         <h2 class="title_bold">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
 
   namespace :account do
     resources :holds, only: [:create, :destroy]
-    resources :appointments, only: [:index, :new, :create]
+    resources :appointments, only: [:index, :new, :create, :destroy]
     resource :member, only: [:show, :edit, :update]
     resource :password, only: [:edit, :update]
     resources :loans, only: [:index]

--- a/test/controllers/account/appointments_controller_test.rb
+++ b/test/controllers/account/appointments_controller_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+module Account
+  class AppointmentsControllerTest < ActionDispatch::IntegrationTest
+    include Devise::Test::IntegrationHelpers
+
+    setup do
+      @appointment = FactoryBot.build(:appointment)
+      @user = FactoryBot.create(:user)
+      @member = FactoryBot.create(:member, user: @user)
+      @hold = FactoryBot.create(:hold, member: @member)
+      @appointment.holds << @hold
+      @appointment.member = @member
+      @appointment.starts_at = "2020-10-05 7:00AM"
+      @appointment.ends_at = "2020-10-05 8:00AM"
+      @appointment.save
+
+      sign_in @user
+    end
+
+    test "should cancel appointment without affecting holds" do
+      
+        delete account_appointment_path(@appointment)
+        assert_nil assigns(:appointment)
+        assert Hold.find_by(member_id: @member.id) != nil, "Member holds should not be deleted when an appointment is cancelled"
+        assert_redirected_to account_appointments_path
+    end
+  end
+end

--- a/test/controllers/account/appointments_controller_test.rb
+++ b/test/controllers/account/appointments_controller_test.rb
@@ -22,7 +22,7 @@ module Account
       
         delete account_appointment_path(@appointment)
         assert_nil assigns(:appointment)
-        assert Hold.find_by(member_id: @member.id) != nil, "Member holds should not be deleted when an appointment is cancelled"
+        assert_equal 1, @member.holds.count, "Member holds should not be deleted when an appointment is cancelled"
         assert_redirected_to account_appointments_path
     end
   end


### PR DESCRIPTION
# What it does

Added cancelling of member's appointments by the member

# Why it is important

Fixes Issue #354 

# UI Change Screenshot

![cancel_appointment](https://user-images.githubusercontent.com/52544819/97169298-d24e6200-17af-11eb-9478-a3f514a07f5f.jpeg)


# Implementation notes

- Added the destroy method for appointments under the Account module
- Added test case for the same.
