### PR TITLE
Allow librarians to create appointments

### DIFF
--- a/app/controllers/account/appointments_controller.rb
+++ b/app/controllers/account/appointments_controller.rb
@@ -1,5 +1,7 @@
 module Account
   class AppointmentsController < BaseController
+    include AppointmentSlots
+
     def index
       @appointments = current_user.member.appointments.upcoming.includes(:member, :holds, :loans)
     end
@@ -73,14 +75,6 @@ module Account
     def load_holds_and_loans
       @holds = Hold.active.includes(member: {appointments: :holds}).where(member: @member)
       @loans = @member.loans.includes(:item, member: {appointments: :loans}).checked_out
-    end
-
-    def load_appointment_slots
-      events = Event.appointment_slots.upcoming
-      @appointment_slots = events.group_by { |event| event.start.to_date }.map { |date, events|
-        times = events.map { |event| [helpers.format_appointment_times(event.start, event.finish), event.start..event.finish] }
-        [date.strftime("%A, %B %-d, %Y"), times]
-      }
     end
   end
 end

--- a/app/controllers/admin/members/appointments_controller.rb
+++ b/app/controllers/admin/members/appointments_controller.rb
@@ -1,0 +1,33 @@
+module Admin
+  module Members
+    class AppointmentsController < BaseController
+      include AppointmentSlots
+
+      def index
+        @appointments = @member.appointments.today_or_later.chronologically
+        load_appointment_slots
+      end
+
+      def create
+        @appointment = Appointment.new
+
+        if update_appointment
+          redirect_to admin_appointment_path(@appointment), flash: {success: "Appointment created"}
+        else
+          flash[:alert] = @appointment.errors.full_messages
+          redirect_to admin_member_appointments_path(@member)
+        end
+      end
+
+      private
+
+      def appointment_params
+        params.require(:appointment).permit(:time_range_string)
+      end
+
+      def update_appointment
+        @appointment.update(member: @member, time_range_string: appointment_params[:time_range_string], staff_updating: true)
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/appointment_slots.rb
+++ b/app/controllers/concerns/appointment_slots.rb
@@ -1,0 +1,11 @@
+module AppointmentSlots
+  private
+
+  def load_appointment_slots
+    events = Event.appointment_slots.upcoming
+    @appointment_slots = events.group_by { |event| event.start.to_date }.map { |date, events|
+      times = events.map { |event| [helpers.format_appointment_times(event.start, event.finish), event.start..event.finish] }
+      [date.strftime("%A, %B %-d, %Y"), times]
+    }
+  end
+end

--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -16,6 +16,6 @@ module DateHelper
     date_string = appointment.starts_at.strftime("%A, %B %-d, %Y")
     return date_string unless include_time
 
-    date_string + " between #{appointment.starts_at.strftime("%I:%M%P")} and #{appointment.ends_at.strftime("%I:%M%P")}"
+    date_string + " between #{appointment.starts_at.strftime("%-I:%M%P")} and #{appointment.ends_at.strftime("%-I:%M%P")}"
   end
 end

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -694,7 +694,7 @@ form.membership-amount {
 }
 
 .admin {
-  .member-lookup-items, .member-notes {
+  .member-lookup-items, .member-notes, .member-appointment-form {
     background: white;
     padding: .7rem .5rem;
     .info-box {

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -701,6 +701,12 @@ form.membership-amount {
       background: $secondary-color-light;
     }
   }
+
+  .member-appointment-form {
+    .form-select {
+      width: auto;
+    }
+  }
 }
 
 @keyframes highlight-fade-out {

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -5,14 +5,15 @@ class Appointment < ApplicationRecord
   has_many :loans, through: :appointment_loans
   belongs_to :member
 
-  validate :ends_at_later_than_starts_at, :item_present, :date_present
+  validate :ends_at_later_than_starts_at, :date_present
   validate :starts_before_holds_expire, if: :member_updating
+  validate :item_present, unless: :staff_updating
 
   scope :upcoming, -> { where("starts_at > ?", Time.zone.now).order(:starts_at) }
   scope :today_or_later, -> { where("starts_at > ?", Time.zone.now.beginning_of_day).order(:starts_at) }
   scope :chronologically, -> { order("starts_at ASC") }
 
-  attr_accessor :member_updating
+  attr_accessor :member_updating, :staff_updating
 
   def time_range_string
     starts_at.to_s + ".." + ends_at.to_s

--- a/app/views/admin/members/_member_details.html.erb
+++ b/app/views/admin/members/_member_details.html.erb
@@ -25,7 +25,7 @@
       <% next_appointment = member.appointments.today_or_later.first %>
       <% if next_appointment %>
         <li>
-          <%= link_to admin_appointment_path(next_appointment) do %>
+          <%= link_to admin_member_appointments_path(member) do %>
             <%= feather_icon "calendar" %> <%= pluralize(member.appointments.today_or_later.count, "upcoming appointment") %>
           <% end %>
         </li>

--- a/app/views/admin/members/_profile.html.erb
+++ b/app/views/admin/members/_profile.html.erb
@@ -24,6 +24,7 @@
     <ul class="tab">
       <%= tab_link "Current Loans", admin_member_path(@member) %>
       <%= tab_link "Holds", admin_member_holds_path(@member) %>
+      <%= tab_link "Appointments", admin_member_appointments_path(@member) %>
       <%= tab_link "Previous Loans", admin_member_loan_summaries_path(@member) %>
       <%= tab_link "Membership", admin_member_memberships_path(@member) %>
       <%= tab_link "Account", admin_member_adjustments_path(@member) %>

--- a/app/views/admin/members/appointments/_form.html.erb
+++ b/app/views/admin/members/appointments/_form.html.erb
@@ -1,0 +1,16 @@
+<div class="columns member-appointment-form">
+    <div class="column col-12">
+        <h2 class="h3">Create an Appointment</h2>
+        <%= form_with(model: Appointment.new, url: admin_member_appointments_path(@member)) do |form| %>
+            <div class="form-group" data-controller="appointment-date">
+                <label class="form-label" for="time_range_string">Select an appointment time to create an appointment for this member</label>
+                <%= select("appointment", "time_range_string", grouped_options_for_select(@appointment_slots, nil), { include_blank: 'Select a Date' },
+                    class: "form-select", data: { action: "appointment-date#sync", target: "appointment-date.select" }) %>
+                <span data-target="appointment-date.display"></span>
+            </div>
+            <div class="form-buttons">
+                <%= form.submit "Create Appointment", class: "btn btn-primary" %>
+            </div>
+        <% end %>
+    </div>
+</div>

--- a/app/views/admin/members/appointments/index.html.erb
+++ b/app/views/admin/members/appointments/index.html.erb
@@ -1,0 +1,17 @@
+<%= render "admin/members/profile" do %>
+
+<% if @appointments.any? %>
+    <ul>
+    <% @appointments.each do |appointment| %>
+        <li>
+            <%= link_to appointment_date_and_time(appointment), admin_appointment_path(appointment) %>
+        </li>
+    <% end %>
+    </ul>
+<% else %>
+    <p>No upcoming appointments</p>
+<% end %>
+
+<%= render partial: "admin/members/appointments/form" %>
+
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,6 +99,7 @@ Rails.application.routes.draw do
         resources :memberships, only: [:index, :new, :create, :update]
         resources :payments, only: [:new, :create]
         resource :verification, only: [:edit, :update]
+        resources :appointments, only: [:index, :create]
 
         resources :loan_summaries, only: :index
       end

--- a/test/controllers/admin/members/appointments_controller_test.rb
+++ b/test/controllers/admin/members/appointments_controller_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+module Admin
+  module Members
+    class AppointmentsControllerTest < ActionDispatch::IntegrationTest
+      include Devise::Test::IntegrationHelpers
+
+      setup do
+        @admin_user = create(:admin_user, member: @member_2)
+        sign_in @admin_user
+      end
+
+      test "should create an appointment for a member" do
+        member = create(:member)
+        starts_at = Time.current
+        ends_at = starts_at + 2.hours
+
+        assert_difference("member.appointments.count", 1) do
+          post admin_member_appointments_path(member), params: {appointment: {time_range_string: "#{starts_at}..#{ends_at}"}}
+        end
+        assert_redirected_to admin_appointment_path(member.reload.appointments.last)
+      end
+    end
+  end
+end

--- a/test/models/appointment_test.rb
+++ b/test/models/appointment_test.rb
@@ -17,7 +17,7 @@ class AppointmentTest < ActiveSupport::TestCase
   test "invalid without hold or loan selected and date not given" do
     appointment = Appointment.new
     appointment.save
-    assert_equal appointment.errors[:base], ["Please select an item to pick-up or return for your appointment", "Please select a date and time for this appointment."]
+    assert_equal appointment.errors[:base], ["Please select a date and time for this appointment.", "Please select an item to pick-up or return for your appointment"]
   end
 
   test "sets starts_at and ends_at using time_range_string=" do


### PR DESCRIPTION
# What it does

Allows librarians to create appointments in the member section of the admin page. I tried to base this on existing functionality so let me know if there's anything that should change!

# Why it is important

Closes #358 

# UI Change Screenshot

![circulate-issue-member-appts](https://user-images.githubusercontent.com/8291663/119271790-a6ba1b80-bbc8-11eb-944d-8ad9351d51ee.gif)

# Implementation notes

* I based the conditional validation on #519
* I moved the `load_appointment_slots` into a concern now that we're using it in more than one place, but let me know if there's a better spot
* Adding the new "Appointments" tab causes the line to wrap, so not sure if we want to address that

# Your bandwidth for additional changes to this PR

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
