### PR TITLE
477 - Allow multiple members to create an appointment for the same item

### DIFF
--- a/app/controllers/account/appointments_controller.rb
+++ b/app/controllers/account/appointments_controller.rb
@@ -51,7 +51,7 @@ module Account
     def load_appointment_slots
       events = Event.appointment_slots.upcoming
       @appointment_slots = events.group_by { |event| event.start.to_date }.map { |date, events|
-        times = events.map { |event| [event.times, event.start..event.finish] }
+        times = events.map { |event| [helpers.format_appointment_times(event.start, event.finish), event.start..event.finish] }
         [date.strftime("%A, %B %-d, %Y"), times]
       }
     end

--- a/app/helpers/appointments_helper.rb
+++ b/app/helpers/appointments_helper.rb
@@ -1,0 +1,10 @@
+module AppointmentsHelper
+  def format_appointment_times(start, stop)
+    date_format = "%l:%M%P"
+    "#{start.strftime(date_format).strip} - #{stop.strftime(date_format).strip}"
+  end
+
+  def appointment_time(appointment)
+    format_appointment_times(appointment.starts_at, appointment.ends_at)
+  end
+end

--- a/app/helpers/holds_helper.rb
+++ b/app/helpers/holds_helper.rb
@@ -21,7 +21,7 @@ module HoldsHelper
 
     if appointment
       "Scheduled for pick-up at #{format_date(appointment.starts_at)}, " +
-        format_time_range(appointment.starts_at, appointment.ends_at)
+        appointment_time(appointment)
     elsif hold.ready_for_pickup?
       "Ready for pickup. Schedule by #{format_date(hold.created_at + 7.days)}"
     else
@@ -43,9 +43,5 @@ module HoldsHelper
 
   def format_date(date)
     date.strftime("%a, %-m/%-d")
-  end
-
-  def format_time_range(starts_at, ends_at)
-    "#{starts_at.strftime("%l%P")}–#{ends_at.strftime("%l%P")}"
   end
 end

--- a/app/helpers/loans_helper.rb
+++ b/app/helpers/loans_helper.rb
@@ -26,8 +26,7 @@ module LoansHelper
     appointment = loan.upcoming_appointment
     appointment_time =
       if appointment
-        ". Scheduled for return at #{format_date(appointment.starts_at)}, " +
-          format_time_range(appointment.starts_at, appointment.ends_at)
+        ". Scheduled for return at #{format_date(appointment.starts_at)}, #{appointment_time(appointment)}"
       else
         ""
       end

--- a/app/models/hold.rb
+++ b/app/models/hold.rb
@@ -30,6 +30,13 @@ class Hold < ApplicationRecord
   end
 
   def ready_for_pickup?
+    # Holds for uncounted items are always ready to be picked up
+    unless item.borrow_policy.uniquely_numbered?
+      return true
+    end
+
+    # For uniquely numbered items there need to be no earlier holds
+    # and the item needs to be in the library
     previous_active_holds.empty? && item.available?
   end
 

--- a/app/views/account/appointments/index.html.erb
+++ b/app/views/account/appointments/index.html.erb
@@ -24,7 +24,7 @@
         <h2 class="title_bold">
           <%= appointment.starts_at.strftime("%A, %b %-d, %Y") %>
           <br />
-          <small class="gray-dark"><%= "#{appointment.starts_at.strftime("%I:%M%P")} - #{appointment.ends_at.strftime("%I:%M%P")}" %></small>
+          <small class="gray-dark"><%= appointment_time(appointment) %></small>
         </h2>
       </div>
 

--- a/test/models/hold_test.rb
+++ b/test/models/hold_test.rb
@@ -9,4 +9,14 @@ class HoldTest < ActiveSupport::TestCase
       hold.upcoming_appointment
     end
   end
+
+  test "is ready for pickup if item is uncounted" do
+    item = create(:uncounted_item)
+
+    hold = create(:hold, item: item)
+    assert hold.ready_for_pickup?
+
+    second_hold = create(:hold, item: item)
+    assert second_hold.ready_for_pickup?
+  end
 end

--- a/test/system/appointments_test.rb
+++ b/test/system/appointments_test.rb
@@ -1,16 +1,6 @@
 require "application_system_test_case"
 
 class AppointmentsTest < ApplicationSystemTestCase
-  setup do
-    @held_item1 = create(:item)
-    @held_item2 = create(:item)
-    @borrowed_item1 = create(:item)
-    @borrowed_item2 = create(:item)
-
-    @member = create(:verified_member_with_membership)
-    login_as @member.user
-  end
-
   def check_row_with_name(item_name)
     within row_containing(item_name) do
       find("input[type=checkbox]").check
@@ -21,8 +11,22 @@ class AppointmentsTest < ApplicationSystemTestCase
     find("tr", text: text)
   end
 
+  def select_first_available_date
+    first_optgroup = find("#appointment_time_range_string optgroup", match: :first)
+    first_optgroup.find("option", match: :first).select_option
+    first_optgroup.text
+  end
+
   test "schedules an appointment" do
-    create(:event, calendar_id: Event.appointment_slot_calendar_id, start: 3.hours.since, finish: 4.hours.since)
+    @held_item1 = create(:item)
+    @held_item2 = create(:item)
+    @borrowed_item1 = create(:item)
+    @borrowed_item2 = create(:item)
+
+    @member = create(:verified_member_with_membership)
+
+    login_as @member.user
+    create(:event, calendar_id: Event.appointment_slot_calendar_id, start: 27.hours.since.beginning_of_hour, finish: 28.hours.since.beginning_of_hour)
 
     create(:hold, item: @held_item1, member: @member)
     create(:hold, item: @held_item2, member: @member)
@@ -39,14 +43,12 @@ class AppointmentsTest < ApplicationSystemTestCase
     check_row_with_name(@held_item1.complete_number)
     check_row_with_name(@borrowed_item1.complete_number)
 
-    first_optgroup = find("#appointment_time_range_string optgroup", match: :first)
-    selected_date = first_optgroup.value
-    first_optgroup.find("option", match: :first).select_option
+    selected_date = select_first_available_date
 
     fill_in "Optional: Tell us about the project you are working on. This may help us recommend a different or additional tool for you.", with: "Just a small project"
     click_on "Create Appointment"
 
-    # assert_text "Upcoming Appointments"
+    assert_text " Appointments"
     assert_text selected_date
     assert_text @held_item1.complete_number
     assert_text @borrowed_item1.complete_number
@@ -60,5 +62,39 @@ class AppointmentsTest < ApplicationSystemTestCase
     within row_containing(@held_item2.complete_number) { assert_text "Ready for pickup" }
     within row_containing(@borrowed_item1.complete_number) { assert_text "Scheduled for drop-off" }
     within row_containing(@borrowed_item2.complete_number) { assert_text "Checked-out" }
+  end
+
+  test "multiple members can make an appointment for an uncounted tool" do
+    create(:event, calendar_id: Event.appointment_slot_calendar_id, start: 27.hours.since, finish: 28.hours.since)
+
+    @held_item = create(:uncounted_item)
+    @member = create(:verified_member_with_membership)
+    @second_member = create(:verified_member_with_membership)
+
+    create(:hold, item: @held_item, member: @member)
+    create(:hold, item: @held_item, member: @second_member)
+
+    [@member, @second_member].each do |member|
+      login_as member.user
+
+      visit account_home_url
+
+      click_on "Schedule a Pick Up"
+
+      assert_text "Schedule an Appointment"
+      check_row_with_name(@held_item.complete_number)
+
+      selected_date = select_first_available_date
+
+      click_on "Create Appointment"
+
+      assert_text "Appointments"
+      assert_text selected_date
+      assert_text @held_item.complete_number
+
+      visit account_home_url
+
+      within row_containing(@held_item.complete_number) { assert_text "Scheduled for pick-up" }
+    end
   end
 end

--- a/test/system/member_holds_test.rb
+++ b/test/system/member_holds_test.rb
@@ -7,7 +7,7 @@ class MemberHoldsTest < ApplicationSystemTestCase
     login_as @member.user
   end
 
-  test "member can Place a hold" do
+  test "member can place a hold" do
     visit item_url(@item)
     click_button "Place a hold"
 
@@ -15,7 +15,7 @@ class MemberHoldsTest < ApplicationSystemTestCase
     assert_text "You placed a hold on this item."
   end
 
-  test "member can Place a hold multiple times when the borrow policy allows it" do
+  test "member can place a hold multiple times when the borrow policy allows it" do
     @item.borrow_policy.update(uniquely_numbered: false)
 
     visit item_url(@item)


### PR DESCRIPTION
# What it does

* This corrects a few bits of logic around appointments and holds for uncounted items.
* The way that appointment times were displayed was unified to improve consistency.