### PR TITLE
Disable check out buttons for unverified users on Appointments

### DIFF
--- a/app/views/admin/appointments/_checkouts.html.erb
+++ b/app/views/admin/appointments/_checkouts.html.erb
@@ -2,7 +2,7 @@
   <div class="columns col-oneline">
     <div class="column col-8"><h4>Items to be checked-out (<%= checkout_items_quantity_for_appointment %>)</h4></div>
     <div class="column col-sm-12 col-4 text-right">
-      <%= button_to "Check-out All", admin_appointment_checkouts_path(current_appointment, hold_ids: appointment_pickup_items.active.pluck(:id)), class: "btn btn-primary", data: { disable_with: "Checking-out...", confirm: "Are you sure you want to check-out all items?" }, disabled: !appointment_pickup_items.active.exists? %>
+      <%= button_to "Check-out All", admin_appointment_checkouts_path(current_appointment, hold_ids: appointment_pickup_items.active.pluck(:id)), class: "btn btn-primary", data: { disable_with: "Checking-out...", confirm: "Are you sure you want to check-out all items?" }, disabled: !appointment_pickup_items.active.exists? || !member.active_membership || !member.status_verified? %>
     </div>
   </div>
 
@@ -23,7 +23,7 @@
         <p><%= full_item_number(pickup_item.item) %></p>
       </div>
       <div class="column col-sm-12 col-4 text-right">
-        <%= button_to "Check-out", admin_appointment_checkouts_path(current_appointment, hold_ids: [pickup_item.id]), class: "btn btn-primary btn-sm", data: { disable_with: "Checking-out..." }, disabled: !pickup_item.active? %>
+        <%= button_to "Check-out", admin_appointment_checkouts_path(current_appointment, hold_ids: [pickup_item.id]), class: "btn btn-primary btn-sm", data: { disable_with: "Checking-out..." }, disabled: !pickup_item.active? || !member.active_membership || !member.status_verified? %>
         <% if pickup_item.active? %>
           <%= button_to 'Cancel Hold', admin_appointment_hold_path(current_appointment, pickup_item, cancel_hold: true), class: "btn btn-sm mt-2 float-right", method: :delete, data: { disable_with: "Canceling...", confirm: "Are you sure you want to remove this item from the appointment and cancel the member's hold?" } %>
           <%= button_to 'Remove Item', admin_appointment_hold_path(current_appointment, pickup_item, cancel_hold: false), class: "btn btn-sm mt-2 float-right", method: :delete, data: { disable_with: "Removing...", confirm: "Are you sure you want to remove this item from the appointment?" } %>

--- a/app/views/admin/appointments/show.html.erb
+++ b/app/views/admin/appointments/show.html.erb
@@ -2,6 +2,27 @@
   <%= index_header "#{preferred_or_default_name(current_appointment.member)}'s Appointment" %>
 <% end %>
 
+<% if !current_appointment.member.active_membership %>
+  <% if current_appointment.member.pending_membership %>
+    <div class="toast member-membership clearfix">
+      <p class="float-left"><i class="icon icon-stop"></i> Member has a pending membership.</p>
+      <p class="float-right"><%= link_to "Start Membership", admin_member_membership_path(current_appointment.member, current_appointment.member.pending_membership), method: :patch %></p>
+    </div>
+  <% else %>
+    <div class="toast member-membership clearfix">
+      <p class="float-left"><i class="icon icon-stop"></i> Member needs to start a membership.</p>
+      <p class="float-right"><%= link_to "Create Membership", new_admin_member_membership_path(current_appointment.member) %></p>
+    </div>
+  <% end %>
+<% end %>
+
+<% unless current_appointment.member.status_verified? %>
+  <div class="toast clearfix member-membership">
+    <p class="float-left"><i class="icon icon-stop"></i> Member's ID and zipcode need to be verified.</p>
+    <p class="float-right"><%= link_to "Verify Info", edit_admin_member_verification_path(current_appointment.member) %></p>
+  </div>
+<% end %>
+
 <div class="columns">
   <div class="column col-4 col-sm-12">
     <%= render "admin/members/member_details", member: current_appointment.member %>
@@ -20,6 +41,6 @@
         </div>
       </div>
   </div>
-  <%= render "checkouts" %>
+  <%= render "checkouts", member: current_appointment.member %>
   <%= render "checkins" %>
 </div>


### PR DESCRIPTION
# What it does

Disable the check-out all and check-out button on the appointments page if a user is unverified or inactive

# Why it is important

Closes issue #427. 

# UI Change Screenshot

<img width="1412" alt="Screen Shot 2021-01-20 at 6 13 39 PM" src="https://user-images.githubusercontent.com/47793873/105257285-10f47e00-5b4d-11eb-8883-74ddb912f3e4.png">

<img width="1389" alt="Screen Shot 2021-01-20 at 6 30 49 PM" src="https://user-images.githubusercontent.com/47793873/105257725-fb338880-5b4d-11eb-8ad1-bfa5c365a9d5.png">

<img width="1371" alt="Screen Shot 2021-01-20 at 6 33 11 PM" src="https://user-images.githubusercontent.com/47793873/105257731-fec70f80-5b4d-11eb-83b5-1ad0c6747954.png">

# Implementation notes

Reused alert banners from member's page
Covered both cases of Unverified and Inactive individually, and links to verify and active work as expected
