### PR TITLE
Avoid loading every item for a blank search query

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,7 +1,14 @@
 class SearchesController < ApplicationController
   def show
-    query = params[:query]
-    @items = Item.search_by_anything(query).by_name
-    @items_by_number = Item.number_contains(query)
+    query = params[:query].to_s.strip
+
+    if query.size < 3
+      @items = []
+      @items_by_number = []
+      flash.now[:warning] = "You must provide at least three numbers or letters to search by."
+    else
+      @items = Item.search_by_anything(query).by_name
+      @items_by_number = Item.number_contains(query)
+    end
   end
 end

--- a/test/controllers/searches_controller_test.rb
+++ b/test/controllers/searches_controller_test.rb
@@ -18,4 +18,11 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select ".items-table a", "Hammer"
   end
+
+  test "performs no search without a sufficently lengthy query" do
+    get search_url
+
+    assert_match "must provide at least", @response.body
+    assert_match "No matching items found", @response.body
+  end
 end


### PR DESCRIPTION
# What it does

Right now, an empty search query loads a page that lists every item. This, as you can imagine, is bad for the health of the server and the patience of the user.

This PR checks for a sufficiently lengthy query and shows an error if there isn't one.

![image](https://user-images.githubusercontent.com/3331/112243886-5c460e00-8c1c-11eb-9830-d128d31b7a76.png)
