### PR TITLE
Send staff daily email of renewal requests

### DIFF
--- a/app/lib/activity_notifier.rb
+++ b/app/lib/activity_notifier.rb
@@ -37,7 +37,7 @@ class ActivityNotifier
 
   def send_staff_daily_renewal_requests
     daily_renewal_requests = RenewalRequest.requested.where.not(loan_id: nil).where("created_at >= ?", @now.beginning_of_day.utc).includes(loan: [:item, :member])
-    Member.joins(:user).where(users: {role: [:staff, :admin]}).each do |staff|
+    Member.joins(:user).where(users: {role: :admin}).each do |staff|
       MemberMailer.with(member: staff, renewal_requests: daily_renewal_requests).staff_daily_renewal_requests.deliver
     end
   end

--- a/app/lib/activity_notifier.rb
+++ b/app/lib/activity_notifier.rb
@@ -35,6 +35,13 @@ class ActivityNotifier
     end
   end
 
+  def send_staff_daily_renewal_requests
+    daily_renewal_requests = RenewalRequest.requested.where.not(loan_id: nil).where("created_at >= ?", @now.beginning_of_day.utc).includes(loan: [:item, :member])
+    Member.joins(:user).where(users: {role: [:staff, :admin]}).each do |staff|
+      MemberMailer.with(member: staff, renewal_requests: daily_renewal_requests).staff_daily_renewal_requests.deliver
+    end
+  end
+
   private
 
   def each_member(ids, &block)

--- a/app/mailers/member_mailer.rb
+++ b/app/mailers/member_mailer.rb
@@ -57,6 +57,14 @@ class MemberMailer < ApplicationMailer
     mail(to: @member.email, subject: @subject)
   end
 
+  def staff_daily_renewal_requests
+    @member = params[:member]
+    @renewal_requests = params[:renewal_requests]
+    @now = params[:now] || Time.current
+    @subject = "Open renewal requests as of #{@now.strftime("%m/%d/%Y")}"
+    mail(to: @member.email, subject: @subject)
+  end
+
   private
 
   def summary_mail

--- a/app/views/member_mailer/_staff_daily_renewal_requests.erb
+++ b/app/views/member_mailer/_staff_daily_renewal_requests.erb
@@ -1,0 +1,15 @@
+<% if renewal_requests.empty? %>
+<p>
+  No open renewal requests
+</p>
+<% else %>
+<ul>
+<% renewal_requests.each do |request| %>
+  <li>
+    <strong><%= full_item_number(request.loan.item) %> - <%= request.loan.item.name %></strong>,
+    by <%= preferred_or_default_name(request.loan.member) %>,
+    requested <%= checked_out_date(request.created_at) %>
+  </li>
+<% end %>
+</ul>
+<% end %>

--- a/app/views/member_mailer/staff_daily_renewal_requests.mjml
+++ b/app/views/member_mailer/staff_daily_renewal_requests.mjml
@@ -1,0 +1,75 @@
+<mjml>
+  <mj-head>
+    <mj-preview><%= @subject %></mj-preview>
+    <mj-attributes>
+      <mj-all font-family="Montserrat, Helvetica, Arial, sans-serif"></mj-all>
+      <mj-text
+        font-weight="400"
+        font-size="16px"
+        color="#1D181A"
+        line-height="24px"
+      ></mj-text>
+      <mj-section background-color="#FFF" padding="0"></mj-section>
+    </mj-attributes>
+    <mj-style inline="inline">
+      a, a:visited {
+        color: #2F7890;
+      }
+      li {
+        margin-bottom: 1em;
+      }
+      .info {
+        border: solid 3px #66C4E3;
+        background: aliceblue;
+        padding: 0 1em;
+      }
+    </mj-style>
+  </mj-head>
+  <mj-body background-color="#F4F4F4">
+    <mj-section>
+      <mj-column padding-top="20px">
+        <mj-image src="<%= asset_pack_url "media/images/logo.jpg" %>"
+        width="100px" />
+      </mj-column>
+    </mj-section>
+    <mj-section>
+      <mj-column>
+        <mj-text
+          font-size="36px"
+          line-height="28px"
+          font-weight="bold"
+          align="center"
+          ><%= @subject %></mj-text
+        >
+      </mj-column>
+    </mj-section>
+    <mj-section>
+      <mj-column>
+        <mj-text>
+          <%= render partial: "member_mailer/staff_daily_renewal_requests", locals: {renewal_requests: @renewal_requests, now: @now} %>
+        </mj-text>
+      </mj-column>
+    </mj-section>
+    <mj-section>
+      <mj-column>
+        <mj-text>
+          <p>
+            <a href="<%= admin_renewal_requests_url %>">Review these renewal requests</a> in the Circulate app.
+          </p>
+        </mj-text>
+      </mj-column>
+    </mj-section>
+    <mj-section background-color="#F4F4F4">
+      <mj-column>
+        <mj-text font-size="14px" line-height="20px" align="center">
+          <p>
+            <a href="https://chicagotoollibrary.org">The Chicago Tool Library</a
+            ><br />
+            1048 W 37th Street Suite 102<br />
+            Chicago, IL 60609
+          </p>
+        </mj-text>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>

--- a/lib/tasks/email.rake
+++ b/lib/tasks/email.rake
@@ -35,4 +35,9 @@ namespace :email do
       MemberMailer.with(member: member, amount: amount).membership_renewal_reminder.deliver_now
     end
   end
+
+  desc "Send staff renewal request summary emails"
+  task :send_staff_daily_renewal_requests, [:date] => :environment do |task, args|
+    send_emails :send_staff_daily_renewal_requests, args[:date]
+  end
 end

--- a/test/mailers/previews/member_mailer_preview.rb
+++ b/test/mailers/previews/member_mailer_preview.rb
@@ -61,6 +61,6 @@ class MemberMailerPreview < ActionMailer::Preview
 
     renewal_requests = RenewalRequest.requested.where.not(loan_id: nil).where("created_at >= ?", Time.current.beginning_of_day.utc).includes(loan: [:item, :member]).limit(5)
 
-    MemberMailer.with(member: Member.joins(:user).where(users: {role: [:staff, :admin]}).first, renewal_requests: renewal_requests).staff_daily_renewal_requests
+    MemberMailer.with(member: Member.joins(:user).where(users: {role: :admin}).first, renewal_requests: renewal_requests).staff_daily_renewal_requests
   end
 end

--- a/test/mailers/previews/member_mailer_preview.rb
+++ b/test/mailers/previews/member_mailer_preview.rb
@@ -51,4 +51,16 @@ class MemberMailerPreview < ActionMailer::Preview
   def membership_renewal_reminder
     MemberMailer.with(member: Member.first).membership_renewal_reminder
   end
+
+  def staff_daily_renewal_requests
+    tomorrow = Time.current.end_of_day + 1.day
+    3.times do
+      loan = Loan.create!(item: Item.available.order("RANDOM()").first, member: Member.verified.first, due_at: tomorrow, uniquely_numbered: false)
+      RenewalRequest.create!(loan: loan)
+    end
+
+    renewal_requests = RenewalRequest.requested.where.not(loan_id: nil).where("created_at >= ?", Time.current.beginning_of_day.utc).includes(loan: [:item, :member]).limit(5)
+
+    MemberMailer.with(member: Member.joins(:user).where(users: {role: [:staff, :admin]}).first, renewal_requests: renewal_requests).staff_daily_renewal_requests
+  end
 end


### PR DESCRIPTION
# What it does

Adds a task for sending a daily summary of renewal requests to library staff

# Why it is important

Closes #346

# UI Change Screenshot

![renewal_requests_email](https://user-images.githubusercontent.com/8291663/111875884-119d6b00-896a-11eb-9070-e4ddb519ddba.png)

# Implementation notes

* The email goes to both staff and admins, but should this just go to staff?
* I reused `MemberMailer` instead of adding a separate mailer because all of the boilerplate seemed the same and it didn't seem worth splitting out for now
* I based the query for determining whether a request was made on the current day on the `LoanSummary` `active_on` scope, but it's not clear to me why that works with UTC instead of the local time
* I'm filtering on the user role database enum directly because I didn't see any case where we filter for multiple roles, not sure if a scope would make more sense
