### PR TITLE
Allow admins to approve, reject renewals

### DIFF
--- a/app/controllers/account/home_controller.rb
+++ b/app/controllers/account/home_controller.rb
@@ -1,7 +1,7 @@
 module Account
   class HomeController < BaseController
     def index
-      @loans = current_member.loans.checked_out.includes(:item).order(:due_at)
+      @loans = current_member.loans.checked_out.includes(:item, :renewal_requests).order(:due_at)
       @holds = current_member.holds.includes(:item)
     end
   end

--- a/app/controllers/admin/renewal_requests_controller.rb
+++ b/app/controllers/admin/renewal_requests_controller.rb
@@ -5,22 +5,22 @@ module Admin
     def index
       renewal_requests_scope = RenewalRequest.send(index_filter)
         .order(created_at: :desc)
-        .includes(loan: [{item: :borrow_policy}, :member])
+        .includes(loan: [{item: :borrow_policy}, :member, :renewals])
       @pagy, @renewal_requests = pagy(renewal_requests_scope, items: 50)
     end
 
     def update
       return head(:forbidden) unless current_user.admin? || current_user.staff?
 
-      flash_message = if @renewal_request.save
-        # TODO: Renew loan
-        MemberMailer.with(member: @renewal_request.loan.member, renewal_request: @renewal_request).loan_renewal_request_message.deliver_later
+      @renewal_request = RenewalRequest.find(params[:id])
+      flash_message = if @renewal_request.update(renewal_request_params)
+        @renewal_request.loan.renew! if @renewal_request.approved?
         {success: "Renewal request updated."}
       else
         {error: "Something went wrong!"}
       end
 
-      redirect_to admin_load_summaries_url, flash: flash_message
+      redirect_to admin_renewal_requests_url, flash: flash_message
     end
 
     private

--- a/app/lib/activity_notifier.rb
+++ b/app/lib/activity_notifier.rb
@@ -41,7 +41,7 @@ class ActivityNotifier
     Member.find(ids).each do |member|
       summaries = member.loan_summaries
         .active_on(@now)
-        .or(member.loan_summaries.checked_out)
+        .or(member.loan_summaries.includes(:renewal_requests).checked_out)
         .includes(item: :borrow_policy)
       yield member, summaries
     end

--- a/app/models/renewal_request.rb
+++ b/app/models/renewal_request.rb
@@ -1,5 +1,6 @@
 class RenewalRequest < ApplicationRecord
   belongs_to :loan
+  belongs_to :loan_summary, foreign_key: "loan_id", optional: true
 
   enum status: {
     requested: "requested",

--- a/app/views/account/home/index.html.erb
+++ b/app/views/account/home/index.html.erb
@@ -34,9 +34,13 @@
           <td><%= render_loan_status(loan) %></td>
           <td>
             <% if ENV["FEATURE_RENEWAL_REQUESTS"] == "on" && loan.renewal_requests.any? %>
-              <%= button_to "Renewal #{loan.latest_renewal_request.rejected? ? "Rejected" : "Requested"}", "#", method: :post, class: "btn", disabled: true %>
+              <% if loan.latest_renewal_request.rejected? %>
+                Renewal refused
+              <% else %>
+                Renewal requested
+              <% end %>
             <% elsif !loan.within_borrow_policy_duration? && loan.renewal? %>
-              <%= button_to "Renewed", "#", method: :post, class: "btn", disabled: true %>
+              Renewed
             <% elsif loan.member_renewable? %>
               <%= button_to 'Renew Loan', account_renewals_path(loan_id: loan), method: :post, class: "btn" %>
             <% elsif ENV["FEATURE_RENEWAL_REQUESTS"] == "on" && loan.member_renewal_requestable? %>

--- a/app/views/admin/renewal_requests/index.html.erb
+++ b/app/views/admin/renewal_requests/index.html.erb
@@ -46,12 +46,22 @@
               <td><%= full_item_number(request.loan.item) %></td>
               <td><%= link_to preferred_or_default_name(request.loan.member), [:admin, request.loan.member] %></td>
               <td><%= date_with_time_title request.created_at %></td>
-              <td><%= request.status %></td>
               <td>
+                <% if request.approved? && request.loan.renewals.any? %>
+                  <%= request.status %>, due <%= date_with_time_title request.loan.renewals.max_by{ |r| r.created_at }.due_at %>
+                <% elsif request.rejected? %>
+                  <%= request.status %> <%= date_with_time_title request.updated_at %>
+                <% else %>
+                  <%= request.status %>
+                <% end %>
+              </td>
+              <td>
+                <% if request.requested? %>
                 <div class="btn-group">
-                  <%= button_to "Renew", "#", method: :post, class: "btn" %>
-                  <%= button_to "Reject", "#", method: :post, class: "btn" %>
+                  <%= button_to "Renew", admin_renewal_request_path(request, renewal_request: {status: :approved}), method: :put, class: "btn" %>
+                  <%= button_to "Reject", admin_renewal_request_path(request, renewal_request: {status: :rejected}), method: :put, class: "btn" %>
                 </div>
+                <% end %>
               </td>
             </tr>
           <% end %>

--- a/app/views/member_mailer/_summaries.erb
+++ b/app/views/member_mailer/_summaries.erb
@@ -9,6 +9,11 @@
     <% if summary.ended? %>
       returned
     <% else %>
+      <% if summary.renewal_request_rejected? %>
+        <span class="rejected">
+          renewal rejected,
+        </span>
+      <% end %>
       <% if summary.overdue_as_of?(now) %>
         <span class="overdue">
           was due

--- a/app/views/member_mailer/summary.mjml
+++ b/app/views/member_mailer/summary.mjml
@@ -13,7 +13,7 @@
       li {
         margin-bottom: 1em;
       }
-      .overdue, .people-waiting {
+      .rejected, .overdue, .people-waiting {
         color: #DF6C54;
       }
       p.overdue {

--- a/test/controllers/admin/renewal_requests_controller_test.rb
+++ b/test/controllers/admin/renewal_requests_controller_test.rb
@@ -16,5 +16,28 @@ module Admin
       get admin_renewal_requests_url
       assert_response :success
     end
+
+    test "should renew a loan on approval" do
+      put admin_renewal_request_path(@renewal_request), params: {
+        renewal_request: {
+          status: :approved
+        }
+      }
+      assert_response :redirect
+
+      assert @renewal_request.reload.approved?
+      refute @renewal_request.loan.checked_out?
+    end
+
+    test "should reject a renewal" do
+      put admin_renewal_request_path(@renewal_request), params: {
+        renewal_request: {
+          status: :rejected
+        }
+      }
+      assert_response :redirect
+
+      assert @renewal_request.reload.rejected?
+    end
   end
 end

--- a/test/lib/activity_notifier_test.rb
+++ b/test/lib/activity_notifier_test.rb
@@ -175,4 +175,32 @@ class ActivityNotifierTest < ActiveSupport::TestCase
     assert_includes mail.encoded, checked_out_today.item.complete_number
     refute_includes mail.encoded, previous_loan.item.complete_number
   end
+
+  test "sends emails to folks with rejected renewal requests" do
+    loan = Time.use_zone("America/Chicago") {
+      create(:loan, created_at: Time.current.beginning_of_day - 1.minute)
+    }
+
+    Time.use_zone("America/Chicago") do
+      end_of_previous_day = Time.current.beginning_of_day - 1.minute
+
+      travel_to end_of_previous_day do
+        loan.return!
+      end
+
+      create(:renewal_request, loan: loan, status: :rejected)
+
+      notifier = ActivityNotifier.new
+      notifier.send_daily_loan_summaries
+    end
+
+    refute ActionMailer::Base.deliveries.empty?
+
+    mail = ActionMailer::Base.deliveries.find { |delivery| delivery.to == [loan.member.email] }
+    refute mail.nil?
+
+    assert_equal "Today's loan summary", mail.subject
+    assert_includes mail.encoded, loan.item.complete_number
+    refute_includes mail.encoded, "rejected"
+  end
 end

--- a/test/system/admin/renewal_requests_test.rb
+++ b/test/system/admin/renewal_requests_test.rb
@@ -1,0 +1,41 @@
+require "application_system_test_case"
+
+class AdminRenewalRequestsTest < ApplicationSystemTestCase
+  setup do
+    @member = create(:verified_member_with_membership)
+    @item = create(:item)
+    @loan = create(:loan, item: @item)
+    @renewal_request = create(:renewal_request, loan: @loan)
+
+    sign_in_as_admin
+    visit admin_renewal_requests_url
+  end
+
+  test "viewing renewal requests" do
+    within ".table" do
+      assert_text @item.complete_number
+    end
+  end
+
+  test "approving renewal requests" do
+    click_on "Renew"
+
+    within ".table" do
+      assert_text "approved, due"
+      refute_text "Renew"
+    end
+
+    assert_text "Renewal request updated"
+  end
+
+  test "rejecting renewal requests" do
+    click_on "Reject"
+
+    within ".table" do
+      assert_text "rejected"
+      refute_text "Reject"
+    end
+
+    assert_text "Renewal request updated"
+  end
+end


### PR DESCRIPTION
# What it does

Adds support for admins approving and rejecting renewal requests based on the descriptions in the issues with some caveats listed in the notes here. Also updates the member loan update email to mention rejections, since renewals are already covered

# Why it is important

Closes #305 and #306.

# UI Change Screenshot

## Admin view

![admin-renewal-request](https://user-images.githubusercontent.com/8291663/108579872-aa4eb580-72ee-11eb-9a8e-33853e8b6be9.gif)

## Member view

![renewal-screenshot](https://user-images.githubusercontent.com/8291663/108579893-b8043b00-72ee-11eb-80e7-6c701d1fb657.png)

# Implementation notes

* I updated the `active_on` scope for loan summaries to check renewal request updates, and moved it to keyword interpolation to be a little more clear since the query is pretty long
* The issue about rejecting renewals says the status column for members should include a longer message telling people to schedule a time to return items, but that didn't fit in the table so I used the shorter version in the screenshot
