### PR TITLE
Add label to distinguish between pick-ups and drop-offs

### DIFF
--- a/app/javascript/stylesheets/partials/_admin_appointments.scss
+++ b/app/javascript/stylesheets/partials/_admin_appointments.scss
@@ -27,6 +27,11 @@
 		}
 	}
 
+  span.label {
+    margin-right: 0.25rem;
+    margin-bottom: 0.125rem;
+  }
+
 	a.view-appointment {
 		display: inline-block;
 	}

--- a/app/views/admin/appointments/_appointment.html.erb
+++ b/app/views/admin/appointments/_appointment.html.erb
@@ -6,21 +6,21 @@
   </td>
   <td class="items">
     <% appointment.holds.take(10).each do |hold| %>
-        pick-up
-        <%= link_to hold.item.name, admin_item_path(hold.item), title: hold.item.complete_number%> <br/>
+      <span class="label label-primary">pick-up</span>
+      <%= link_to hold.item.name, admin_item_path(hold.item), title: hold.item.complete_number%> <br/>
     <% end %>
     <% if appointment.holds.count > 10 %>
       <details>
         <summary>and <%= appointment.holds.count - 10 %> more</summary>
         <% appointment.holds[10..].each do |hold| %>
-            pick-up
-            <%= link_to hold.item.name, admin_item_path(hold.item), title: hold.item.complete_number%> <br/>
+          <span class="label label-primary">pick-up</span>
+          <%= link_to hold.item.name, admin_item_path(hold.item), title: hold.item.complete_number%> <br/>
         <% end %>
       </details>
     <% end %>
     <% appointment.loans.each do |loan| %>
-        drop-off
-        <%= link_to loan.item.name, admin_item_path(loan.item) %> <br/>
+      <span class="label label-seondary">drop-off</span>
+      <%= link_to loan.item.name, admin_item_path(loan.item) %> <br/>
     <% end %>
   </td>
   <td class="notes"><%= appointment.comment %></td>


### PR DESCRIPTION
# What it does

closes #468 

Add colored labels to distinguish between pick-ups and drop-offs on admin appointment index.

# Why it is important

Admins/librarians need to be able to easily distinguish between the two types of appointments.

# UI Change Screenshot

<img width="1304" alt="Screen Shot 2021-06-27 at 8 54 18 AM" src="https://user-images.githubusercontent.com/18114012/123545347-829cad80-d725-11eb-8400-9a915ac0a582.png">

<img width="1388" alt="Screen Shot 2021-06-27 at 8 55 09 AM" src="https://user-images.githubusercontent.com/18114012/123545348-83354400-d725-11eb-93a8-2aa743656fda.png">
