### PR TITLE
[#263] Rename memberships started on and ended on columns

### DIFF
--- a/app/controllers/admin/reports/memberships_controller.rb
+++ b/app/controllers/admin/reports/memberships_controller.rb
@@ -16,7 +16,7 @@ module Admin
           .left_joins(memberships: :adjustment)
           .select("email", "members.id", "status", "full_name", "preferred_name", "loans_count",
             "count(memberships.id) as memberships_count",
-            "max(memberships.ended_on) as expires_on",
+            "max(memberships.ended_at) as expires_on",
             "array_agg(adjustments.amount_cents ORDER BY adjustments.created_at ASC) as amounts")
           .from(members_and_loan_counts, :members)
           .group("members.id", "members.email", "members.status", "members.full_name", "members.preferred_name", "loans_count")

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -4,8 +4,8 @@ class Membership < ApplicationRecord
   belongs_to :member
   has_one :adjustment, as: "adjustable"
 
-  scope :active, -> { where("started_on <= ? AND ended_on >= ?", Time.current, Time.current) }
-  scope :pending, -> { where(started_on: nil, ended_on: nil) }
+  scope :active, -> { where("started_at <= ? AND ended_on >= ?", Time.current, Time.current) }
+  scope :pending, -> { where(started_at: nil, ended_on: nil) }
 
   validate :no_overlapping_dates
   validate :start_after_end
@@ -15,11 +15,11 @@ class Membership < ApplicationRecord
   end
 
   def pending?
-    started_on.nil? && ended_on.nil?
+    started_at.nil? && ended_on.nil?
   end
 
   def start!(now = Time.current)
-    update!(started_on: now, ended_on: now + 364.days)
+    update!(started_at: now, ended_on: now + 364.days)
   end
 
   def self.next_start_date_for_member(member, now: Time.current.to_date)
@@ -39,7 +39,7 @@ class Membership < ApplicationRecord
       start_date = next_start_date_for_member(member, now: now)
       raise PendingMembership.new("member with pending membership can't start a new membership") unless start_date
 
-      membership = member.memberships.create!(started_on: start_date, ended_on: start_date + 364.days)
+      membership = member.memberships.create!(started_at: start_date, ended_on: start_date + 364.days)
     else
       membership = member.memberships.create!
     end
@@ -55,18 +55,18 @@ class Membership < ApplicationRecord
 
   def no_overlapping_dates
     overlapping = member.memberships.where(
-      "started_on BETWEEN ? AND ? OR ended_on BETWEEN ? AND ?",
-      started_on, ended_on, started_on, ended_on
+      "started_at BETWEEN ? AND ? OR ended_on BETWEEN ? AND ?",
+      started_at, ended_on, started_at, ended_on
     ).count
 
     errors.add(:base, "can't overlap with another membership") if overlapping > 0
   end
 
   def start_after_end
-    return true unless started_on && ended_on
+    return true unless started_at && ended_on
 
-    if started_on > ended_on
-      errors.add(:started_on, "must start before end")
+    if started_at > ended_on
+      errors.add(:started_at, "must start before end")
       errors.add(:ended_on, "must end after start")
     end
   end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -4,8 +4,8 @@ class Membership < ApplicationRecord
   belongs_to :member
   has_one :adjustment, as: "adjustable"
 
-  scope :active, -> { where("started_at <= ? AND ended_on >= ?", Time.current, Time.current) }
-  scope :pending, -> { where(started_at: nil, ended_on: nil) }
+  scope :active, -> { where("started_at <= ? AND ended_at >= ?", Time.current, Time.current) }
+  scope :pending, -> { where(started_at: nil, ended_at: nil) }
 
   validate :no_overlapping_dates
   validate :start_after_end
@@ -15,11 +15,11 @@ class Membership < ApplicationRecord
   end
 
   def pending?
-    started_at.nil? && ended_on.nil?
+    started_at.nil? && ended_at.nil?
   end
 
   def start!(now = Time.current)
-    update!(started_at: now, ended_on: now + 364.days)
+    update!(started_at: now, ended_at: now + 364.days)
   end
 
   def self.next_start_date_for_member(member, now: Time.current.to_date)
@@ -27,7 +27,7 @@ class Membership < ApplicationRecord
     return nil if member.pending_membership
 
     # renewal memberships should start on the day after the active one ends
-    return member.active_membership.ended_on + 1.day if member.active_membership
+    return member.active_membership.ended_at + 1.day if member.active_membership
 
     # if there isn't an active membership (this includes if there was one that
     # has already ended), it can start today
@@ -39,7 +39,7 @@ class Membership < ApplicationRecord
       start_date = next_start_date_for_member(member, now: now)
       raise PendingMembership.new("member with pending membership can't start a new membership") unless start_date
 
-      membership = member.memberships.create!(started_at: start_date, ended_on: start_date + 364.days)
+      membership = member.memberships.create!(started_at: start_date, ended_at: start_date + 364.days)
     else
       membership = member.memberships.create!
     end
@@ -55,19 +55,19 @@ class Membership < ApplicationRecord
 
   def no_overlapping_dates
     overlapping = member.memberships.where(
-      "started_at BETWEEN ? AND ? OR ended_on BETWEEN ? AND ?",
-      started_at, ended_on, started_at, ended_on
+      "started_at BETWEEN ? AND ? OR ended_at BETWEEN ? AND ?",
+      started_at, ended_at, started_at, ended_at
     ).count
 
     errors.add(:base, "can't overlap with another membership") if overlapping > 0
   end
 
   def start_after_end
-    return true unless started_at && ended_on
+    return true unless started_at && ended_at
 
-    if started_at > ended_on
+    if started_at > ended_at
       errors.add(:started_at, "must start before end")
-      errors.add(:ended_on, "must end after start")
+      errors.add(:ended_at, "must end after start")
     end
   end
 end

--- a/app/views/account/members/show.html.erb
+++ b/app/views/account/members/show.html.erb
@@ -46,7 +46,7 @@
         <dd class="title_bold"><%= @member.number %></dd>
 
         <dt>Membership Expiration Date</dt>
-        <dd class="title_bold"><%= date_with_time_title(@member.active_membership.ended_on) %></dd>
+        <dd class="title_bold"><%= date_with_time_title(@member.active_membership.ended_at) %></dd>
       <% else %>
         <dd class="label"><%= @member.status %></dd>
       <% end %>

--- a/app/views/admin/members/_member_details.html.erb
+++ b/app/views/admin/members/_member_details.html.erb
@@ -41,7 +41,7 @@
         <li>
           <%= feather_icon "key" %>
           <%= link_to admin_member_memberships_path(member) do %>
-            Expires <%= member.active_membership.ended_on.strftime("%b %-d, %Y") %>
+            Expires <%= member.active_membership.ended_at.strftime("%b %-d, %Y") %>
           <% end %>
         </li>
       <% elsif member.pending_membership %>

--- a/app/views/admin/members/memberships/index.html.erb
+++ b/app/views/admin/members/memberships/index.html.erb
@@ -15,7 +15,7 @@
             <td colspan="2" class="text-center"><em>pending</em></td>
           <% else %>
             <td><%= membership.started_at&.to_s(:long_date) %></td>
-            <td><%= membership.ended_on&.to_s(:long_date) %></td>
+            <td><%= membership.ended_at&.to_s(:long_date) %></td>
           <% end %>
           <td><%= membership.amount.format %></td>
         </tr>

--- a/app/views/admin/members/memberships/index.html.erb
+++ b/app/views/admin/members/memberships/index.html.erb
@@ -14,7 +14,7 @@
           <% if membership.pending? %>
             <td colspan="2" class="text-center"><em>pending</em></td>
           <% else %>
-            <td><%= membership.started_on&.to_s(:long_date) %></td>
+            <td><%= membership.started_at&.to_s(:long_date) %></td>
             <td><%= membership.ended_on&.to_s(:long_date) %></td>
           <% end %>
           <td><%= membership.amount.format %></td>

--- a/db/migrate/20201231181600_rename_membership_started_on_and_ended_on.rb
+++ b/db/migrate/20201231181600_rename_membership_started_on_and_ended_on.rb
@@ -1,0 +1,6 @@
+class RenameMembershipStartedOnAndEndedOn < ActiveRecord::Migration[6.0]
+  def change
+    rename_column(:memberships, :started_on, :started_at)
+    rename_column(:memberships, :ended_on, :ended_at)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_29_191804) do
+ActiveRecord::Schema.define(version: 2020_12_31_181600) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -328,8 +328,8 @@ ActiveRecord::Schema.define(version: 2020_11_29_191804) do
 
   create_table "memberships", force: :cascade do |t|
     t.bigint "member_id", null: false
-    t.datetime "started_on", precision: 6
-    t.datetime "ended_on", precision: 6
+    t.datetime "started_at", precision: 6
+    t.datetime "ended_at", precision: 6
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["member_id"], name: "index_memberships_on_member_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -51,7 +51,7 @@ verified_member = Member.create!(
   reminders_via_email: true, reminders_via_text: true, receive_newsletter: true, volunteer_interest: true
 )
 User.create!(email: verified_member.email, password: "password", member: verified_member)
-verified_member.memberships.create!(started_on: Time.current)
+verified_member.memberships.create!(started_at: Time.current)
 
 unverified_member = Member.create!(
   email: "newmember@example.com", full_name: "Firstname Lastname", preferred_name: "New",

--- a/test/factories/memberships.rb
+++ b/test/factories/memberships.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory :membership do
     member
-    started_on { Time.current - 1.month }
-    after(:build) { |m| m.ended_on = m.started_on + 364.days if m.started_on }
+    started_at { Time.current - 1.month }
+    after(:build) { |m| m.ended_on = m.started_at + 364.days if m.started_at }
 
     factory :pending_membership do
-      started_on { nil }
+      started_at { nil }
       ended_on { nil }
     end
   end

--- a/test/factories/memberships.rb
+++ b/test/factories/memberships.rb
@@ -2,11 +2,11 @@ FactoryBot.define do
   factory :membership do
     member
     started_at { Time.current - 1.month }
-    after(:build) { |m| m.ended_on = m.started_at + 364.days if m.started_at }
+    after(:build) { |m| m.ended_at = m.started_at + 364.days if m.started_at }
 
     factory :pending_membership do
       started_at { nil }
-      ended_on { nil }
+      ended_at { nil }
     end
   end
 end

--- a/test/models/membership_test.rb
+++ b/test/models/membership_test.rb
@@ -13,7 +13,7 @@ class MembershipTest < ActiveSupport::TestCase
 
     assert_equal member, membership.member
     assert_equal now, membership.started_at
-    assert_equal now + 364.days, membership.ended_on
+    assert_equal now + 364.days, membership.ended_at
   end
 
   test "creates a pending membership for a member" do
@@ -28,7 +28,7 @@ class MembershipTest < ActiveSupport::TestCase
 
     assert_equal member, membership.member
     assert_nil membership.started_at
-    assert_nil membership.ended_on
+    assert_nil membership.ended_at
   end
 
   test "creates a membership for a member with a cash payment" do
@@ -43,7 +43,7 @@ class MembershipTest < ActiveSupport::TestCase
     }
 
     assert_equal now, membership.started_at
-    assert_equal now + 364.days, membership.ended_on
+    assert_equal now + 364.days, membership.ended_at
     membership_adjustment = membership.adjustment
     assert_equal amount * -1, membership_adjustment.amount
     assert_equal "membership", membership_adjustment.kind
@@ -70,7 +70,7 @@ class MembershipTest < ActiveSupport::TestCase
     }
 
     assert_nil membership.started_at
-    assert_nil membership.ended_on
+    assert_nil membership.ended_at
     membership_adjustment = membership.adjustment
     assert_equal amount * -1, membership_adjustment.amount
     assert_equal "membership", membership_adjustment.kind
@@ -98,7 +98,7 @@ class MembershipTest < ActiveSupport::TestCase
 
     assert_equal member, membership.member
     assert_equal now, membership.started_at
-    assert_equal now + 364.days, membership.ended_on
+    assert_equal now + 364.days, membership.ended_at
 
     membership_adjustment = membership.adjustment
     assert_equal amount * -1, membership_adjustment.amount
@@ -127,7 +127,7 @@ class MembershipTest < ActiveSupport::TestCase
 
     assert_equal member, membership.member
     assert_nil membership.started_at
-    assert_nil membership.ended_on
+    assert_nil membership.ended_at
 
     membership_adjustment = membership.adjustment
     assert_equal amount * -1, membership_adjustment.amount
@@ -147,7 +147,7 @@ class MembershipTest < ActiveSupport::TestCase
     membership = create(:pending_membership)
 
     assert_nil membership.started_at
-    assert_nil membership.ended_on
+    assert_nil membership.ended_at
     assert membership.pending?
     assert_equal membership, Membership.pending.first
   end
@@ -156,7 +156,7 @@ class MembershipTest < ActiveSupport::TestCase
     member = create(:member)
     membership = create(:membership, member: member)
 
-    later_membership = build(:membership, member: member, started_at: membership.ended_on)
+    later_membership = build(:membership, member: member, started_at: membership.ended_at)
     refute later_membership.valid?
     assert_equal ["can't overlap with another membership"], later_membership.errors[:base]
   end
@@ -165,7 +165,7 @@ class MembershipTest < ActiveSupport::TestCase
     member = create(:member)
     membership = create(:membership, member: member)
 
-    earlier_membership = build(:membership, member: member, ended_on: membership.started_at)
+    earlier_membership = build(:membership, member: member, ended_at: membership.started_at)
     refute earlier_membership.valid?
     assert_equal ["can't overlap with another membership"], earlier_membership.errors[:base]
   end

--- a/test/models/membership_test.rb
+++ b/test/models/membership_test.rb
@@ -12,7 +12,7 @@ class MembershipTest < ActiveSupport::TestCase
     }
 
     assert_equal member, membership.member
-    assert_equal now, membership.started_on
+    assert_equal now, membership.started_at
     assert_equal now + 364.days, membership.ended_on
   end
 
@@ -27,7 +27,7 @@ class MembershipTest < ActiveSupport::TestCase
     }
 
     assert_equal member, membership.member
-    assert_nil membership.started_on
+    assert_nil membership.started_at
     assert_nil membership.ended_on
   end
 
@@ -42,7 +42,7 @@ class MembershipTest < ActiveSupport::TestCase
       }
     }
 
-    assert_equal now, membership.started_on
+    assert_equal now, membership.started_at
     assert_equal now + 364.days, membership.ended_on
     membership_adjustment = membership.adjustment
     assert_equal amount * -1, membership_adjustment.amount
@@ -69,7 +69,7 @@ class MembershipTest < ActiveSupport::TestCase
       }
     }
 
-    assert_nil membership.started_on
+    assert_nil membership.started_at
     assert_nil membership.ended_on
     membership_adjustment = membership.adjustment
     assert_equal amount * -1, membership_adjustment.amount
@@ -97,7 +97,7 @@ class MembershipTest < ActiveSupport::TestCase
     }
 
     assert_equal member, membership.member
-    assert_equal now, membership.started_on
+    assert_equal now, membership.started_at
     assert_equal now + 364.days, membership.ended_on
 
     membership_adjustment = membership.adjustment
@@ -126,7 +126,7 @@ class MembershipTest < ActiveSupport::TestCase
     }
 
     assert_equal member, membership.member
-    assert_nil membership.started_on
+    assert_nil membership.started_at
     assert_nil membership.ended_on
 
     membership_adjustment = membership.adjustment
@@ -146,7 +146,7 @@ class MembershipTest < ActiveSupport::TestCase
   test "is pending" do
     membership = create(:pending_membership)
 
-    assert_nil membership.started_on
+    assert_nil membership.started_at
     assert_nil membership.ended_on
     assert membership.pending?
     assert_equal membership, Membership.pending.first
@@ -156,7 +156,7 @@ class MembershipTest < ActiveSupport::TestCase
     member = create(:member)
     membership = create(:membership, member: member)
 
-    later_membership = build(:membership, member: member, started_on: membership.ended_on)
+    later_membership = build(:membership, member: member, started_at: membership.ended_on)
     refute later_membership.valid?
     assert_equal ["can't overlap with another membership"], later_membership.errors[:base]
   end
@@ -165,7 +165,7 @@ class MembershipTest < ActiveSupport::TestCase
     member = create(:member)
     membership = create(:membership, member: member)
 
-    earlier_membership = build(:membership, member: member, ended_on: membership.started_on)
+    earlier_membership = build(:membership, member: member, ended_on: membership.started_at)
     refute earlier_membership.valid?
     assert_equal ["can't overlap with another membership"], earlier_membership.errors[:base]
   end
@@ -175,6 +175,6 @@ class MembershipTest < ActiveSupport::TestCase
     membership = create(:membership, member: member)
 
     member2 = create(:member)
-    create(:membership, member: member2, started_on: membership.started_on)
+    create(:membership, member: member2, started_at: membership.started_at)
   end
 end

--- a/test/system/admin/memberships_test.rb
+++ b/test/system/admin/memberships_test.rb
@@ -21,12 +21,12 @@ class MembershipsTest < ApplicationSystemTestCase
       membership.reload
 
       within ".account" do
-        assert_content "Expires #{membership.ended_on.strftime("%b %-d, %Y")}"
+        assert_content "Expires #{membership.ended_at.strftime("%b %-d, %Y")}"
       end
 
       click_on "Membership"
       assert_content membership.started_at.to_s(:long_date)
-      assert_content membership.ended_on.to_s(:long_date)
+      assert_content membership.ended_at.to_s(:long_date)
     end
   end
 

--- a/test/system/admin/memberships_test.rb
+++ b/test/system/admin/memberships_test.rb
@@ -25,7 +25,7 @@ class MembershipsTest < ApplicationSystemTestCase
       end
 
       click_on "Membership"
-      assert_content membership.started_on.to_s(:long_date)
+      assert_content membership.started_at.to_s(:long_date)
       assert_content membership.ended_on.to_s(:long_date)
     end
   end


### PR DESCRIPTION
# What it does

This PR contains the following changes:

1. A database migration to rename two columns on the `memberships` table.
2. Application and test level changes to reflect the renamed attributes on the `Member` model.

Relevant quote from https://github.com/rubyforgood/circulate/issues/263:

> memberships.started_on and memberships.ended_on store timestamps but are named using _on which indicates that they should be dates. Rename these columns to ended_at and started_at using a database migration to align their names with the values they store.

# Why it is important

This PR closes https://github.com/rubyforgood/circulate/issues/263.

# UI Change Screenshot

There are no UI changes on this PR. But I thought a before/after comparison of the Membership records would be helpful, so I'm including this screenshot:

<img width="1630" alt="before_and_after_migration" src="https://user-images.githubusercontent.com/1179668/103423102-d9f50300-4b72-11eb-892f-88dee480c179.png">

# Implementation notes

* I didn't include previous database migrations when I renamed the attributes.
* The tests are green locally, with the exception of some system tests which are also failing on the [main branch](https://gist.github.com/gregblake/92b0370e378d28d8fb59d2e5d04cff4a).
* It would be wise for someone who is knowledgable about how librarians and members use the application to do a quick regression test to make sure I didn't miss anything related to the name changes.