### PR TITLE
Eager load active holds to avoid a query per item on the item index

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -11,7 +11,7 @@ class ItemsController < ApplicationController
       item_scope = @category.items.listed_publicly
     end
 
-    item_scope = item_scope.includes(:categories, :borrow_policy).with_attached_image.order(index_order)
+    item_scope = item_scope.includes(:categories, :borrow_policy, :active_holds).with_attached_image.order(index_order)
 
     @categories = CategoryNode.all
     @pagy, @items = pagy(item_scope)

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -90,7 +90,7 @@ module ItemsHelper
     if item.active?
       if item.checked_out_exclusive_loan
         ["label-warning", "Checked Out"]
-      elsif item.borrow_policy.uniquely_numbered? && item.holds.active.count > 0
+      elsif item.borrow_policy.uniquely_numbered? && item.active_holds.size > 0
         ["label-warning", "On Hold"]
       else
         ["label-success", "Available"]


### PR DESCRIPTION
# What it does

There was an N+q query on the items index. We were making a query to the database for every item to determine what status label to display (if there are active holds, it will show that the item is on hold). This PR eager loads the active holds so to avoid those additional queries