### PR TITLE
Remove reference to nonexistant route. Closes #528.

### DIFF
--- a/app/views/admin/borrow_policies/index.html.erb
+++ b/app/views/admin/borrow_policies/index.html.erb
@@ -26,7 +26,5 @@
   </div>
 
 <% else %>
-  <%= empty_state "There are no borrow policies.", subtitle:"Create one?" do %>
-    <%= link_to "Add a Borrow Policy", new_admin_borrow_policy_path, class: "btn btn-primary" %>
-  <% end %>
+  <%= empty_state "There are no borrow policies." %>
 <% end %>

--- a/test/controllers/admin/borrow_policies_controller_test.rb
+++ b/test/controllers/admin/borrow_policies_controller_test.rb
@@ -5,7 +5,6 @@ module Admin
     include Devise::Test::IntegrationHelpers
 
     setup do
-      @borrow_policy = create(:default_borrow_policy)
       @user = create(:admin_user)
       sign_in @user
     end
@@ -16,17 +15,23 @@ module Admin
     end
 
     test "should get edit" do
+      @borrow_policy = create(:default_borrow_policy)
       get edit_admin_borrow_policy_url(@borrow_policy)
       assert_response :success
     end
 
     test "should redirect to admin borrow policies page" do
+      @borrow_policy = create(:default_borrow_policy)
+
       patch admin_borrow_policy_url(@borrow_policy), params: {borrow_policy: {duration: @borrow_policy.duration, fine_cents: @borrow_policy.fine_cents, fine_period: @borrow_policy.fine_period, name: @borrow_policy.name, code: "Q"}}
+
       assert_redirected_to admin_borrow_policies_url
     end
 
     test "should update borrow_policy" do
+      @borrow_policy = create(:default_borrow_policy)
       patch admin_borrow_policy_url(@borrow_policy), params: {borrow_policy: {duration: 10, fine: 8.23, fine_period: 26, name: "New name", code: "Q", member_renewable: true}}
+
       @borrow_policy.reload
       assert_equal 10, @borrow_policy.duration
       assert_equal 823, @borrow_policy.fine_cents


### PR DESCRIPTION
# What it does

This fixes an exception that was raised when operating the software with an empty database. This could cause confusion for new users or developers as it obscured the cause of the issue.