### PR TITLE
Clear holds when an item is made inactive

### DIFF
--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -120,4 +120,15 @@ class ItemTest < ActiveSupport::TestCase
 
     refute item.next_hold
   end
+
+  test "clears holds when changing to an inactive status" do
+    item = create(:item)
+    create(:started_hold, item: item)
+
+    item.update!(status: Item.statuses[:pending])
+    assert_equal item.active_holds.count, 1
+
+    item.update!(status: Item.statuses[:maintenance])
+    assert_equal item.active_holds.count, 0
+  end
 end


### PR DESCRIPTION
# What it does

Adds an `after_update` callback to items so that whenever an item is changed to an inactive status all of its active holds are made inactive.

# Why it is important

Closes #475 

# Implementation notes

* The check for whether the status is changed to `maintenance` or `expired` is more verbose than I expected because `saved_change_to_attribute?` doesn't seem to support multiple values in the `to:` argument. And not sure if this is the expected behavior, but `status` in the callback is a string instead of an int so I'm converting it back in `Item.statuses[status]`

# Your bandwidth for additional changes to this PR

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
