### PR TITLE
Move completed holds to the bottom of the page.

### DIFF
--- a/app/controllers/admin/appointments_controller.rb
+++ b/app/controllers/admin/appointments_controller.rb
@@ -8,6 +8,16 @@ module Admin
         .where(starts_at: @current_day.beginning_of_day..@current_day.end_of_day)
         .chronologically
         .includes(:member, loans: {item: :borrow_policy}, holds: {item: :borrow_policy})
+
+      @pending_appointments = []
+      @completed_appointments = []
+      sort_by_member_and_time(@appointments).each_with_index do |appointment, index|
+        if appointment.completed?
+          @completed_appointments << [appointment, index]
+        else
+          @pending_appointments << [appointment, index]
+        end
+      end
     end
 
     def show
@@ -32,6 +42,14 @@ module Admin
     end
 
     private
+
+    def sort_by_member_and_time(appointments)
+      appointments
+        .group_by { |a| a.member }
+        .map { |member, appointments| [appointments.map(&:starts_at).min, appointments] }
+        .sort_by { |first_time, appointments| [first_time, helpers.preferred_or_default_name(appointments.first.member)] }
+        .flat_map { |_, appointments| appointments.sort_by(&:created_at) }
+    end
 
     def load_appointment
       @appointment = Appointment.find(params[:id])

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -97,12 +97,4 @@ module AdminHelper
   def appointment_in_schedule_path(appointment)
     admin_appointments_path(day: appointment.starts_at.to_date.to_s, anchor: dom_id(appointment))
   end
-
-  def sort_by_member_and_time(appointments)
-    appointments
-      .group_by { |a| a.member }
-      .map { |member, appointments| [appointments.map(&:starts_at).min, appointments] }
-      .sort_by { |first_time, appointments| [first_time, preferred_or_default_name(appointments.first.member)] }
-      .flat_map { |_, appointments| appointments.sort_by(&:created_at) }
-  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,13 +4,13 @@ module ApplicationHelper
     %w[new edit].include? params[:action]
   end
 
-  def portal(tag_name: "div", &block)
-    attrs = {
+  def portal(tag_name: "div", attributes: {}, &block)
+    attrs = attributes.deep_merge({
       data: {
         controller: "portal",
         action: "ajax:error->portal#replaceContent ajax:success->portal#replaceContent"
       }
-    }
+    })
     tag.send(tag_name, **attrs, &block)
   end
 

--- a/app/javascript/controllers/appointments_index_controller.js
+++ b/app/javascript/controllers/appointments_index_controller.js
@@ -1,0 +1,31 @@
+import { Controller } from "stimulus";
+
+export default class extends Controller {
+  static targets = [ "pending", "completed" ]
+
+  connect() {
+  }
+
+  arrange() {
+    Array.from(this.pendingTarget.querySelectorAll("tbody tr.completed")).forEach(element => {
+      this.positionRow(element.parentElement, this.completedTarget);
+    });
+    Array.from(this.completedTarget.querySelectorAll("tbody tr.pending")).forEach(element => {
+      this.positionRow(element.parentElement, this.pendingTarget);
+    });
+  }
+
+  positionRow(element, parent) {
+    const index = parseInt(element.dataset.index, 10);
+    const found = Array.from(parent.children).some(sibling => {
+      if (parseInt(sibling.dataset.index) > index) {
+        parent.insertBefore(element, sibling)
+        return true;
+      }
+    });
+
+    if (!found) {
+      parent.appendChild(element);
+    }
+  }
+}

--- a/app/javascript/stylesheets/partials/_admin_appointments.scss
+++ b/app/javascript/stylesheets/partials/_admin_appointments.scss
@@ -1,4 +1,5 @@
 .admin-appointments {
+
 	table {
 		td, th {
       vertical-align: top;
@@ -6,6 +7,10 @@
 			&.member { width: 20%; }
 			&.items { width: 30%; }
 			&.notes { width: 30%; }
+		}
+
+		&.pending-appointments {
+			margin-bottom: 2rem;
 		}
 	}
 

--- a/app/views/admin/appointments/_appointment.html.erb
+++ b/app/views/admin/appointments/_appointment.html.erb
@@ -5,9 +5,18 @@
     <%= appointment.member.display_pronouns %>
   </td>
   <td class="items">
-    <% appointment.holds.each do |hold| %>
+    <% appointment.holds.take(10).each do |hold| %>
         pick-up
         <%= link_to hold.item.name, admin_item_path(hold.item), title: hold.item.complete_number%> <br/>
+    <% end %>
+    <% if appointment.holds.count > 10 %>
+      <details>
+        <summary>and <%= appointment.holds.count - 10 %> more</summary>
+        <% appointment.holds[10..].each do |hold| %>
+            pick-up
+            <%= link_to hold.item.name, admin_item_path(hold.item), title: hold.item.complete_number%> <br/>
+        <% end %>
+      </details>
     <% end %>
     <% appointment.loans.each do |loan| %>
         drop-off

--- a/app/views/admin/appointments/index.html.erb
+++ b/app/views/admin/appointments/index.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <div class="columns">
-  <div class="col-12 admin-appointments">
+  <div class="col-12 admin-appointments" data-controller="appointments-index" data-action="turbolinks:load@document->appointments-index#arrange">
     <ul class="pagination">
       <li class="page-item page-prev appointments-date-nav">
         <%= link_to admin_appointments_path(day: previous_day) do %>
@@ -24,7 +24,8 @@
     </ul>
 
     <% if @appointments.exists? %>
-      <table class="table">
+
+      <table class="table pending-appointments" data-target="appointments-index.pending" >
         <thead>
           <tr>
             <th class="time">Time</th>
@@ -35,12 +36,33 @@
           </tr>
         </thead>
 
-        <% sort_by_member_and_time(@appointments).each do |appointment| %>
-          <%= portal tag_name: "tbody" do %>
+        <% @pending_appointments.each do |appointment, index| %>
+          <%= portal tag_name: "tbody", attributes: {data: {index: index}} do %>
             <%= render partial: "appointment", locals: { appointment: appointment } %>
           <% end %>
         <% end %>
       </table>
+
+      <h2>Completed Appointments</h2>
+
+      <table class="table completed-appointments" data-target="appointments-index.completed">
+        <thead>
+          <tr>
+            <th class="time">Time</th>
+            <th class="member">Member</th>
+            <th class="items">Items</th>
+            <th class="notes">Notes</th>
+            <th></th>
+          </tr>
+        </thead>
+
+        <% @completed_appointments.each do |appointment, index| %>
+          <%= portal tag_name: "tbody", attributes: {data: {index: index}} do %>
+            <%= render partial: "appointment", locals: { appointment: appointment } %>
+          <% end %>
+        <% end %>
+      </table>
+
     <% else %>
         <%= empty_state "No appointments scheduled for this day." %>
     <% end %>


### PR DESCRIPTION
# What it does

This change moves completed holds to the bottom of the appointment page so they are out of the way but reviewable.

It also collapses really long lists of items to pick up so that the appointments are easier to browse.