### PR TITLE
474 - Hide retired and pending items from inventory page.

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -8,7 +8,7 @@ class ItemsController < ApplicationController
       @category = CategoryNode.where(id: params[:category]).first
       redirect_to(items_path, error: "Category not found") && return unless @category
 
-      item_scope = @category.items
+      item_scope = @category.items.listed_publicly
     end
 
     item_scope = item_scope.includes(:categories, :borrow_policy).with_attached_image.order(index_order)

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -24,4 +24,32 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     get item_url(@item)
     assert_response :success
   end
+
+  [:retired, :pending].each do |status|
+    test "doesn't display the show page for a #{status} item" do
+      hidden_item = create(:item, status: status)
+
+      assert_raises ActiveRecord::RecordNotFound do
+        get item_url(hidden_item)
+      end
+    end
+
+    test "hides #{status} items from the item index" do
+      hidden_item = create(:item, status: status)
+
+      get items_url
+
+      assert_match @item.complete_number, @response.body
+      refute_match hidden_item.complete_number, @response.body
+    end
+
+    test "hides #{status} items from the item index for a category" do
+      category = create(:category)
+      hidden_item = create(:item, status: status, categories: [category])
+
+      get items_url(category: category)
+
+      refute_match hidden_item.complete_number, @response.body
+    end
+  end
 end


### PR DESCRIPTION
# What it does

* Fixes #474.
* There was a bug where items that were retired or pending would appear on the category listing pages.