### PR TITLE
Update membership Square order number

### DIFF
--- a/app/controllers/renewal/payments_controller.rb
+++ b/app/controllers/renewal/payments_controller.rb
@@ -17,7 +17,7 @@ module Renewal
         return
       end
 
-      result = checkout.checkout_url(amount: @form.amount, email: @member.email, return_to: callback_renewal_payments_url, member_id: @member.id)
+      result = checkout.checkout_url(amount: @form.amount, email: @member.email, return_to: callback_renewal_payments_url, member_id: @member.id, date: Date.today)
       if result.success?
         redirect_to result.value
       else

--- a/app/controllers/renewal/payments_controller.rb
+++ b/app/controllers/renewal/payments_controller.rb
@@ -17,7 +17,7 @@ module Renewal
         return
       end
 
-      result = checkout.checkout_url(amount: @form.amount, email: @member.email, return_to: callback_renewal_payments_url, member_id: @member.id, date: Date.today)
+      result = checkout.checkout_url(amount: @form.amount, email: @member.email, return_to: callback_renewal_payments_url, member_id: @member.id, date: Date.current)
       if result.success?
         redirect_to result.value
       else

--- a/app/controllers/signup/payments_controller.rb
+++ b/app/controllers/signup/payments_controller.rb
@@ -16,7 +16,7 @@ module Signup
         return
       end
 
-      result = checkout.checkout_url(amount: @form.amount, email: @member.email, return_to: callback_signup_payments_url, member_id: @member.id, date: Date.today)
+      result = checkout.checkout_url(amount: @form.amount, email: @member.email, return_to: callback_signup_payments_url, member_id: @member.id, date: Date.current)
       if result.success?
         redirect_to result.value
       else

--- a/app/controllers/signup/payments_controller.rb
+++ b/app/controllers/signup/payments_controller.rb
@@ -16,7 +16,7 @@ module Signup
         return
       end
 
-      result = checkout.checkout_url(amount: @form.amount, email: @member.email, return_to: callback_signup_payments_url, member_id: @member.id)
+      result = checkout.checkout_url(amount: @form.amount, email: @member.email, return_to: callback_signup_payments_url, member_id: @member.id, date: Date.today)
       if result.success?
         redirect_to result.value
       else

--- a/app/lib/square_checkout.rb
+++ b/app/lib/square_checkout.rb
@@ -5,7 +5,7 @@ class SquareCheckout
     @now = now
   end
 
-  def checkout_url(amount:, email:, member_id:, return_to:, idempotency_key: random_idempotency_key)
+  def checkout_url(amount:, email:, date:, member_id:, return_to:, idempotency_key: random_idempotency_key)
     checkout_response = @client.checkout.create_checkout(
       location_id: @location_id,
       body: {
@@ -15,7 +15,7 @@ class SquareCheckout
         order: {
           order: {
             location_id: @location_id,
-            reference_id: member_id.to_s,
+            reference_id: "#{date.strftime("%Y%m%d")}-#{member_id}",
             line_items: [{
               name: "Annual Membership",
               quantity: "1",

--- a/test/controllers/signup/payments_controller_test.rb
+++ b/test/controllers/signup/payments_controller_test.rb
@@ -23,7 +23,8 @@ module Signup
         amount: Money.new(1200),
         email: @member.email,
         return_to: "http://www.example.com/signup/payments/callback",
-        member_id: @member.id
+        member_id: @member.id,
+        date: Date.today
       }]
 
       SquareCheckout.stub :new, mock_checkout do

--- a/test/controllers/signup/payments_controller_test.rb
+++ b/test/controllers/signup/payments_controller_test.rb
@@ -24,7 +24,7 @@ module Signup
         email: @member.email,
         return_to: "http://www.example.com/signup/payments/callback",
         member_id: @member.id,
-        date: Date.today
+        date: Date.current
       }]
 
       SquareCheckout.stub :new, mock_checkout do

--- a/test/lib/square_checkout_test.rb
+++ b/test/lib/square_checkout_test.rb
@@ -52,7 +52,7 @@ class SquareCheckoutTest < ActiveSupport::TestCase
         email: member.email,
         return_to: "http://example.com/callback",
         member_id: member.id,
-        date: Date.new(2021, 1, 1),
+        date: Time.zone.local(2021, 1, 1),
         idempotency_key: "test"
       )
 
@@ -112,7 +112,7 @@ class SquareCheckoutTest < ActiveSupport::TestCase
         email: member.email,
         return_to: "http://example.com/callback",
         member_id: member.id,
-        date: Date.new(2021, 1, 1),
+        date: Time.zone.local(2021, 1, 1),
         idempotency_key: "test"
       )
 

--- a/test/lib/square_checkout_test.rb
+++ b/test/lib/square_checkout_test.rb
@@ -26,7 +26,7 @@ class SquareCheckoutTest < ActiveSupport::TestCase
           order: {
             order: {
               location_id: "SQ_LOCATION_ID",
-              reference_id: member.id.to_s,
+              reference_id: "20210101-#{member.id}",
               line_items: [{
                 name: "Annual Membership",
                 quantity: "1",
@@ -52,6 +52,7 @@ class SquareCheckoutTest < ActiveSupport::TestCase
         email: member.email,
         return_to: "http://example.com/callback",
         member_id: member.id,
+        date: Date.new(2021, 1, 1),
         idempotency_key: "test"
       )
 
@@ -85,7 +86,7 @@ class SquareCheckoutTest < ActiveSupport::TestCase
           order: {
             order: {
               location_id: "SQ_LOCATION_ID",
-              reference_id: member.id.to_s,
+              reference_id: "20210101-#{member.id}",
               line_items: [{
                 name: "Annual Membership",
                 quantity: "1",
@@ -111,6 +112,7 @@ class SquareCheckoutTest < ActiveSupport::TestCase
         email: member.email,
         return_to: "http://example.com/callback",
         member_id: member.id,
+        date: Date.new(2021, 1, 1),
         idempotency_key: "test"
       )
 


### PR DESCRIPTION
# What it does

Updates the Square reference ID for membership orders to include the membership creation date before the member ID.

# Why it is important

Closes #441

# Implementation notes

* I made `date` a parameter of `checkout_url` and passed `Date.today` from the controller because I'm assuming that will always correspond to the membership creation date. Let me know if any of that isn't what you're expecting!
