### PR TITLE
Member unique emails

### DIFF
--- a/app/controllers/admin/members_controller.rb
+++ b/app/controllers/admin/members_controller.rb
@@ -34,34 +34,26 @@ module Admin
     def create
       @member = Member.new(member_params)
 
-      respond_to do |format|
-        if @member.save
-          format.html { redirect_to [:admin, @member], notice: "Member was successfully created." }
-          format.json { render :show, status: :created, location: @member }
-        else
-          format.html { render :new }
-          format.json { render json: @member.errors, status: :unprocessable_entity }
-        end
+      if @member.save
+        redirect_to [:admin, @member], success: "Member was successfully created."
+      else
+        render :new
       end
     end
 
     def update
-      respond_to do |format|
-        if @member.update(member_params)
-          format.html { redirect_to [:admin, @member], notice: "Member was successfully updated." }
-          format.json { render :show, status: :ok, location: @member }
-        else
-          format.html { render :edit }
-          format.json { render json: @member.errors, status: :unprocessable_entity }
-        end
+      if @member.update(member_params)
+        redirect_to [:admin, @member], success: "Member was successfully updated."
+      else
+        render :edit
       end
     end
 
     def destroy
-      @member.destroy
-      respond_to do |format|
-        format.html { redirect_to admin_members_url, notice: "Member was successfully destroyed." }
-        format.json { head :no_content }
+      if @member.destroy
+        redirect_to admin_members_url, success: "Member was successfully destroyed."
+      else
+        redirect_to admin_member_url(@member), error: "Member could not be destroyed."
       end
     end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::Base
 
   add_flash_types :success, :error, :warning
 
+  before_action :set_raven_context
   around_action :set_time_zone
 
   def current_member
@@ -20,11 +21,15 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def set_raven_context
+    if user_signed_in?
+      Raven.user_context(id: current_user.id, member_id: current_member.try(:id))
+    end
+  end
+
   def render_not_found
     render file: "#{Rails.root}/public/404.html", layout: false, status: :not_found
   end
-
-  protected
 
   def after_sign_in_path_for(user)
     referer = stored_location_for(user)

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -4,8 +4,7 @@ module Users
       if request.referer.present?
         referer = URI.parse(request.referer)
         if referer.host == request.host
-          self.resource = resource_class.create(sign_in_params)
-          store_location_for(resource, request.referer)
+          store_location_for(:user, request.referer)
         end
       end
     rescue URI::InvalidURIError

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -45,6 +45,7 @@ class Member < ApplicationRecord
 
   before_validation :strip_phone_number
   before_validation :set_default_address_fields
+  before_validation :downcase_email
 
   after_save :update_user_email
 
@@ -86,9 +87,9 @@ class Member < ApplicationRecord
 
   def upcoming_appointment_of(schedulable)
     if schedulable.is_a? Hold
-      appointments.upcoming.joins(:holds).where(holds: {id: schedulable.id }).first
+      appointments.upcoming.joins(:holds).where(holds: {id: schedulable.id}).first
     elsif schedulable.is_a? Loan
-      appointments.upcoming.joins(:loans).where(loans: { id: schedulable.id }).first
+      appointments.upcoming.joins(:loans).where(loans: {id: schedulable.id }).first
     end
   end
 
@@ -105,6 +106,10 @@ class Member < ApplicationRecord
   def set_default_address_fields
     self.city ||= "Chicago"
     self.region ||= "IL"
+  end
+
+  def downcase_email
+    self.email = email.try(:downcase)
   end
 
   def postal_code_must_be_in_chicago

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,6 +1,7 @@
 class Member < ApplicationRecord
   has_many :acceptances, class_name: "AgreementAcceptance", dependent: :destroy
-  has_many :adjustments
+  has_many :adjustments, dependent: :destroy
+  has_many :notifications, dependent: :destroy
 
   has_many :loans, dependent: :destroy
   has_many :checked_out_loans, -> { checked_out }, class_name: "Loan"

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -20,7 +20,7 @@ class Member < ApplicationRecord
   enum id_kind: [:drivers_license, :state_id, :city_key, :student_id, :employee_id, :other_id_kind]
   enum status: [:pending, :verified, :suspended, :deactivated], _prefix: true
 
-  validates :email, format: {with: URI::MailTo::EMAIL_REGEXP, message: "must be a valid email"}
+  validates :email, format: {with: URI::MailTo::EMAIL_REGEXP, message: "must be a valid email"}, uniqueness: true
   validates :full_name, presence: true
   validates :phone_number, length: {is: 10, blank: false, message: "must be 10 digits"}
   validates :custom_pronoun, presence: true, if: proc { |m| m.custom_pronoun? }
@@ -89,7 +89,7 @@ class Member < ApplicationRecord
     if schedulable.is_a? Hold
       appointments.upcoming.joins(:holds).where(holds: {id: schedulable.id}).first
     elsif schedulable.is_a? Loan
-      appointments.upcoming.joins(:loans).where(loans: {id: schedulable.id }).first
+      appointments.upcoming.joins(:loans).where(loans: {id: schedulable.id}).first
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,12 +1,6 @@
 class User < ApplicationRecord
   devise :database_authenticatable, :recoverable, :rememberable,
-    :lockable, :timeoutable, :trackable
-
-  validates_presence_of :email, if: :email_required?
-  validates_format_of :email, with: Devise.email_regexp, allow_blank: true, if: :email_changed?
-  validates_presence_of :password, if: :password_required?
-  validates_confirmation_of :password, if: :password_required?
-  validates_length_of :password, within: Devise.password_length, allow_blank: true
+    :lockable, :timeoutable, :trackable, :validatable
 
   # while the canonical list of roles is the "user_role" enum in the
   # database, this enum exists to help display the list of roles
@@ -37,15 +31,5 @@ class User < ApplicationRecord
   def self.serialize_from_session(key, salt)
     record = eager_load(:member).find_by(id: key)
     record if record && record.authenticatable_salt == salt
-  end
-
-  private
-
-  def password_required?
-    !persisted? || !password.nil? || !password_confirmation.nil?
-  end
-
-  def email_required?
-    true
   end
 end

--- a/app/views/admin/members/_member.json.jbuilder
+++ b/app/views/admin/members/_member.json.jbuilder
@@ -1,2 +1,0 @@
-json.extract! member, :id, :full_name, :preferred_name, :email, :pronoun, :custom_pronoun, :phone_number, :bio, :id_kind, :custom_id, :id_number, :address_erified, :created_at, :updated_at
-json.url admin_member_url(member, format: :json)

--- a/app/views/admin/members/edit.html.erb
+++ b/app/views/admin/members/edit.html.erb
@@ -6,5 +6,14 @@
   <div class="column col-12">
 
     <%= render 'form', member: @member %>
+
+  <div class="destroy-area">
+    <details>
+      <summary>Destroy this member record?</summary>
+      <%= action_bar "If you destroy this member record, it can not be recovered. All member information, including loan history, will be removed from the system.", icon: "alert-octagon", type: :warning do %>
+        <%= button_to 'Destroy Member', [:admin, @member], method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-sm" %>
+      <% end %>
+    </details>
   </div>
+
 </div>

--- a/app/views/admin/members/index.json.jbuilder
+++ b/app/views/admin/members/index.json.jbuilder
@@ -1,1 +1,0 @@
-json.array! @members, partial: "admin/members/member", as: :member

--- a/app/views/admin/members/show.json.jbuilder
+++ b/app/views/admin/members/show.json.jbuilder
@@ -1,1 +1,0 @@
-json.partial! "admin/members/member", member: @member

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,7 +62,7 @@ Rails.application.routes.draw do
     resources :renewals, only: [:create, :destroy]
     resources :bulk_renewals, only: [:update]
 
-    resources :members, except: :destroy do
+    resources :members do
       scope module: "members" do
         resources :adjustments, only: :index
         resources :holds, only: [:create, :index, :destroy] do

--- a/db/migrate/20201107024718_downcase_emails.rb
+++ b/db/migrate/20201107024718_downcase_emails.rb
@@ -1,0 +1,5 @@
+class DowncaseEmails < ActiveRecord::Migration[6.0]
+  def change
+    execute "UPDATE members SET email = LOWER(email)"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_24_225228) do
-
+ActiveRecord::Schema.define(version: 2020_11_07_024718) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,26 +18,26 @@ ActiveRecord::Schema.define(version: 2020_10_24_225228) do
     "fine",
     "membership",
     "donation",
-    "payment",
+    "payment"
   ], force: :cascade
 
   create_enum :adjustment_source, [
     "cash",
     "square",
-    "forgiveness",
+    "forgiveness"
   ], force: :cascade
 
   create_enum :hold_request_status, [
     "new",
     "completed",
-    "denied",
+    "denied"
   ], force: :cascade
 
   create_enum :notification_status, [
     "pending",
     "sent",
     "bounced",
-    "error",
+    "error"
   ], force: :cascade
 
   create_enum :power_source, [
@@ -46,13 +45,13 @@ ActiveRecord::Schema.define(version: 2020_10_24_225228) do
     "gas",
     "air",
     "electric (corded)",
-    "electric (battery)",
+    "electric (battery)"
   ], force: :cascade
 
   create_enum :user_role, [
     "staff",
     "admin",
-    "member",
+    "member"
   ], force: :cascade
 
   create_table "action_text_rich_texts", force: :cascade do |t|

--- a/test/controllers/admin/members_controller_test.rb
+++ b/test/controllers/admin/members_controller_test.rb
@@ -21,21 +21,22 @@ module Admin
     end
 
     test "should create member" do
+      member_attrs = build(:member)
       assert_difference("Member.count") do
         post admin_members_url, params: {
           member: {
-            address_verified: @member.address_verified,
-            other_id_kind: @member.other_id_kind,
-            custom_pronoun: @member.custom_pronoun,
-            email: @member.email,
-            full_name: @member.full_name,
-            id_kind: @member.id_kind,
-            bio: @member.bio,
-            phone_number: @member.phone_number,
-            preferred_name: @member.preferred_name,
-            pronoun: @member.pronoun,
+            address_verified: member_attrs.address_verified,
+            other_id_kind: member_attrs.other_id_kind,
+            custom_pronoun: member_attrs.custom_pronoun,
+            email: member_attrs.email,
+            full_name: member_attrs.full_name,
+            id_kind: member_attrs.id_kind,
+            bio: member_attrs.bio,
+            phone_number: member_attrs.phone_number,
+            preferred_name: member_attrs.preferred_name,
+            pronoun: member_attrs.pronoun,
             postal_code: "60606",
-            address1: @member.address1
+            address1: member_attrs.address1
           }
         }
       end

--- a/test/models/member_test.rb
+++ b/test/models/member_test.rb
@@ -137,6 +137,12 @@ class MemberTest < ActiveSupport::TestCase
     create(:user, email: "test@notunique.obv")
   end
 
+  test "downcases member email in the database" do
+    user = create(:user, email: "emailWithCapitalLetters@example.com")
+
+    assert_equal "emailwithcapitalletters@example.com", user.email
+  end
+
   test "a member can have an optional bio" do
     member = FactoryBot.build(:member, :with_bio)
     member.save

--- a/test/models/member_test.rb
+++ b/test/models/member_test.rb
@@ -132,15 +132,18 @@ class MemberTest < ActiveSupport::TestCase
     assert_equal "revised@different.biz", member.user.email
   end
 
-  test "allows multiple users with the same email address" do
-    create(:user, email: "test@notunique.obv")
-    create(:user, email: "test@notunique.obv")
+  test "doesn't allow multiple users with the same email address" do
+    create(:member, email: "test@notunique.obv")
+    dupe = build(:member, email: "test@notunique.obv")
+
+    refute dupe.valid?
+    assert dupe.errors.messages.include?(:email)
   end
 
   test "downcases member email in the database" do
-    user = create(:user, email: "emailWithCapitalLetters@example.com")
+    member = create(:member, email: "emailWithCapitalLetters@example.com")
 
-    assert_equal "emailwithcapitalletters@example.com", user.email
+    assert_equal "emailwithcapitalletters@example.com", member.email
   end
 
   test "a member can have an optional bio" do


### PR DESCRIPTION
This PR fixes some issues that arose from unintentionally creating extra User records when we were storing the user's location before login. This was made worse by a change that allowed for User records to have duplicate email addresses.

It also restores an admin's ability to destroy a member record to the UI to help with cases where someone signed up to be a member a long time ago and attempts to then signup another time, leading to confusion. Hopefully it'll be used sparingly, but we don't want to require someone with database access to help handle those situations.