### PR TITLE
Make holds 7 days instead of 14.

### DIFF
--- a/app/models/hold.rb
+++ b/app/models/hold.rb
@@ -1,5 +1,5 @@
 class Hold < ApplicationRecord
-  HOLD_LENGTH = 14.days
+  HOLD_LENGTH = 7.days
 
   has_many :appointment_holds
   has_many :appointments, through: :appointment_holds

--- a/test/models/hold_test.rb
+++ b/test/models/hold_test.rb
@@ -43,7 +43,7 @@ class HoldTest < ActiveSupport::TestCase
   end
 
   test "ended hold" do
-    hold = create(:hold, ended_at: 2.days.ago, started_at: 9.days.ago)
+    hold = create(:hold, ended_at: 2.days.ago, started_at: 5.days.ago)
 
     refute hold.active?
     assert hold.inactive?


### PR DESCRIPTION
# What it does

Holds will now wait for 7 days before the item is offered to the next person in line.

# Why it is important

We have a decent number of items that sit for 14 days when someone no longer wants them. This will shorten that cycle and help more members access the items they are waiting for.