### PR TITLE
add database credentials to dotenv example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,10 @@
 # This file lists all of the environment variables that the application uses for various purposes.
 
+# Database credentials
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=
+DATABASE_HOST=database
+
 # Square API is uses to process online payments
 SQUARE_ACCESS_TOKEN=
 SQUARE_LOCATION_ID=


### PR DESCRIPTION
# What it does

This PR has goal to add Database credentials to .env exemple