### PR TITLE
Fix renewal of A tools

### DIFF
--- a/app/controllers/admin/borrow_policies_controller.rb
+++ b/app/controllers/admin/borrow_policies_controller.rb
@@ -24,7 +24,7 @@ module Admin
     end
 
     def borrow_policy_params
-      params.require(:borrow_policy).permit(:name, :duration, :fine, :fine_period, :uniquely_numbered, :code, :description, :default, :renewal_limit)
+      params.require(:borrow_policy).permit(:name, :duration, :fine, :fine_period, :uniquely_numbered, :code, :description, :default, :renewal_limit, :member_renewable)
     end
   end
 end

--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -74,7 +74,7 @@ class Loan < ApplicationRecord
   end
 
   def member_renewable?
-    renewable? && within_borrow_policy_duration? && item.borrow_policy.member_renewable?
+    renewable? && within_borrow_policy_duration? && item.borrow_policy.member_renewable? && ended_at.nil?
   end
 
   def within_borrow_policy_duration?

--- a/app/views/admin/borrow_policies/_form.html.erb
+++ b/app/views/admin/borrow_policies/_form.html.erb
@@ -10,6 +10,7 @@
   <%= form.text_field :fine_period, hint: "Days that pass before assigning the fine; 1 is every day after something is late, 7 is every week, etc." %>
   <%= form.check_box :uniquely_numbered, hint: "Is each item with this policy given a unique identification number?"%>
   <%= form.check_box :default, hint: "Use as the default policy for new items"%>
+  <%= form.check_box :member_renewable %>
 
   <%= form.actions do %>
     <%= form.submit %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -36,8 +36,9 @@ admin_member = Member.create!(
 )
 User.create!(email: admin_member.email, password: "password", member: admin_member, role: "admin")
 
-BorrowPolicy.create!(code: "B", name: "Default", fine: Money.new(100), fine_period: 1, duration: 7)
-BorrowPolicy.create!(code: "C", name: "One Renewal", fine: Money.new(100), fine_period: 1, duration: 7, renewal_limit: 1)
+a_policy = BorrowPolicy.create!(code: "A", name: "Uncounted", fine_period: 1, duration: 7, renewal_limit: 52, uniquely_numbered: false, member_renewable: true)
+b_policy = BorrowPolicy.create!(code: "B", name: "Default", fine: Money.new(100), fine_period: 1, duration: 7)
+c_policy = BorrowPolicy.create!(code: "C", name: "One Renewal", fine: Money.new(100), fine_period: 1, duration: 7, renewal_limit: 1)
 
 Document.create!(name: "Agreement", code: "agreement", summary: "Member Waiver of Indemnification")
 Document.create!(name: "Borrow Policy", code: "borrow_policy", summary: "Covers the rules of borrowing. Shown on the first page of member signup.")
@@ -60,8 +61,9 @@ unverified_member = Member.create!(
 )
 User.create!(email: unverified_member.email, password: "password", member: unverified_member)
 
-Item.create!( name: "Hammer", status: Item.statuses[:active], borrow_policy: BorrowPolicy.first )
-Item.create!( name: "Cordless Drill", status: Item.statuses[:active], borrow_policy: BorrowPolicy.last )
+Item.create!( name: "Flathead Screwdriver", status: Item.statuses[:active], borrow_policy: a_policy )
+Item.create!( name: "Hammer", status: Item.statuses[:active], borrow_policy: b_policy )
+Item.create!( name: "Cordless Drill", status: Item.statuses[:active], borrow_policy: c_policy )
 
 Item.all.each do |item|
   Loan.create!(

--- a/test/controllers/admin/borrow_policies_controller_test.rb
+++ b/test/controllers/admin/borrow_policies_controller_test.rb
@@ -26,13 +26,14 @@ module Admin
     end
 
     test "should update borrow_policy" do
-      patch admin_borrow_policy_url(@borrow_policy), params: {borrow_policy: {duration: 10, fine: 8.23, fine_period: 26, name: "New name", code: "Q"}}
+      patch admin_borrow_policy_url(@borrow_policy), params: {borrow_policy: {duration: 10, fine: 8.23, fine_period: 26, name: "New name", code: "Q", member_renewable: true}}
       @borrow_policy.reload
       assert_equal 10, @borrow_policy.duration
       assert_equal 823, @borrow_policy.fine_cents
       assert_equal 26, @borrow_policy.fine_period
       assert_equal "New name", @borrow_policy.name
       assert_equal "Q", @borrow_policy.code
+      assert_equal true, @borrow_policy.member_renewable
     end
   end
 end

--- a/test/controllers/admin/borrow_policies_controller_test.rb
+++ b/test/controllers/admin/borrow_policies_controller_test.rb
@@ -20,9 +20,19 @@ module Admin
       assert_response :success
     end
 
-    test "should update borrow_policy" do
+    test "should redirect to admin borrow policies page" do
       patch admin_borrow_policy_url(@borrow_policy), params: {borrow_policy: {duration: @borrow_policy.duration, fine_cents: @borrow_policy.fine_cents, fine_period: @borrow_policy.fine_period, name: @borrow_policy.name, code: "Q"}}
       assert_redirected_to admin_borrow_policies_url
+    end
+
+    test "should update borrow_policy" do
+      patch admin_borrow_policy_url(@borrow_policy), params: {borrow_policy: {duration: 10, fine: 8.23, fine_period: 26, name: "New name", code: "Q"}}
+      @borrow_policy.reload
+      assert_equal 10, @borrow_policy.duration
+      assert_equal 823, @borrow_policy.fine_cents
+      assert_equal 26, @borrow_policy.fine_period
+      assert_equal "New name", @borrow_policy.name
+      assert_equal "Q", @borrow_policy.code
     end
   end
 end

--- a/test/models/loan_test.rb
+++ b/test/models/loan_test.rb
@@ -308,6 +308,14 @@ class LoanTest < ActiveSupport::TestCase
     refute loan.member_renewable?
   end
 
+  test "is not member_renewable if loan has end date" do
+    borrow_policy = build(:member_renewable_borrow_policy)
+    item = build(:item, borrow_policy: borrow_policy)
+    loan = build(:loan, item: item, ended_at: Time.current)
+
+    refute loan.member_renewable?
+  end
+
   test "#upcoming_appointment should call its member.upcoming_appointment_of with itself" do
     member_double = Minitest::Mock.new
     loan = create(:loan)


### PR DESCRIPTION
# What it does

closes #344 

* Added `member_renewable` field to the admin borrow policy form
* Added an A tool to the seeds file
* Updated the `member_renewable?` method for loans to be false if the loan has an `ended_at` date

# Why it is important

I suspect that this isn't working on staging because the `member_renewable` flag for the A policy is set to false.

# UI Change Screenshot

**Admin form before**:

<img width="1084" alt="Screen Shot 2020-10-30 at 4 56 22 PM" src="https://user-images.githubusercontent.com/1938665/97765814-edcbac80-1ad0-11eb-8c82-af32b4491617.png">

**Admin form after**:
<img width="1062" alt="Screen Shot 2020-10-30 at 4 56 52 PM" src="https://user-images.githubusercontent.com/1938665/97765821-f6bc7e00-1ad0-11eb-8208-18f77108773d.png">

**Member page with Renew button**

<img width="690" alt="Screen Shot 2020-10-30 at 5 01 14 PM" src="https://user-images.githubusercontent.com/1938665/97765958-9c6fed00-1ad1-11eb-89cb-45a129c6cf16.png">
<img width="653" alt="Screen Shot 2020-10-30 at 5 01 20 PM" src="https://user-images.githubusercontent.com/1938665/97765962-a09c0a80-1ad1-11eb-8439-e9d0f57a10a5.png">

# Implementation notes
* Check that the `member_renewable` flag for the A policy is set to true
* I tried to add the `member_renewable` field to the table on the borrow policies index page, but the alignment ended up wonky, and I couldn't see immediately how to fix it.
