### PR TITLE
Show all of a member's appointments together regardless of their time

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -93,4 +93,17 @@ module AdminHelper
   def modal(title:, body:, &block)
     render "shared/modal", title: title, body: body, &block
   end
+
+  def sort_by_member_and_time(appointments)
+    list = []
+    appointments.each do |appointment|
+      earlier_appointment_index = list.index { |a| a.member == appointment.member }
+      if earlier_appointment_index
+        list[earlier_appointment_index + 1] = appointment
+      else
+        list << appointment
+      end
+    end
+    list
+  end
 end

--- a/app/views/admin/appointments/index.html.erb
+++ b/app/views/admin/appointments/index.html.erb
@@ -36,7 +36,7 @@
         </thead>
 
         <tbody>
-          <% @appointments.each do |appointment| %>
+          <% sort_by_member_and_time(@appointments).each do |appointment| %>
             <tr>
               <td class="time"><%= l appointment.starts_at, format: :hour %> - <%= l appointment.ends_at, format: :hour %></td>
               <td class="member">


### PR DESCRIPTION
# What it does

Occasionally a member will schedule multiple appointments. This PR groups them together in the appointment list while we improve the system to help members edit existing appointments instead of creating new ones. 