### PR TITLE
Require member appointments be before holds expire

### DIFF
--- a/app/controllers/account/appointments_controller.rb
+++ b/app/controllers/account/appointments_controller.rb
@@ -63,7 +63,8 @@ module Account
         holds: Hold.where(id: appointment_params[:hold_ids], member: @member),
         loans: Loan.where(id: appointment_params[:loan_ids], member: @member),
         comment: appointment_params[:comment],
-        time_range_string: appointment_params[:time_range_string]
+        time_range_string: appointment_params[:time_range_string],
+        member_updating: true
       }
 
       @appointment.update(params)

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -6,9 +6,12 @@ class Appointment < ApplicationRecord
   belongs_to :member
 
   validate :ends_at_later_than_starts_at, :item_present, :date_present
+  validate :starts_before_holds_expire, if: :member_updating
 
   scope :upcoming, -> { where("starts_at > ?", Time.zone.now).order(:starts_at) }
   scope :chronologically, -> { order("starts_at ASC") }
+
+  attr_accessor :member_updating
 
   def time_range_string
     starts_at.to_s + ".." + ends_at.to_s
@@ -43,6 +46,14 @@ class Appointment < ApplicationRecord
 
     if ends_at < starts_at
       errors.add(:ends_at, "must be after the starts_at date")
+    end
+  end
+
+  def starts_before_holds_expire
+    holds_first_expire = holds.filter_map(&:expires_at).min
+    before_holds_expire = holds_first_expire.nil? || starts_at <= holds_first_expire
+    unless before_holds_expire
+      errors.add(:base, "Please pick an appointment on or before hold expires on #{holds_first_expire.strftime("%a, %-m/%-d")}.")
     end
   end
 end

--- a/test/controllers/account/appointments_controller_test.rb
+++ b/test/controllers/account/appointments_controller_test.rb
@@ -50,5 +50,13 @@ module Account
       @appointment.reload
       assert_equal 1, @appointment.holds.count
     end
+
+    test "should not update appointment scheduled after any holds expire" do
+      @expired_hold = FactoryBot.create(:hold, member: @member, started_at: @appointment.starts_at - Hold::HOLD_LENGTH - 1.days)
+      put account_appointment_path(@appointment), params: {appointment: {hold_ids: [@hold.id, @expired_hold.id], time_range_string: @appointment.time_range_string, comment: @appointment.comment}}
+
+      assert_template :edit
+      assert_select "ul.error", /on or before hold expires on/
+    end
   end
 end


### PR DESCRIPTION
# What it does

Adds a conditional validation to `Appointment` making sure that the appointment starts before the earliest hold expiration. 

# Why it is important

Closes #375

# Implementation notes

* I was initially looking at using a validation context, but it looks like those require calling `save` or `valid?` after using `assign_attributes` which forces related models to update before validation. Using an `attr_accessor` to determine whether or not a member is updating the record seemed to be the simplest way to only apply the validation to members and not admins

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
