### PR TITLE
Pending memberships

### DIFF
--- a/app/controllers/admin/members/memberships_controller.rb
+++ b/app/controllers/admin/members/memberships_controller.rb
@@ -6,29 +6,34 @@ module Admin
       end
 
       def new
-        @payment = Payment.new
+        @form = MembershipForm.new(@member)
       end
 
       def create
-        if params[:without_payment]
-          Membership.create_for_member(@member)
-          redirect_to admin_member_path(@member), success: "Membership created."
-          return
-        end
-
-        @payment = Payment.new(payment_params)
-        if @payment.valid?
-          Membership.create_for_member(@member, amount: @payment.amount, source: @payment.payment_source)
+        @form = MembershipForm.new(@member, membership_form_params)
+        if @form.save
           redirect_to admin_member_path(@member), success: "Membership created."
         else
           render :new
         end
       end
 
+      # This should probably be a MembershipActivation controller since it doesn't rely on params.
+      def update
+        @membership = @member.pending_membership
+
+        if @membership
+          @membership.start!
+          redirect_to admin_member_path(@member), success: "Membership started."
+        else
+          redirect_to admin_member_path(@member), error: "Could not start membership"
+        end
+      end
+
       private
 
-      def payment_params
-        params.require(:admin_payment).permit(:amount_dollars, :payment_source)
+      def membership_form_params
+        params.require(:membership_form).permit(:amount_dollars, :payment_source, :with_payment, :start_membership)
       end
     end
   end

--- a/app/forms/membership_form.rb
+++ b/app/forms/membership_form.rb
@@ -1,0 +1,40 @@
+class MembershipForm
+  include ActiveModel::Model
+
+  attr_reader :with_payment
+  attr_reader :start_membership
+
+  PAYMENT_ATTRIBUTES = %w[amount_dollars payment_source]
+
+  delegate(*PAYMENT_ATTRIBUTES, to: :@payment)
+
+  def initialize(member, params = {})
+    @member = member
+    @payment = Admin::Payment.new(params.slice(*PAYMENT_ATTRIBUTES))
+
+    @with_payment = params.key?("with_payment") ? params["with_payment"] == "true" : true
+    @start_membership = params["start_membership"] == "1"
+  end
+
+  def errors
+    @payment.errors.dup
+  end
+
+  def save
+    if with_payment
+      save_with_payment
+    else
+      save_without_payment
+    end
+  end
+
+  private
+
+  def save_with_payment
+    @payment.valid? && Membership.create_for_member(@member, amount: @payment.amount, source: @payment.payment_source, start_membership: start_membership)
+  end
+
+  def save_without_payment
+    Membership.create_for_member(@member, start_membership: start_membership)
+  end
+end

--- a/app/javascript/stylesheets/partials/_admin_memberships.scss
+++ b/app/javascript/stylesheets/partials/_admin_memberships.scss
@@ -1,0 +1,3 @@
+.fieldset-radio-inputs {
+  margin-left: 1.2rem;
+}

--- a/app/javascript/stylesheets/partials/_index.scss
+++ b/app/javascript/stylesheets/partials/_index.scss
@@ -5,3 +5,4 @@
 @import './appointments';
 @import './item_header';
 @import './new_appointment';
+@import './admin_memberships';

--- a/app/lib/spectre_form_builder.rb
+++ b/app/lib/spectre_form_builder.rb
@@ -90,6 +90,15 @@ class SpectreFormBuilder < ActionView::Helpers::FormBuilder
     end
   end
 
+  def radio_button(method, tag_value, options = {})
+    options[:label_class] = "form-radio"
+    options[:label_for] = nil
+    wrapped_layout(method, options) do
+      super +
+        @template.tag.i(class: "form-icon")
+    end
+  end
+
   def check_box(method, options = {}, *args)
     options[:label_class] = "form-checkbox"
     wrapped_layout(method, options) do
@@ -132,7 +141,7 @@ class SpectreFormBuilder < ActionView::Helpers::FormBuilder
   end
 
   def submit(label = nil, options = {}, &block)
-    parent_button(label, options.merge(type: "submit", class: "btn btn-primary btn-lg btn-block", data: {disable: true }), &block)
+    parent_button(label, options.merge(type: "submit", class: "btn btn-primary btn-lg btn-block", data: {disable: true}), &block)
   end
 
   def errors
@@ -177,7 +186,7 @@ class SpectreFormBuilder < ActionView::Helpers::FormBuilder
 
   # Use this method for inputs where the label has to wrap the input
   def wrapped_layout(method, options = {})
-    label_text = label_or_default(options[:label], method)
+    label_text = label_or_default(options.delete(:label), method)
     has_error = @object.errors.include?(method)
     display_required = options.fetch(:required, true)
     messages = has_error ? @object.errors.messages[method].join(", ") : options.delete(:hint)
@@ -189,7 +198,9 @@ class SpectreFormBuilder < ActionView::Helpers::FormBuilder
     wrapper_options[:class].strip!
 
     @template.content_tag :div, wrapper_options do
-      label(method, class: "form-label #{options[:label_class]}") {
+      label_options = {class: "form-label #{options.delete(:label_class)}"}
+      label_options[:for] = options.delete(:label_for) if options.key?(:label_for)
+      label(method, **label_options) {
         yield +
           label_text +
           required_label(method, display_required)

--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -57,6 +57,7 @@ class Loan < ApplicationRecord
 
   def self.open_days
     [
+      3, # Wednesday
       4, # Thursday
       6 # Saturday
     ]

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -13,6 +13,8 @@ class Member < ApplicationRecord
 
   has_many :memberships, dependent: :destroy
   has_one :active_membership, -> { merge(Membership.active) }, class_name: "Membership"
+  has_one :pending_membership, -> { merge(Membership.pending) }, class_name: "Membership"
+
   has_one :user, dependent: :destroy
   has_many :notes, as: :notable
 

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,10 +1,16 @@
 class Membership < ApplicationRecord
   belongs_to :member
   has_one :adjustment, as: "adjustable"
+
   scope :active, -> { where("started_on <= ? AND ended_on >= ?", Time.current, Time.current) }
+  scope :pending, -> { where(started_on: nil, ended_on: nil) }
 
   def amount
     adjustment ? adjustment.amount * -1 : Money.new(0)
+  end
+
+  def pending?
+    started_on.nil? && ended_on.nil?
   end
 
   def self.create_for_member(member, amount: 0, source: nil, now: Time.current.to_date, square_transaction_id: nil)

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,9 +1,14 @@
 class Membership < ApplicationRecord
+  class PendingMembership < StandardError; end
+
   belongs_to :member
   has_one :adjustment, as: "adjustable"
 
   scope :active, -> { where("started_on <= ? AND ended_on >= ?", Time.current, Time.current) }
   scope :pending, -> { where(started_on: nil, ended_on: nil) }
+
+  validate :no_overlapping_dates
+  validate :start_after_end
 
   def amount
     adjustment ? adjustment.amount * -1 : Money.new(0)
@@ -13,12 +18,56 @@ class Membership < ApplicationRecord
     started_on.nil? && ended_on.nil?
   end
 
-  def self.create_for_member(member, amount: 0, source: nil, now: Time.current.to_date, square_transaction_id: nil)
-    membership = member.memberships.create!(started_on: now, ended_on: now + 364.days)
+  def start!(now = Time.current)
+    update!(started_on: now, ended_on: now + 364.days)
+  end
+
+  def self.next_start_date_for_member(member, now: Time.current.to_date)
+    # no safe start date if there is a pending membership
+    return nil if member.pending_membership
+
+    # renewal memberships should start on the day after the active one ends
+    return member.active_membership.ended_on + 1.day if member.active_membership
+
+    # if there isn't an active membership (this includes if there was one that
+    # has already ended), it can start today
+    now
+  end
+
+  def self.create_for_member(member, amount: 0, source: nil, start_membership: false, now: Time.current.to_date, square_transaction_id: nil)
+    if start_membership
+      start_date = next_start_date_for_member(member, now: now)
+      raise PendingMembership.new("member with pending membership can't start a new membership") unless start_date
+
+      membership = member.memberships.create!(started_on: start_date, ended_on: start_date + 364.days)
+    else
+      membership = member.memberships.create!
+    end
+
     if amount > 0
       Adjustment.record_membership(membership, amount)
       Adjustment.record_member_payment(member, amount, source, square_transaction_id)
     end
     membership
+  end
+
+  private
+
+  def no_overlapping_dates
+    overlapping = member.memberships.where(
+      "started_on BETWEEN ? AND ? OR ended_on BETWEEN ? AND ?",
+      started_on, ended_on, started_on, ended_on
+    ).count
+
+    errors.add(:base, "can't overlap with another membership") if overlapping > 0
+  end
+
+  def start_after_end
+    return true unless started_on && ended_on
+
+    if started_on > ended_on
+      errors.add(:started_on, "must start before end")
+      errors.add(:ended_on, "must end after start")
+    end
   end
 end

--- a/app/views/admin/members/_member_details.html.erb
+++ b/app/views/admin/members/_member_details.html.erb
@@ -44,6 +44,13 @@
             Expires <%= member.active_membership.ended_on.strftime("%b %-d, %Y") %>
           <% end %>
         </li>
+      <% elsif member.pending_membership %>
+        <li>
+          <%= feather_icon "key" %>
+          <%= link_to admin_member_memberships_path(member) do %>
+            Pending membership
+          <% end %>
+        </li>
       <% end %>
     </ul>
 

--- a/app/views/admin/members/_profile.html.erb
+++ b/app/views/admin/members/_profile.html.erb
@@ -13,10 +13,17 @@
   <div class="column col-sm-12 col-8">
 
     <% if !@member.active_membership %>
-      <div class="toast member-membership clearfix">
-        <p class="float-left"><i class="icon icon-stop"></i> Member needs to start a membership.</p>
-        <p class="float-right"><%= link_to "Create Membership", new_admin_member_membership_path(@member) %></p>
-      </div>
+      <% if @member.pending_membership %>
+        <div class="toast member-membership clearfix">
+          <p class="float-left"><i class="icon icon-stop"></i> Member has a pending membership.</p>
+          <p class="float-right"><%= link_to "Start Membership", admin_member_membership_path(@member, @member.pending_membership), method: :patch %></p>
+        </div>
+      <% else %>
+        <div class="toast member-membership clearfix">
+          <p class="float-left"><i class="icon icon-stop"></i> Member needs to start a membership.</p>
+          <p class="float-right"><%= link_to "Create Membership", new_admin_member_membership_path(@member) %></p>
+        </div>
+      <% end %>
     <% end %>
 
     <% unless @member.status_verified? %>

--- a/app/views/admin/members/memberships/index.html.erb
+++ b/app/views/admin/members/memberships/index.html.erb
@@ -11,8 +11,12 @@
     <tbody>
       <% @memberships.each do |membership| %>
         <tr>
-          <td><%= membership.started_on.to_s(:long_date) %></td>
-          <td><%= membership.ended_on.to_s(:long_date) %></td>
+          <% if membership.pending? %>
+            <td colspan="2" class="text-center"><em>pending</em></td>
+          <% else %>
+            <td><%= membership.started_on&.to_s(:long_date) %></td>
+            <td><%= membership.ended_on&.to_s(:long_date) %></td>
+          <% end %>
           <td><%= membership.amount.format %></td>
         </tr>
       <% end %>

--- a/app/views/admin/members/memberships/new.html.erb
+++ b/app/views/admin/members/memberships/new.html.erb
@@ -1,46 +1,38 @@
-<h1>New Membership</h1>
+<% content_for :header do %>
+  <%= index_header "New Membership" %>
+<% end %>
 
 <div class="instructions">
   <p class="main">Memberships provide one year of borrowing privileges.</p>
-  <p class="sub">We ask that members pay what they can.</p>
+  <p class="sub">We ask that members pay what they can, however, we don't turn anyone away because they can't pay.</p>
     <p>Our recommendation is that folks pay $1 for every $1,000 of income they make in a year.<br>For example, if a person makes $40,000 each year, we recommend their membership fee be $40.</p>
 </div>
 
-<%= form_with model: @payment, url: admin_member_memberships_path(@member), builder: SpectreFormBuilder do |form| %>
-
+<%= form_with model: @form, url: admin_member_memberships_path(@member), builder: SpectreFormBuilder do |form| %>
   <div class="columns">
-    <div class="column col-sm-12 col-lg-5 col-mr-auto">
-      <div class="panel">
-        <div class="panel-header">
-          <div class="panel-title"><strong>Accept a Payment</strong></div>
-        </div>
-        <div class="panel-body">
+    <div class="column col-12">
+      <fieldset>
+        <legend>
+          <%= form.radio_button :with_payment, true, label: "Accept payment today", required: false %>
+        </legend>
+        <div class="fieldset-radio-inputs">
           <%= form.money_field :amount_dollars, label: "This year's membership fee", class: "input-lg" %>
-          <%= form.select :payment_source, options_for_select(membership_payment_source_options, @payment.payment_source || "cash"), prompt: true %>
+          <%= form.select :payment_source, options_for_select(membership_payment_source_options, @form.payment_source || "cash"), prompt: true %>
         </div>
-        <div class="panel-footer">
-          <%= form.submit "Save Membership" %>
-        </div>
-      </div>
-    </div>
+      </fieldset>
 
-    <div class="divider-vert hide-sm" data-content="OR"></div>
-
-    <div class="divider text-center show-sm" data-content="OR"></div>
-
-    <div class="column col-sm-12 col-lg-5 col-mx-auto">
-      <div class="panel">
-        <div class="panel-header">
-          <div class="panel-title"><strong>Create without Payment</strong></div>
-        </div>
-        <div class="panel-body">
+      <fieldset>
+        <legend>
+          <%= form.radio_button :with_payment, false, label: "Create without payment", required: false %>
+        </legend>
+        <div class="fieldset-radio-inputs">
           <p>Remember that we don't turn anyone away because they can't pay. Use this option to create a membership without accepting a payment.</p>
         </div>
-        <div class="panel-footer">
-          <%= form.button "Save without Payment", name: "without_payment", value: "1" %>
-        </div>
-      </div>
+      </fieldset>
+
+      <%= form.check_box :start_membership, label: "Start this membership", hint: "If unchecked, this membership can be started at a later time.", checked: true %>
+
+      <%= form.submit "Save Membership" %>
     </div>
   </div>
-
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,7 +74,7 @@ Rails.application.routes.draw do
         end
         resource :hold_loan, only: :create
         resources :lookups, only: :create
-        resources :memberships, only: [:index, :new, :create]
+        resources :memberships, only: [:index, :new, :create, :update]
         resources :payments, only: [:new, :create]
         resource :verification, only: [:edit, :update]
 

--- a/db/migrate/20201129191804_make_memberships_pending.rb
+++ b/db/migrate/20201129191804_make_memberships_pending.rb
@@ -1,0 +1,8 @@
+class MakeMembershipsPending < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :memberships, :started_on, true
+    change_column_default :memberships, :started_on, nil
+    change_column_null :memberships, :ended_on, true
+    change_column_default :memberships, :ended_on, nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_18_221831) do
+ActiveRecord::Schema.define(version: 2020_11_29_191804) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -328,7 +328,7 @@ ActiveRecord::Schema.define(version: 2020_11_18_221831) do
 
   create_table "memberships", force: :cascade do |t|
     t.bigint "member_id", null: false
-    t.datetime "started_on", precision: 6, null: false
+    t.datetime "started_on", precision: 6
     t.datetime "ended_on", precision: 6
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/test/controllers/admin/memberships_controller_test.rb
+++ b/test/controllers/admin/memberships_controller_test.rb
@@ -19,9 +19,11 @@ module Admin
       test "creates new membership using #{payment_source}" do
         assert_difference "Adjustment.count", 2 do
           post admin_member_memberships_url(@member), params: {
-            admin_payment: {
+            membership_form: {
               amount_dollars: 12,
-              payment_source: payment_source
+              payment_source: payment_source,
+              with_payment: "true",
+              start_membership: "1"
             }
           }
         end
@@ -29,6 +31,8 @@ module Admin
 
         membership = @member.memberships.last
         membership_adjustment, payment_adjustment = @member.adjustments.to_a[-2, 2]
+
+        refute membership.pending?
 
         assert_equal membership, membership_adjustment.adjustable
         assert_equal Money.new(-1200), membership_adjustment.amount
@@ -42,6 +46,51 @@ module Admin
         assert_equal payment_source, payment_adjustment.payment_source
         assert_nil payment_adjustment.square_transaction_id
       end
+    end
+
+    %w[square cash].each do |payment_source|
+      test "creates new pending membership using #{payment_source}" do
+        assert_difference "Adjustment.count", 2 do
+          post admin_member_memberships_url(@member), params: {
+            membership_form: {
+              amount_dollars: 12,
+              payment_source: payment_source,
+              with_payment: "true",
+              start_membership: "0"
+            }
+          }
+        end
+        assert_response :redirect
+
+        membership = @member.memberships.last
+        assert membership.pending?
+      end
+    end
+
+    test "creates new membership without payment" do
+      post admin_member_memberships_url(@member), params: {
+        membership_form: {
+          with_payment: "false",
+          start_membership: "1"
+        }
+      }
+      assert_response :redirect
+
+      membership = @member.memberships.last
+      refute membership.pending?
+    end
+
+    test "creates new pending membership without payment" do
+      post admin_member_memberships_url(@member), params: {
+        membership_form: {
+          with_payment: "false",
+          start_membership: "0"
+        }
+      }
+      assert_response :redirect
+
+      membership = @member.memberships.last
+      assert membership.pending?
     end
   end
 end

--- a/test/factories/memberships.rb
+++ b/test/factories/memberships.rb
@@ -3,5 +3,10 @@ FactoryBot.define do
     member
     started_on { Time.current - 1.month }
     ended_on { started_on + 11.months }
+
+    factory :pending_membership do
+      started_on { nil }
+      ended_on { nil }
+    end
   end
 end

--- a/test/factories/memberships.rb
+++ b/test/factories/memberships.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :membership do
     member
     started_on { Time.current - 1.month }
-    ended_on { started_on + 11.months }
+    after(:build) { |m| m.ended_on = m.started_on + 364.days if m.started_on }
 
     factory :pending_membership do
       started_on { nil }

--- a/test/models/membership_test.rb
+++ b/test/models/membership_test.rb
@@ -69,4 +69,11 @@ class MembershipTest < ActiveSupport::TestCase
     assert_equal "sq_abcd", payment_adjustment.square_transaction_id
     assert_nil payment_adjustment.adjustable
   end
+
+  test "is pending" do
+    membership = create(:pending_membership)
+
+    assert membership.pending?
+    assert_equal membership, Membership.pending.first
+  end
 end

--- a/test/models/membership_test.rb
+++ b/test/models/membership_test.rb
@@ -7,7 +7,7 @@ class MembershipTest < ActiveSupport::TestCase
 
     membership = assert_difference("Membership.count", 1) {
       assert_difference("Adjustment.count", 0) {
-        Membership.create_for_member(member, now: now)
+        Membership.create_for_member(member, now: now, start_membership: true)
       }
     }
 
@@ -16,7 +16,49 @@ class MembershipTest < ActiveSupport::TestCase
     assert_equal now + 364.days, membership.ended_on
   end
 
+  test "creates a pending membership for a member" do
+    member = create(:member)
+    now = Time.current.beginning_of_day
+
+    membership = assert_difference("Membership.count", 1) {
+      assert_difference("Adjustment.count", 0) {
+        Membership.create_for_member(member, now: now)
+      }
+    }
+
+    assert_equal member, membership.member
+    assert_nil membership.started_on
+    assert_nil membership.ended_on
+  end
+
   test "creates a membership for a member with a cash payment" do
+    member = create(:member)
+    now = Time.current.beginning_of_day
+    amount = Money.new(12.34)
+
+    membership = assert_difference("Membership.count", 1) {
+      assert_difference("Adjustment.count", 2) {
+        Membership.create_for_member(member, now: now, amount: amount, source: "cash", start_membership: true)
+      }
+    }
+
+    assert_equal now, membership.started_on
+    assert_equal now + 364.days, membership.ended_on
+    membership_adjustment = membership.adjustment
+    assert_equal amount * -1, membership_adjustment.amount
+    assert_equal "membership", membership_adjustment.kind
+    assert_nil membership_adjustment.payment_source
+    assert_equal membership, membership_adjustment.adjustable
+
+    payment_adjustment = member.adjustments.where.not(id: membership_adjustment.id).first
+    assert_equal amount, payment_adjustment.amount
+    assert_equal "payment", payment_adjustment.kind
+    assert_equal "cash", payment_adjustment.payment_source
+    assert_nil payment_adjustment.square_transaction_id
+    assert_nil payment_adjustment.adjustable
+  end
+
+  test "creates a pending membership for a member with a cash payment" do
     member = create(:member)
     now = Time.current.beginning_of_day
     amount = Money.new(12.34)
@@ -27,6 +69,8 @@ class MembershipTest < ActiveSupport::TestCase
       }
     }
 
+    assert_nil membership.started_on
+    assert_nil membership.ended_on
     membership_adjustment = membership.adjustment
     assert_equal amount * -1, membership_adjustment.amount
     assert_equal "membership", membership_adjustment.kind
@@ -48,7 +92,7 @@ class MembershipTest < ActiveSupport::TestCase
 
     membership = assert_difference("Membership.count", 1) {
       assert_difference("Adjustment.count", 2) {
-        Membership.create_for_member(member, now: now, amount: amount, source: "square", square_transaction_id: "sq_abcd")
+        Membership.create_for_member(member, now: now, amount: amount, start_membership: true, source: "square", square_transaction_id: "sq_abcd")
       }
     }
 
@@ -70,10 +114,67 @@ class MembershipTest < ActiveSupport::TestCase
     assert_nil payment_adjustment.adjustable
   end
 
+  test "creates a pending membership for a member with a square payment" do
+    member = create(:member)
+    now = Time.current.beginning_of_day
+    amount = Money.new(12.34)
+
+    membership = assert_difference("Membership.count", 1) {
+      assert_difference("Adjustment.count", 2) {
+        Membership.create_for_member(member, now: now, amount: amount, source: "square", square_transaction_id: "sq_abcd")
+      }
+    }
+
+    assert_equal member, membership.member
+    assert_nil membership.started_on
+    assert_nil membership.ended_on
+
+    membership_adjustment = membership.adjustment
+    assert_equal amount * -1, membership_adjustment.amount
+    assert_equal "membership", membership_adjustment.kind
+    assert_nil membership_adjustment.payment_source
+    assert_equal membership, membership_adjustment.adjustable
+
+    payment_adjustment = member.adjustments.where.not(id: membership_adjustment.id).first
+    assert_equal amount, payment_adjustment.amount
+    assert_equal "payment", payment_adjustment.kind
+    assert_equal "square", payment_adjustment.payment_source
+    assert_equal "sq_abcd", payment_adjustment.square_transaction_id
+    assert_nil payment_adjustment.adjustable
+  end
+
   test "is pending" do
     membership = create(:pending_membership)
 
+    assert_nil membership.started_on
+    assert_nil membership.ended_on
     assert membership.pending?
     assert_equal membership, Membership.pending.first
+  end
+
+  test "prevents a member from having an overlapping later membership" do
+    member = create(:member)
+    membership = create(:membership, member: member)
+
+    later_membership = build(:membership, member: member, started_on: membership.ended_on)
+    refute later_membership.valid?
+    assert_equal ["can't overlap with another membership"], later_membership.errors[:base]
+  end
+
+  test "prevents a member from having an overlapping earlier membership" do
+    member = create(:member)
+    membership = create(:membership, member: member)
+
+    earlier_membership = build(:membership, member: member, ended_on: membership.started_on)
+    refute earlier_membership.valid?
+    assert_equal ["can't overlap with another membership"], earlier_membership.errors[:base]
+  end
+
+  test "allows different members to have overlapping memberships" do
+    member = create(:member)
+    membership = create(:membership, member: member)
+
+    member2 = create(:member)
+    create(:membership, member: member2, started_on: membership.started_on)
   end
 end

--- a/test/system/admin/member_verification_test.rb
+++ b/test/system/admin/member_verification_test.rb
@@ -89,7 +89,8 @@ class MemberVerificationTest < ApplicationSystemTestCase
     visit admin_member_url(@member)
 
     click_on "Create Membership"
-    click_on "Save without Payment"
+    first("label", text: "Create without payment").click
+    click_on "Save Membership"
 
     assert_content "Expires"
 

--- a/test/system/admin/memberships_test.rb
+++ b/test/system/admin/memberships_test.rb
@@ -1,0 +1,105 @@
+require "application_system_test_case"
+
+class MembershipsTest < ApplicationSystemTestCase
+  def setup
+    sign_in_as_admin
+  end
+
+  test "starts membership for pending member" do
+    membership = create(:pending_membership)
+    member = membership.member
+
+    Time.use_zone "America/Chicago" do
+      visit admin_member_url(member)
+
+      assert_content "pending membership"
+      click_on "Start Membership"
+
+      refute_content "pending membership"
+      assert_content "Membership started"
+
+      membership.reload
+
+      within ".account" do
+        assert_content "Expires #{membership.ended_on.strftime("%b %-d, %Y")}"
+      end
+
+      click_on "Membership"
+      assert_content membership.started_on.to_s(:long_date)
+      assert_content membership.ended_on.to_s(:long_date)
+    end
+  end
+
+  test "create active membership without a payment" do
+    @member = create(:verified_member)
+
+    visit admin_member_url(@member)
+
+    click_on "Create Membership"
+    first("label", text: "Create without payment").click
+    click_on "Save Membership"
+
+    within ".account" do
+      assert_content "Expires"
+    end
+
+    click_on "Membership"
+    assert_content "$0.00"
+  end
+
+  test "create pending membership without a payment" do
+    @member = create(:verified_member)
+
+    visit admin_member_url(@member)
+
+    click_on "Create Membership"
+    first("label", text: "Create without payment").click
+    first("label", text: "Start this membership").click # uncheck
+
+    click_on "Save Membership"
+
+    within ".account" do
+      assert_content "Pending"
+    end
+
+    click_on "Membership"
+    assert_content "$0.00"
+  end
+
+  test "create active membership with payment" do
+    @member = create(:verified_member)
+
+    visit admin_member_url(@member)
+
+    click_on "Create Membership"
+
+    fill_in "This year's membership fee", with: "30"
+    click_on "Save Membership"
+
+    within ".account" do
+      assert_content "Expires"
+    end
+
+    click_on "Membership"
+    assert_content "$30.00"
+  end
+
+  test "create pending membership with payment" do
+    @member = create(:verified_member)
+
+    visit admin_member_url(@member)
+
+    click_on "Create Membership"
+
+    fill_in "This year's membership fee", with: "30"
+    first("label", text: "Start this membership").click # uncheck
+    click_on "Save Membership"
+
+    within ".account" do
+      assert_content "Pending"
+    end
+
+    click_on "Membership"
+    assert_content "$30.00"
+  end
+end

--- a/test/system/user_signup_test.rb
+++ b/test/system/user_signup_test.rb
@@ -111,6 +111,8 @@ class UserSignupTest < ApplicationSystemTestCase
       assert_includes html, "Thank you for signing up"
       assert_includes html, "Your payment of $42.00"
     end
+
+    assert Membership.last.pending?
   end
 
   test "signup and redeem a gift membership" do
@@ -135,5 +137,6 @@ class UserSignupTest < ApplicationSystemTestCase
     end
 
     assert_equal 0, Member.last.adjustments.count
+    assert Membership.last.pending?
   end
 end


### PR DESCRIPTION
# What it does

This changes memberships to have two states: active and pending. Pending memberships don't have a `started_on` or `ended_on` date and are mostly used when a new member first signs up. This allows the clock on their year-long membership to not start until they come in and verify their account, borrow a tool, etc.

# Why it is important

We have a lot of folks who sign up online but don't make it in to see us for a while. This change avoids the situation where a lot of time passes and they get significantly less than a year before their membership needs to be renewed.