### PR TITLE
Use method on hold to determine place in line.

### DIFF
--- a/app/helpers/holds_helper.rb
+++ b/app/helpers/holds_helper.rb
@@ -42,7 +42,7 @@ module HoldsHelper
   end
 
   def place_in_line_for(hold)
-    Item.find(hold.item.id).holds.active.index(hold) + 1
+    hold.previous_active_holds.count + 1
   end
 
   private


### PR DESCRIPTION
# What it does

This PR addresses an issue where the hold position shown on a member's page was incorrect.
