### PR TITLE
[Appointments] Hovering item link shows item number

### DIFF
--- a/app/views/admin/appointments/index.html.erb
+++ b/app/views/admin/appointments/index.html.erb
@@ -46,7 +46,7 @@
               <td class="items">
                 <% appointment.holds.each do |hold| %>
                     pick-up
-                    <%= link_to hold.item.name, admin_item_path(hold.item) %> <br/>
+                    <%= link_to hold.item.name, admin_item_path(hold.item), title: hold.item.complete_number%> <br/>
                 <% end %>
                 <% appointment.loans.each do |loan| %>
                     drop-off


### PR DESCRIPTION
# What it does

Adds a tooltip to item names on appointment screen showing item number

# Why it is important

Improves librarian experience, closes issue #423 

# UI Change Screenshot

![Screen Shot 2021-01-11 at 5 49 00 PM](https://user-images.githubusercontent.com/47793873/104251831-33dcaf00-5436-11eb-995a-85795a3f85d5.png)

# Implementation notes

Tooltips show at a browser determined time, can be slow on certain browsers to appear.
