### PR TITLE
Include minutes in event times

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -10,8 +10,8 @@ class Event < ApplicationRecord
   end
 
   def times
-    hour_meridian = "%l%P"
-    start.strftime(hour_meridian) + " - " + finish.strftime(hour_meridian).strip
+    format = "%l:%M%P"
+    "#{start.strftime(format).strip} - #{finish.strftime(format).strip}".gsub(/:00/, "").strip
   end
 
   def self.update_events(gcal_events)

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -131,8 +131,8 @@ class EventTest < ActiveSupport::TestCase
   test "times on the hour" do
     Time.use_zone("America/Chicago") do
       event = create(:event,
-        start: Time.new(2020, 11, 5, 18, 0),
-        finish: Time.new(2020, 11, 5, 20, 0))
+        start: Time.zone.local(2020, 11, 5, 18, 0),
+        finish: Time.zone.local(2020, 11, 5, 20, 0))
       assert_equal "6pm - 8pm", event.times
     end
   end
@@ -140,8 +140,8 @@ class EventTest < ActiveSupport::TestCase
   test "times with minutes" do
     Time.use_zone("America/Chicago") do
       event = create(:event,
-        start: Time.new(2020, 11, 5, 18, 15),
-        finish: Time.new(2020, 11, 5, 20, 30))
+        start: Time.zone.local(2020, 11, 5, 18, 15),
+        finish: Time.zone.local(2020, 11, 5, 20, 30))
       assert_equal "6:15pm - 8:30pm", event.times
     end
   end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -129,16 +129,20 @@ class EventTest < ActiveSupport::TestCase
   end
 
   test "times on the hour" do
-    event = create(:event,
-      start: Time.new(2020, 11, 5, 18, 0),
-      finish: Time.new(2020, 11, 5, 20, 0))
-    assert_equal "12am - 2am", event.times
+    Time.use_zone("America/Chicago") do
+      event = create(:event,
+        start: Time.new(2020, 11, 5, 18, 0),
+        finish: Time.new(2020, 11, 5, 20, 0))
+      assert_equal "6pm - 8pm", event.times
+    end
   end
 
   test "times with minutes" do
-    event = create(:event,
-      start: Time.new(2020, 11, 5, 18, 15),
-      finish: Time.new(2020, 11, 5, 20, 30))
-    assert_equal "12:15am - 2:30am", event.times
+    Time.use_zone("America/Chicago") do
+      event = create(:event,
+        start: Time.new(2020, 11, 5, 18, 15),
+        finish: Time.new(2020, 11, 5, 20, 30))
+      assert_equal "6:15pm - 8:30pm", event.times
+    end
   end
 end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -127,4 +127,18 @@ class EventTest < ActiveSupport::TestCase
       Event.update_events([gcal_event])
     end
   end
+
+  test "times on the hour" do
+    event = create(:event,
+      start: Time.new(2020, 11, 5, 18, 0),
+      finish: Time.new(2020, 11, 5, 20, 0))
+    assert_equal "12am - 2am", event.times
+  end
+
+  test "times with minutes" do
+    event = create(:event,
+      start: Time.new(2020, 11, 5, 18, 15),
+      finish: Time.new(2020, 11, 5, 20, 30))
+    assert_equal "12:15am - 2:30am", event.times
+  end
 end


### PR DESCRIPTION
# What it does

Show the full event times on the shifts admin page.