### PR TITLE
Allow staff to modify appointment times

### DIFF
--- a/app/controllers/admin/appointments_controller.rb
+++ b/app/controllers/admin/appointments_controller.rb
@@ -8,6 +8,19 @@ module Admin
     def show
     end
 
+    def edit
+      load_appointment_slots
+    end
+
+    def update
+      if current_appointment.update(appointment_params)
+        redirect_to admin_appointments_path, flash: {success: "Appointment updated."}
+      else
+        load_appointment_slots
+        render :edit
+      end
+    end
+
     def destroy
       current_appointment.destroy
       redirect_to admin_appointments_path, flash: {success: "Appointment cancelled."}
@@ -59,6 +72,26 @@ module Admin
 
     helper_method def checkin_items_quantity_for_appointment
       appointment_return_items.length
+    end
+
+    helper_method def appointment_time_range_string
+      "#{current_appointment.starts_at}..#{current_appointment.ends_at}"
+    end
+
+    def appointment_params
+      update_params = params.require(:appointment).permit(:time_range_string)
+      appointment_times = update_params[:time_range_string].split("..")
+      update_params[:starts_at] = DateTime.parse appointment_times[0]
+      update_params[:ends_at] = DateTime.parse appointment_times[1]
+      update_params
+    end
+
+    def load_appointment_slots
+      events = Event.appointment_slots.upcoming
+      @appointment_slots = events.group_by { |event| event.start.to_date }.map { |date, events|
+        times = events.map { |event| [event.times, event.start..event.finish] }
+        [date.strftime("%A, %B %-d, %Y"), times]
+      }
     end
   end
 end

--- a/app/javascript/stylesheets/partials/_appointment_form.scss
+++ b/app/javascript/stylesheets/partials/_appointment_form.scss
@@ -1,4 +1,4 @@
-.new-appointment {
+.appointment-form {
   select#appointment_time_range_string {
     width: 8rem;
   }

--- a/app/javascript/stylesheets/partials/_index.scss
+++ b/app/javascript/stylesheets/partials/_index.scss
@@ -3,5 +3,5 @@
 @import './admin_appointments';
 @import './appointments';
 @import './item_header';
-@import './new_appointment';
+@import './appointment_form';
 @import './admin_memberships';

--- a/app/views/account/appointments/new.html.erb
+++ b/app/views/account/appointments/new.html.erb
@@ -2,6 +2,6 @@
   <%= index_header "Schedule an Appointment" %>
 <% end %>
 
-<div class="new-appointment">
+<div class="appointment-form">
   <%= render partial: "form", locals: { holds: @holds, loans: @loans, can_schedule_appointment: @holds.any? || @loans.any? } %>
 </div>

--- a/app/views/admin/appointments/_form.html.erb
+++ b/app/views/admin/appointments/_form.html.erb
@@ -1,0 +1,22 @@
+<% if current_appointment.errors.any?  %>
+  <ul class="error">
+    <% current_appointment.errors.full_messages.each do |message| %>
+      <li><%= message %></li>
+    <% end %>
+  </ul>
+<% end %>
+
+<%= form_for :appointment, url: admin_appointment_path, method: :put do |form| %>
+
+  <div class="form-group" data-controller="appointment-date">
+    <label class="form-label" for="time_range_string">Select an appointment time</label>
+    <%= select("appointment", "time_range_string", grouped_options_for_select(@appointment_slots, appointment_time_range_string), { include_blank: 'Select a Date'},
+      class: "form-select", data: { action: "appointment-date#sync", target: "appointment-date.select" }) %>
+      <span data-target="appointment-date.display"></span>
+  </div>
+
+  <div>
+    <%= form.submit "Edit Appointment", class: "btn btn-primary" %>
+  </div>
+
+<% end %>

--- a/app/views/admin/appointments/edit.html.erb
+++ b/app/views/admin/appointments/edit.html.erb
@@ -1,0 +1,7 @@
+<% content_for :header do %>
+  <%= index_header "Edit Appointment" %>
+<% end %>
+
+<div class="appointment-form">
+  <%= render partial: "form" %>
+</div>

--- a/app/views/admin/appointments/show.html.erb
+++ b/app/views/admin/appointments/show.html.erb
@@ -16,6 +16,7 @@
           <h6>Appointment Date</h6>
           <h6><%= l current_appointment.starts_at, format: :date %></h6>
           <h6><%= l current_appointment.starts_at, format: :hour %>&nbsp;&ndash;<%= l current_appointment.ends_at, format: :hour %></h6>
+          <%= link_to "Edit date and time", edit_admin_appointment_path(current_appointment), class: "btn btn-sm mt-2" %>
         </div>
         <div class="column col-3">
           <%= button_to "Cancel", admin_appointment_path(current_appointment), class: "btn btn-primary", method: :delete, data: { disabled_with: "Cancelling appointment...", confirm: "Are you sure to cancel this appointment?" }%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,7 +60,7 @@ Rails.application.routes.draw do
     resources :shifts, only: :index
     resources :categories, except: :show
     resources :gift_memberships
-    resources :appointments, only: [:index, :show, :destroy] do
+    resources :appointments, only: [:index, :show, :edit, :update, :destroy] do
       resources :holds, only: [:create, :destroy], controller: :appointment_holds
       resources :loans, only: [:create, :destroy], controller: :appointment_loans
       resources :checkouts, only: [:create], controller: :appointment_checkouts

--- a/test/controllers/admin/appointments_test.rb
+++ b/test/controllers/admin/appointments_test.rb
@@ -26,5 +26,17 @@ module Admin
       assert_select "a[href=?]", admin_item_path(@hold.item)
       assert_select "a[href=?]", admin_member_path(@appointment.member)
     end
+
+    test "allows admins to modify appointment time range" do
+      starts_at = Time.current
+      ends_at = starts_at + 2.hours
+
+      put admin_appointment_path(@appointment), params: {appointment: {time_range_string: "#{starts_at}..#{ends_at}"}}
+      assert_redirected_to admin_appointments_url
+
+      @appointment.reload
+      assert_equal @appointment.starts_at.to_i, starts_at.to_i
+      assert_equal @appointment.ends_at.to_i, ends_at.to_i
+    end
   end
 end


### PR DESCRIPTION
# What it does

Adds a form for staff and admins to modify appointment times and a link from the appointment detail page to get to the form. Also adds a helper method for converting an appointment's start and end into a `time_range_string` for the select input.

# Why it is important

Closes #237

# UI Change Screenshot

![edit-appointment](https://user-images.githubusercontent.com/8291663/111882240-98f6d880-8982-11eb-94f4-138334e95a16.png)
![edit-appointment-button](https://user-images.githubusercontent.com/8291663/111882243-9ac09c00-8982-11eb-95a4-d402f4f79819.png)


# Implementation notes

* Is there a reason for including `current_appointment` as a helper here instead of something like `before_action :set_appointment`?
* I copied `load_appointment_slots` from the other appointments controller, but that could probably be abstracted somewhere. That also might be better as a `before_action`
