### PR TITLE
Display librarian appointment time next to date

### DIFF
--- a/app/views/admin/appointments/show.html.erb
+++ b/app/views/admin/appointments/show.html.erb
@@ -13,6 +13,7 @@
         <div class="column col-3">
           <h6>Appointment Date</h6>
           <h6><%= l current_appointment.starts_at, format: :date %></h6>
+          <h6><%= l current_appointment.starts_at, format: :hour %>&nbsp;&ndash;<%= l current_appointment.ends_at, format: :hour %></h6>
         </div>
         <div class="column col-3">
           <%= button_to "Cancel", admin_appointment_path(current_appointment), class: "btn btn-primary", method: :delete, data: { disabled_with: "Cancelling appointment...", confirm: "Are you sure to cancel this appointment?" }%>


### PR DESCRIPTION
# What it does

Adds appointment start and end time in the following format: "1pm – 2pm" next to the date on the librarian appointment page.

# Why it is important

Fixes #378.

# UI Change Screenshot

**Before:**
![before_time](https://user-images.githubusercontent.com/24724408/97503080-088d0c80-197d-11eb-9e27-8b9fefb38baf.png)

**After:**
![after_time](https://user-images.githubusercontent.com/24724408/97503096-0dea5700-197d-11eb-9365-36c29424cf96.png)

# Implementation notes

Since the `hour` time format uses `%l` which adds a blank space before the hour digit, I used spaces around the en dash, unlike the example in the issue which had no spaces.
