### PR TITLE
Fix flaky test with freeze_time

### DIFF
--- a/test/controllers/signup/payments_controller_test.rb
+++ b/test/controllers/signup/payments_controller_test.rb
@@ -19,22 +19,24 @@ module Signup
       mock_result.expect :value, "https://squareup.com/checkout/12345"
 
       mock_checkout = Minitest::Mock.new
-      mock_checkout.expect :checkout_url, mock_result, [{
-        amount: Money.new(1200),
-        email: @member.email,
-        return_to: "http://www.example.com/signup/payments/callback",
-        member_id: @member.id,
-        date: Date.current
-      }]
+      freeze_time do
+        mock_checkout.expect :checkout_url, mock_result, [{
+          amount: Money.new(1200),
+          email: @member.email,
+          return_to: "http://www.example.com/signup/payments/callback",
+          member_id: @member.id,
+          date: Date.current
+        }]
 
-      SquareCheckout.stub :new, mock_checkout do
-        post signup_payments_url, params: {membership_payment_form: {amount_dollars: "12"}}
+        SquareCheckout.stub :new, mock_checkout do
+          post signup_payments_url, params: {membership_payment_form: {amount_dollars: "12"}}
+        end
+
+        assert_redirected_to "https://squareup.com/checkout/12345"
+
+        assert_mock mock_result
+        assert_mock mock_checkout
       end
-
-      assert_redirected_to "https://squareup.com/checkout/12345"
-
-      assert_mock mock_result
-      assert_mock mock_checkout
     end
 
     test "fails to create a checkout_url" do


### PR DESCRIPTION
# What it does

Cleans up the flaky test from #449 with the `freeze_time` helper

# Why it is important

It looks like the controller test fixed here has been failing on some PRs, so this should clean that up
