### PR TITLE
Show message if member can't make an appointment

### DIFF
--- a/app/views/account/appointments/_form.html.erb
+++ b/app/views/account/appointments/_form.html.erb
@@ -5,6 +5,14 @@
     <% end %>
   </ul>
 <% end %>
+
+<% if !can_schedule_appointment %>
+  <div class="toast toast-warning">
+    <p>You can only schedule an appointment if you have a tool on hold or that can be returned.</p>
+    <%= link_to "View Inventory", items_path, class: "btn btn-lg btn-default" %>
+  </div>
+<% end %>
+
 <%= form_for :appointment, url: account_appointments_path do |form| %>
   <% if loans.any? %>
     <h2 class="title_bold">Select Items to Return</h2>
@@ -77,17 +85,17 @@
   <div class="form-group" data-controller="appointment-date">
     <label class="form-label" for="time_range_string">Select a time to pick-up/return your items</label>
     <%= select("appointment", "time_range_string", grouped_options_for_select(@appointment_slots, @appointment.time_range_string), { include_blank: 'Select a Date'},
-      class: "form-select", data: { action: "appointment-date#sync", target: "appointment-date.select" }) %>
+      class: "form-select", data: { action: "appointment-date#sync", target: "appointment-date.select" }, disabled: !can_schedule_appointment) %>
       <span data-target="appointment-date.display"></span>
   </div>
 
   <div class="form-group mb-2">
     <label class="form-label" for="appointment_comment">Optional: Tell us about the project you are working on. This may help us recommend a different or additional tool for you.</label>
-    <%= form.text_area :comment, class: "form-input" %>
+    <%= form.text_area :comment, class: "form-input", disabled: !can_schedule_appointment %>
   </div>
 
   <div>
-    <%= form.submit "Create Appointment", class: "btn btn-primary" %>
+    <%= form.submit "Create Appointment", class: "btn btn-primary", disabled: !can_schedule_appointment %>
   </div>
 
 <% end %>

--- a/app/views/account/appointments/new.html.erb
+++ b/app/views/account/appointments/new.html.erb
@@ -3,5 +3,5 @@
 <% end %>
 
 <div class="new-appointment">
-  <%= render partial: "form", locals: { holds: @holds, loans: @loans } %>
+  <%= render partial: "form", locals: { holds: @holds, loans: @loans, can_schedule_appointment: @holds.any? || @loans.any? } %>
 </div>


### PR DESCRIPTION
# What it does

If the member doesn't have any items on hold or to return, show a message and disable the form fields on the create appointment page.

# Why it is important

Resolves this issue: https://github.com/rubyforgood/circulate/issues/466

# UI Change Screenshot

When you can't make an appointment...
![image](https://user-images.githubusercontent.com/12875392/112031129-fa48b400-8b08-11eb-8119-cfec621e14e5.png)

When you can make an appointment! 🎉 
![image](https://user-images.githubusercontent.com/12875392/112031097-f1f07900-8b08-11eb-8807-20dc959af495.png)

# Implementation notes
I suppose I could also hide the form fields instead of disabling, whatever feels best