### PR TITLE
Add area and shelf fields to item

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -85,7 +85,7 @@ module Admin
     def all_item_params
       params.require(:item).permit(
         :name, :other_names, :description, :size, :brand, :model, :serial, :number, :image, :status, :strength,
-        :power_source, :borrow_policy_id, :quantity, :checkout_notice, :delete_image, category_ids: []
+        :power_source, :borrow_policy_id, :quantity, :checkout_notice, :delete_image, :location_shelf, :location_area, category_ids: []
       )
     end
 

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -137,4 +137,12 @@ module ItemsHelper
     link = link_to preferred_or_default_name(loan.member), [:admin, loan.member]
     "Currently on loan to ".html_safe + link + "."
   end
+
+  def item_location_span(item)
+    location = []
+    location << "area #{item.location_area}" unless item.location_area.blank?
+    location << "shelf #{item.location_shelf}" unless item.location_shelf.blank?
+
+    location.join(", ")
+  end
 end

--- a/app/views/admin/items/_form.html.erb
+++ b/app/views/admin/items/_form.html.erb
@@ -9,6 +9,46 @@
 
   <%= form.tag_select :category_ids, @categories %>
 
+  <div class="columns">
+    <div class="column col-4 col-sm-12">
+      <%= form.autocomplete_text_field :size, path: admin_ui_sizes_path(format: :json),
+        hint: "Blade or bit diameter, width or height; e.g. 3/8\"" %>
+    </div>
+    <div class="column col-4 col-sm-12">
+      <%= form.autocomplete_text_field :strength, path: admin_ui_strengths_path(format: :json),
+        hint: "i.e. voltage or amps; e.g. 18v, heavy duty" %>
+    </div>
+    <div class="column col-4 col-sm-12">
+      <%= form.select :power_source, options_for_select(item_power_source_options, item.power_source), include_blank: "Not powered", hint: "Specify how the item is powered, if it is powered" %>
+    </div>
+  </div>
+
+  <div class="columns">
+    <div class="column col-4 col-sm-12">
+      <%= form.autocomplete_text_field :brand, path: admin_ui_brands_path(format: :json), hint: "e.g. Dewalt, Craftsman, Singer" %>
+    </div>
+    <div class="column col-4 col-sm-12">
+      <%= form.text_field :model, hint: "e.g. ABC-123; usually found on the back or bottom" %>
+    </div>
+    <div class="column col-4 col-sm-12">
+      <%= form.text_field :serial, hint: "Usually near the model number" %>
+    </div>
+  </div>
+
+  <div class="columns" data-controller="conditional-field" data-conditional-field-trigger="<%= BorrowPolicy.not_uniquely_numbered_ids.join(",") %>">
+    <div class="column col-4 col-sm-12">
+      <%= form.select :status, options_for_select(item_status_options, item.status || Item.statuses[:active]), prompt: true, hint: "Only active items can be checked out" %>
+    </div>
+    <div class="column col-4 col-sm-12">
+      <%= form.select :borrow_policy_id, options_for_select(borrow_policy_options, item.borrow_policy_id || BorrowPolicy.default&.id), {hint: "Borrowing rules used for this item"}, data: {action: "conditional-field#change", target: "conditional-field.parent"} %>
+    </div>
+    <div class="column col-4 col-sm-12">
+      <%= tag.div data: {target: "conditional-field.child"}, class: "conditional-field-child" do %>
+        <%= form.text_field :quantity, label: "Approximate quantity", hint: "Just an estimate for planning purposes" %>
+      <% end %>
+    </div>
+  </div>
+
   <% if item.new_record? %>
     <details class="form-group">
       <summary>Description</summary>
@@ -20,29 +60,29 @@
 
   <%= form.text_area :checkout_notice, hint: "Shown when checking item out" %>
 
-  <%= form.autocomplete_text_field :size, path: admin_ui_sizes_path(format: :json),
-      hint: "Blade or bit diameter, width or height; e.g. 3/8\"" %>
+  <fieldset>
+    <legend>Item Location</legend>
+    <div class="columns">
+      <div class="column col-4 col-sm-12">
+        <%= form.text_field :location_area, label: "Area", hint: "General location of the item" %>
+      </div>
+      <div class="column col-4 col-sm-12">
+        <%= form.text_field :location_shelf, label: "Shelf", hint: "Location within the area" %>
+      </div>
+    </div>
+  </fieldset>
 
-  <%= form.autocomplete_text_field :strength, path: admin_ui_strengths_path(format: :json),
-      hint: "i.e. voltage or amps; e.g. 18v, heavy duty" %>
-
-  <%= form.select :power_source, options_for_select(item_power_source_options, item.power_source), include_blank: "Not powered", hint: "Specify how the item is powered, if it is powered" %>
-
-  <%= form.autocomplete_text_field :brand, path: admin_ui_brands_path(format: :json), hint: "e.g. Dewalt, Craftsman, Singer" %>
-  <%= form.text_field :model, hint: "e.g. ABC-123; usually found on the back or bottom" %>
-  <%= form.text_field :serial, hint: "Usually near the model number" %>
-
-  <%= form.file_field :image, hint: "Take a photo with the device's camera", data: {"turbolinks-permanent": true} %>
-  <%= form.check_box :delete_image, label: "Delete current image" %>
-
-  <%= form.select :status, options_for_select(item_status_options, item.status || Item.statuses[:active]), prompt: true, hint: "Only active items can be checked out" %>
-
-  <div data-controller="conditional-field" data-conditional-field-trigger="<%= BorrowPolicy.not_uniquely_numbered_ids.join(",") %>">
-    <%= form.select :borrow_policy_id, options_for_select(borrow_policy_options, item.borrow_policy_id || BorrowPolicy.default&.id), {hint: "Borrowing rules used for this item"}, data: {action: "conditional-field#change", target: "conditional-field.parent"} %>
-    <%= tag.div data: {target: "conditional-field.child"}, class: "conditional-field-child" do %>
-      <%= form.text_field :quantity, label: "Approximate quantity", hint: "Just an estimate for planning purposes" %>
-    <% end %>
-  </div>
+  <fieldset>
+    <legend>Item Image</legend>
+    <div class="columns">
+      <div class="column col-4 col-sm-12">
+        <%= form.file_field :image, hint: "Take a photo with the device's camera", data: {"turbolinks-permanent": true} %>
+      </div>
+      <div class="column col-4 col-sm-12">
+        <%= form.check_box :delete_image, label: "Delete current image", required: false %>
+      </div>
+    </div>
+  </fieldset>
 
   <% unless item.new_record? %>
     <details>

--- a/app/views/admin/items/_profile.html.erb
+++ b/app/views/admin/items/_profile.html.erb
@@ -44,21 +44,20 @@
 
       <div class="panel-body">
         <ul class="item-stats">
+          <%= icon_stat "map-pin", item_location_span(@item), title: "location", placeholder: "No location" %>
           <%= icon_stat "maximize", @item.size, title: "size", placeholder: "No size" %>
           <%= icon_stat "zap", @item.strength, title: "strength", placeholder: "No strength" %>
           <%= icon_stat "battery-charging", item_powered_by_label(@item), title: "powered by", placeholder: "Not powered" %>
           <%= icon_stat "package", @item.brand, title: "brand", placeholder: "No brand" %>
           <%= icon_stat "box", @item.model, title: "model", placeholder: "No model" %>
           <%= icon_stat "hash", @item.serial, title: "serial number", placeholder: "No serial number" %>
-          <%= icon_stat "tag", title: "categories", css_class: "categories", placeholder: "No category" do %>
+          <%= icon_stat "tag", title: "categories", css_class: "categories", placeholder: "No categories" do %>
             <% if @item.categories.size > 0 %>
               <ul class="category-stats">
                 <% @item.categories.map(&:name).sort.each do |name| %>
                   <li><%= name %></li>
                 <% end %>
               </ul>
-            <% else %>
-              <span class="placeholder-text">No categories</span>
             <% end %>
           <% end %>
           <%= icon_stat "file", title: "files", placeholder: "No files" do %>

--- a/db/migrate/20210722214912_add_item_location_fields.rb
+++ b/db/migrate/20210722214912_add_item_location_fields.rb
@@ -1,0 +1,6 @@
+class AddItemLocationFields < ActiveRecord::Migration[6.1]
+  def change
+    add_column :items, :location_area, :text
+    add_column :items, :location_shelf, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_19_212401) do
+ActiveRecord::Schema.define(version: 2021_07_22_214912) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -291,6 +291,8 @@ ActiveRecord::Schema.define(version: 2021_05_19_212401) do
     t.integer "holds_count", default: 0, null: false
     t.string "other_names"
     t.enum "power_source", enum_name: "power_source"
+    t.text "location_area"
+    t.text "location_shelf"
     t.index ["borrow_policy_id"], name: "index_items_on_borrow_policy_id"
   end
 


### PR DESCRIPTION
# What it does

* Adds two fields where we can experiment with storing location info for tools.
* Also rearranges the item form to reduce scrolling by putting multiple fields on one line for desktop users.