### PR TITLE
Limit volunteers to 3 per shift

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,15 +4,19 @@
 SQUARE_ACCESS_TOKEN=
 SQUARE_LOCATION_ID=
 
-# Google API access for calendar functionality: volunteer hold pickup scheduling
+# Google API access for calendar functionality: volunteer shifts and appointment scheduling
 GCAL_CLIENT_ID=
 GCAL_CLIENT_SECRET=
-GCAL_CALENDAR_ID=
-GOOGLE_CLIENT_ID=
-GOOGLE_CLIENT_SECRET=
+
+# Calendar to use for volunteer slots
+VOLUNTEER_SLOT_CALENDAR_ID=
 
 # Calendar to use for hold slots
 HOLD_SLOTS_GOOGLE_CALENDAR_ID=
+
+# Google Oauth configuration
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
 
 # Bucketeer provides AWS credentials without needing an Amazon account. Used to store image and file uploads.
 BUCKETEER_AWS_ACCESS_KEY_ID=

--- a/app/lib/volunteer/google_calendar.rb
+++ b/app/lib/volunteer/google_calendar.rb
@@ -2,7 +2,7 @@ module Volunteer
   class GoogleCalendar
     TOKEN_ENDPOINT = "https://www.googleapis.com/oauth2/v4/token"
 
-    def initialize(calendar_id: ENV.fetch("GCAL_CALENDAR_ID"))
+    def initialize(calendar_id: ENV.fetch("VOLUNTEER_SLOT_CALENDAR_ID"))
       @calendar_id = calendar_id
     end
 

--- a/app/views/volunteer/shifts/index.html.erb
+++ b/app/views/volunteer/shifts/index.html.erb
@@ -4,7 +4,7 @@
     <div class="instructions mt-2">
       <p class="main">Click <em>Sign up</em> on a shift you'd like to cover.</p>
       <p class="sub">
-        We try to have at least 2 people at each shift, but more is OK!
+        We try to have at least 2 people at each shift (but no more than three due to COVID precautions).
       </p>
     </div>
     <% if signed_in_via_google? %>
@@ -22,6 +22,7 @@
     <div class="shift-schedule">
       <table class="table">
         <% @events.group_by { |e| e.start.to_date }.each do |date, daily_events| %>
+          <%= total_attendees = daily_events.inject(0) { |de, sum| de.accepted_attendees_count + sum %>
           <% daily_events.sort_by{|e| [e.start, e.finish]}.each_with_index do |event, i| %>
             <tr>
               <% if i == 0 %>
@@ -41,6 +42,8 @@
               <td>
                 <% if signed_in_via_google? && event.attended_by?(@attendee.email) %>
                   <%= link_to("Signed up", "", class: "btn btn-success", disabled: true) %>
+                <% elsif total_attendees >= 3 %>
+                  <%= link_to("Full", "", class: "btn btn-success", disabled: true) %>
                 <% else %>
                   <%= link_to("Sign up", new_volunteer_shift_path(event_id: event.id), class: "btn #{"btn-primary" if event.accepted_attendees_count < 2}") %>
                 <% end %>

--- a/app/views/volunteer/shifts/index.html.erb
+++ b/app/views/volunteer/shifts/index.html.erb
@@ -1,10 +1,10 @@
 <div class="columns">
-  <div class="column col-8 col-mx-auto col-md-10 col-sm-12">
+  <div class="column col-10 col-mx-auto col-md-10 col-sm-12">
     <h1>Volunteer Shifts</h1>
     <div class="instructions mt-2">
       <p class="main">Click <em>Sign up</em> on a shift you'd like to cover.</p>
       <p class="sub">
-        We try to have at least 2 people at each shift (but no more than three due to COVID precautions).
+        We try to have at least 2 people at each shift (but no more than three due to COVID).
       </p>
     </div>
     <% if signed_in_via_google? %>
@@ -18,11 +18,20 @@
 </div>
 
 <div class="columns">
-  <div class="column col-8 col-mx-auto col-md-10 col-sm-12">
+  <div class="column col-10 col-mx-auto col-md-10 col-sm-12">
     <div class="shift-schedule">
       <table class="table">
+        <thead>
+          <tr>
+            <th>Date</th>
+            <th>Role</th>
+            <th>Time</th>
+            <th>Signed up</th>
+            <th></th>
+          </tr>
+        </thead>
         <% @events.group_by { |e| e.start.to_date }.each do |date, daily_events| %>
-          <%= total_attendees = daily_events.inject(0) { |de, sum| de.accepted_attendees_count + sum %>
+          <% total_attendees = daily_events.inject(0) { |sum, de| de.accepted_attendees_count + sum } %>
           <% daily_events.sort_by{|e| [e.start, e.finish]}.each_with_index do |event, i| %>
             <tr>
               <% if i == 0 %>
@@ -39,11 +48,12 @@
                 <% end %>
               </td>
               <td><%= event.times %></td>
+              <td class="text-center"><%= total_attendees %></td>
               <td>
-                <% if signed_in_via_google? && event.attended_by?(@attendee.email) %>
+                <% if total_attendees >= 3 %>
+                  <em>Shift full</em>
+                <% elsif signed_in_via_google? && event.attended_by?(@attendee.email) %>
                   <%= link_to("Signed up", "", class: "btn btn-success", disabled: true) %>
-                <% elsif total_attendees >= 3 %>
-                  <%= link_to("Full", "", class: "btn btn-success", disabled: true) %>
                 <% else %>
                   <%= link_to("Sign up", new_volunteer_shift_path(event_id: event.id), class: "btn #{"btn-primary" if event.accepted_attendees_count < 2}") %>
                 <% end %>


### PR DESCRIPTION
# What it does

We only want to allow up to three volunteers to staff any given shift as a part of our COVID precautions.

* This PR also renames the environment variable that holds the volunteer calendar ID to `VOLUNTEER_SLOT_CALENDAR_ID`, which is a much clearer name now that we also use a calendar for appointment scheduling.