### PR TITLE
Allow admins to view renewal requests

### DIFF
--- a/app/views/account/home/index.html.erb
+++ b/app/views/account/home/index.html.erb
@@ -33,13 +33,13 @@
           <td class=<%= loan.due_at - Time.now < 3.days ? "warning" : "" %>><%= "Due #{humanize_due_date(loan)}" %></td>
           <td><%= render_loan_status(loan) %></td>
           <td>
-            <% if ENV["FEATURE_RENEWAL_REQUEST"] == "on" && loan.renewal_requests.any? %>
+            <% if ENV["FEATURE_RENEWAL_REQUESTS"] == "on" && loan.renewal_requests.any? %>
               <%= button_to "Renewal #{loan.latest_renewal_request.rejected? ? "Rejected" : "Requested"}", "#", method: :post, class: "btn", disabled: true %>
             <% elsif !loan.within_borrow_policy_duration? && loan.renewal? %>
               <%= button_to "Renewed", "#", method: :post, class: "btn", disabled: true %>
             <% elsif loan.member_renewable? %>
               <%= button_to 'Renew Loan', account_renewals_path(loan_id: loan), method: :post, class: "btn" %>
-            <% elsif ENV["FEATURE_RENEWAL_REQUEST"] == "on" && loan.member_renewal_requestable? %>
+            <% elsif ENV["FEATURE_RENEWAL_REQUESTS"] == "on" && loan.member_renewal_requestable? %>
               <%= button_to 'Request Loan Renewal', account_renewal_requests_path(loan_id: loan), method: :post, class: "btn" %>
             <% end %>
           </td>

--- a/app/views/admin/renewal_requests/index.html.erb
+++ b/app/views/admin/renewal_requests/index.html.erb
@@ -1,0 +1,68 @@
+<% content_for :header do %>
+  <%= index_header "Renewals" %>
+<% end %>
+
+<div class="columns">
+  <div class="column col-12">
+    <div class="items-summary">
+      Viewing
+      <div class="btn-group">
+        <%= link_to_unless params[:filter] == "all" || params[:filter].blank?, "all", {}, class: "btn btn-sm" do %>
+          <button class="btn btn-sm active">all</button>
+        <% end %>
+        <%= link_to_unless_current "requested", {filter: "requested"}, class: "btn btn-sm" do %>
+          <button class="btn btn-sm active">requested</button>
+        <% end %>
+        <%= link_to_unless_current "rejected", {filter: "rejected"}, class: "btn btn-sm" do %>
+          <button class="btn btn-sm active">rejected</button>
+        <% end %>
+      </div>
+    </div> 
+
+    <% if @renewal_requests.any? %>
+
+      <table class="table table-scroll">
+        <thead>
+          <tr>
+            <th>
+              <span>Item</span><br>
+              <span>Holds</span>
+            </th>
+            <th>Item Number</th>
+            <th>Member</th>
+            <th>Requested On</th>
+            <th>Status</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+
+        <tbody>
+          <% @renewal_requests.each do |request| %>
+            <tr>
+              <td>
+                <span><%= link_to request.loan.item.name, [:admin, request.loan.item] %></span><br>
+                <span><%= request.loan.item.holds.size %> <%= "hold".pluralize(request.loan.item.holds.size) %></span>
+              </td>
+              <td><%= full_item_number(request.loan.item) %></td>
+              <td><%= link_to preferred_or_default_name(request.loan.member), [:admin, request.loan.member] %></td>
+              <td><%= date_with_time_title request.created_at %></td>
+              <td><%= request.status %></td>
+              <td>
+                <div class="btn-group">
+                  <%= button_to "Renew", "#", method: :post, class: "btn" %>
+                  <%= button_to "Reject", "#", method: :post, class: "btn" %>
+                </div>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+
+      <%== pagy_bootstrap_nav(@pagy) %>
+
+    <% else %>
+      <%= empty_state "No matching renewal requests", icon: "time" %>
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -30,6 +30,9 @@
               <li class="nav-item"><%= link_to "Items", admin_items_path %></li>
               <li class="nav-item"><%= link_to "Members", admin_members_path %></li>
               <li class="nav-item"><%= link_to "Loans", admin_loan_summaries_path %></li>
+              <% if ENV["FEATURE_RENEWAL_REQUESTS"] == "on" %>
+              <li class="nav-item"><%= link_to "Renewals", admin_renewal_requests_path %></li>
+              <% end %>
               <li class="nav-item"><%= link_to "Holds", admin_holds_path %></li>
             </ul>
           </li>
@@ -108,6 +111,9 @@
                 <li class="menu-item"><%= link_to "Items", admin_items_path %></li>
                 <li class="menu-item"><%= link_to "Members", admin_members_path %></li>
                 <li class="menu-item"><%= link_to "Loans", admin_loan_summaries_path %></li>
+                <% if ENV["FEATURE_RENEWAL_REQUESTS"] == "on" %>
+                <li class="menu-item"><%= link_to "Renewals", admin_renewal_requests_path %></li>
+                <% end %>
                 <li class="menu-item"><%= link_to "Holds", admin_holds_path %></li>
               </ul>
             </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -115,7 +115,7 @@ Rails.application.routes.draw do
     resources :potential_volunteers, only: :index
     resources :holds, only: [:index]
     resources :users
-    resources :renewal_requests, only: :update if ENV["FEATURE_RENEWAL_REQUESTS"] == "on"
+    resources :renewal_requests, only: [:index, :update] if ENV["FEATURE_RENEWAL_REQUESTS"] == "on"
 
     post "search", to: "searches#create"
     get "search", to: "searches#show"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2021_02_04_025839) do
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,32 +18,32 @@ ActiveRecord::Schema.define(version: 2021_02_04_025839) do
     "fine",
     "membership",
     "donation",
-    "payment",
+    "payment"
   ], force: :cascade
 
   create_enum :adjustment_source, [
     "cash",
     "square",
-    "forgiveness",
+    "forgiveness"
   ], force: :cascade
 
   create_enum :hold_request_status, [
     "new",
     "completed",
-    "denied",
+    "denied"
   ], force: :cascade
 
   create_enum :item_attachment_kind, [
     "manual",
     "parts_list",
-    "other",
+    "other"
   ], force: :cascade
 
   create_enum :notification_status, [
     "pending",
     "sent",
     "bounced",
-    "error",
+    "error"
   ], force: :cascade
 
   create_enum :power_source, [
@@ -52,19 +51,19 @@ ActiveRecord::Schema.define(version: 2021_02_04_025839) do
     "gas",
     "air",
     "electric (corded)",
-    "electric (battery)",
+    "electric (battery)"
   ], force: :cascade
 
   create_enum :renewal_request_status, [
     "requested",
     "approved",
-    "rejected",
+    "rejected"
   ], force: :cascade
 
   create_enum :user_role, [
     "staff",
     "admin",
-    "member",
+    "member"
   ], force: :cascade
 
   create_table "action_text_rich_texts", force: :cascade do |t|

--- a/test/controllers/admin/renewal_requests_controller_test.rb
+++ b/test/controllers/admin/renewal_requests_controller_test.rb
@@ -2,5 +2,19 @@ require "test_helper"
 
 module Admin
   class RenewalRequestsControllerTest < ActionDispatch::IntegrationTest
+    include Devise::Test::IntegrationHelpers
+
+    setup do
+      @item = create(:item)
+      @loan = create(:loan, item: @item)
+      @renewal_request = create(:renewal_request, loan: @loan)
+      @user = create(:admin_user)
+      sign_in @user
+    end
+
+    test "should get index" do
+      get admin_renewal_requests_url
+      assert_response :success
+    end
   end
 end


### PR DESCRIPTION
# What it does

Adds a page for admins to view renewal requests and apply filters based on status. Also fixes an env var typo in the user loans template and re-runs `standardrb` since it looks like my lefthook config wasn't working earlier.

# Why it is important

Implements the changes from the designs in #307

# UI Change Screenshot

![renewal-requests-view](https://user-images.githubusercontent.com/8291663/107512609-ae4f3a80-6b6c-11eb-965b-47daefc30b2f.gif)

# Implementation notes

Everything was based on some existing admin views, so it shouldn't be too different, but let me know if my call to `includes` isn't loading all the models we need. I didn't see any duplicate queries locally, but want to be sure since I'm still getting a hold of the schema
