### PR TITLE
Delete item fixes

### DIFF
--- a/app/controllers/admin/appointments_controller.rb
+++ b/app/controllers/admin/appointments_controller.rb
@@ -1,7 +1,7 @@
 module Admin
   class AppointmentsController < BaseController
     def index
-      @current_day = Date.parse(params[:day] ||= Date.today.to_s)
+      @current_day = Date.parse(params[:day] ||= Time.current.to_date.to_s)
       @appointments = Appointment.where(starts_at: @current_day.beginning_of_day..@current_day.end_of_day).chronologically
     end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -14,13 +14,13 @@ class Item < ApplicationRecord
   has_many :categories, through: :categorizations,
                         before_add: :cache_category_ids,
                         before_remove: :cache_category_ids
-  has_many :loans, dependent: :destroy
+  has_many :loans, dependent: :nullify
   has_many :holds, dependent: :destroy
   has_many :active_holds, -> { active }, dependent: :destroy, class_name: "Hold"
   has_many :loan_summaries
   has_one :checked_out_exclusive_loan, -> { checked_out.exclusive.readonly }, class_name: "Loan"
   belongs_to :borrow_policy
-  has_many :notes, as: :notable
+  has_many :notes, as: :notable, dependent: :destroy
 
   has_rich_text :description
   has_one_attached :image
@@ -71,7 +71,7 @@ class Item < ApplicationRecord
 
   def self.find_by_complete_number(complete_number)
     code, number = complete_number.split("-")
-    joins(:borrow_policy).find_by(borrow_policies: { code: code }, number: number.to_i)
+    joins(:borrow_policy).find_by(borrow_policies: {code: code}, number: number.to_i)
   end
 
   def assign_number

--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -1,10 +1,11 @@
 class Loan < ApplicationRecord
-  belongs_to :item
+  belongs_to :item, optional: true
   belongs_to :member
   has_one :adjustment, as: :adjustable
   has_many :renewals, class_name: "Loan", foreign_key: "initial_loan_id"
   belongs_to :initial_loan, class_name: "Loan", optional: true
   has_one :hold, dependent: :nullify
+
   validates :due_at, presence: true
   validates_numericality_of :ended_at, allow_nil: true, greater_than_or_equal_to: ->(loan) { loan.created_at }
   validates :initial_loan_id, uniqueness: {scope: :renewal_count}, if: ->(l) { l.initial_loan_id.present? }
@@ -17,7 +18,7 @@ class Loan < ApplicationRecord
       elsif !record.item.active?
         record.errors.add(attr, "is not available to loan")
       end
-    else
+    elsif record.new_record? && !record.renewal?
       record.errors.add(attr, "does not exist")
     end
   end
@@ -41,6 +42,10 @@ class Loan < ApplicationRecord
       now, zone, zone, tonight
     )
   }
+
+  def item
+    super || NullItem.new
+  end
 
   def ended?
     ended_at.present?

--- a/app/models/loan_summary.rb
+++ b/app/models/loan_summary.rb
@@ -22,6 +22,10 @@ class LoanSummary < ApplicationRecord
   scope :by_due_date, -> { order(due_at: :asc) }
   scope :chronologically, -> { order(created_at: :asc) }
 
+  def item
+    super || NullItem.new
+  end
+
   def ended?
     ended_at.present?
   end

--- a/app/nulls/null_attachment.rb
+++ b/app/nulls/null_attachment.rb
@@ -1,0 +1,5 @@
+class NullAttachment
+  def attached?
+    false
+  end
+end

--- a/app/nulls/null_borrow_policy.rb
+++ b/app/nulls/null_borrow_policy.rb
@@ -1,0 +1,17 @@
+class NullBorrowPolicy
+  def renewal_limit
+    0
+  end
+
+  def fine
+    0
+  end
+
+  def fine_period
+    7
+  end
+
+  def duration
+    7
+  end
+end

--- a/app/nulls/null_item.rb
+++ b/app/nulls/null_item.rb
@@ -1,0 +1,35 @@
+class NullItem
+  include ActiveModel::Model
+
+  def model_name
+    ActiveModel::Name.new(self.class, nil, "item")
+  end
+
+  def image
+    NullAttachment.new
+  end
+
+  def borrow_policy
+    NullBorrowPolicy.new
+  end
+
+  def id
+    "deleted"
+  end
+
+  def to_param
+    id
+  end
+
+  def complete_number
+    "X-0000"
+  end
+
+  def name
+    "Deleted Item"
+  end
+
+  def marked_for_destruction?
+    false
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -60,7 +60,18 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  config.hosts << "shiny.local"
+  if ENV.fetch("DOCKER", "") == "true"
+    Socket.ip_address_list.each do |addrinfo|
+      next unless addrinfo.ipv4?
+      next if addrinfo.ip_address == "127.0.0.1"
+
+      ip = IPAddr.new(addrinfo.ip_address).mask(24)
+
+      Logger.new($stdout).info "Adding #{ip.inspect} to config.web_console.permissions"
+
+      config.web_console.permissions = ip
+    end
+  end
 
   config.action_mailer.default_url_options = {host: "localhost", port: 3000}
   config.action_mailer.asset_host = "http://localhost:3000"

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -66,4 +66,26 @@ class ItemTest < ActiveSupport::TestCase
 
     assert_equal 2, Item.without_attached_image.count
   end
+
+  test "can delete an item with a renewed loan" do
+    item = create(:item)
+    loan = create(:loan, item: item)
+    loan.renew!
+
+    assert item.destroy
+  end
+
+  test "can delete an item with an active loan" do
+    item = create(:item)
+    create(:loan, item: item)
+
+    assert item.destroy
+  end
+
+  test "can delete an item with a hold" do
+    item = create(:item)
+    create(:hold, item: item)
+
+    assert item.destroy
+  end
 end

--- a/test/models/loan_test.rb
+++ b/test/models/loan_test.rb
@@ -194,6 +194,28 @@ class LoanTest < ActiveSupport::TestCase
     refute Loan.exists?(second_renewal.id)
   end
 
+  test "returns a loan with a deleted item" do
+    item = create(:item)
+    loan = create(:loan, item: item)
+
+    assert item.destroy
+
+    loan.reload # clears item_id
+
+    loan.return!
+  end
+
+  test "renews a loan with a deleted item" do
+    item = create(:item)
+    loan = create(:loan, item: item)
+
+    assert item.destroy
+
+    loan.reload # clears item_id
+
+    loan.renew!
+  end
+
   test "finds loans that were due whole weeks ago" do
     tonight = Time.current.end_of_day
     loan = create(:loan, due_at: tonight)


### PR DESCRIPTION
# What it does

Items that had been loaned couldn't be deleted because they were referenced from `Loan` objects. This change makes it so that even loaned items can be deleted by introducing the concept of a "deleted item".

# Why it is important
Fixes #91 and a few other exceptions we've gotten that don't have GH issues.

# Implementation notes

* This PR introduces the [Null Object Pattern](https://thoughtbot.com/blog/rails-refactoring-example-introduce-null-object) into the codebase. 