### PR TITLE
Set current_user when loading dev data.

### DIFF
--- a/lib/tasks/devdata.rake
+++ b/lib/tasks/devdata.rake
@@ -37,9 +37,12 @@ namespace :devdata do
   end
 
   task load: :environment do
-    load_models Document
-    load_models BorrowPolicy
-    load_models Category
-    load_models Item
+    admin = User.where(email: "admin@example.com").first!
+    Audited.audit_class.as_user(admin) do
+      load_models Document
+      load_models BorrowPolicy
+      load_models Category
+      load_models Item
+    end
   end
 end


### PR DESCRIPTION
# What it does

This fixes an issue where audits were being created for dev data without a `current_user` set. This was causing the item edit history page to throw an error when it attempted to call methods on an audit's user (which was `nil`).

# Why it is important

Developers should be able to view any of the pages in the app using the dev data.