### PR TITLE
Category tree nav for inventory

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -13,7 +13,7 @@ class ItemsController < ApplicationController
 
     item_scope = item_scope.includes(:categories, :borrow_policy, :active_holds).with_attached_image.order(index_order)
 
-    @categories = CategoryNode.all
+    @categories = CategoryNode.with_items
     @pagy, @items = pagy(item_scope)
   end
 

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -77,29 +77,30 @@ module ItemsHelper
     tag.nav(class: "tree-nav", data: {controller: "tree-nav"}) do
       concat(tag.ul do
         root.children.values.map do |node|
-          concat(render_tree_node(node))
+          concat(render_tree_node(node, current_category))
         end
       end)
     end
   end
 
-  def render_tree_node(node)
+  def render_tree_node(node, current_value)
     has_children = node.children.size > 0
-    tag.li(class: "tree-node") do
+    tag.li(class: "tree-node", data: {id: node.value.id}) do
       if has_children
         concat(
           tag.button(
             '<i class="icon icon-arrow-right"></i>'.html_safe,
             class: "tree-node-toggle",
-            data: {action: "tree-nav#toggle"}
+            data: {action: "tree-nav#toggle"},
+            "aria-expanded": false
           )
         )
       end
-      concat(link_to(node.value.name, category: node.value.id))
+      concat(link_to(node.value.name, {category: node.value.id}))
       if has_children
         concat(tag.ul(class: "tree-node-children") do
           node.children.values.map do |child|
-            concat(render_tree_node(child))
+            concat(render_tree_node(child, current_value))
           end
         end)
       end

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -89,14 +89,14 @@ module ItemsHelper
       if has_children
         concat(
           tag.button(
-            '<i class="icon icon-arrow-right"></i>'.html_safe,
+            '<i class="icon icon-arrow-right">Toggle subcategories</i>'.html_safe,
             class: "tree-node-toggle",
             data: {action: "tree-nav#toggle"},
             "aria-expanded": false
           )
         )
       end
-      concat(link_to(node.value.name, {category: node.value.id}))
+      concat(link_to((node.value.name + "&nbsp;(#{node.value.tree_categorizations_count})").html_safe, {category: node.value.id}))
       if has_children
         concat(tag.ul(class: "tree-node-children") do
           node.children.values.map do |child|

--- a/app/javascript/controllers/collapse_controller.js
+++ b/app/javascript/controllers/collapse_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  static targets = [ "content", "button" ]
+
+  connect() {
+    this.toggle();
+  }
+
+  toggle() {
+    if (this.contentTarget.classList.contains("hidden")) {
+      this.buttonTarget.setAttribute("aria-expanded", "true")
+    } else {
+      this.buttonTarget.setAttribute("aria-expanded", "false")
+    }
+    this.contentTarget.classList.toggle("hidden");
+  }
+}

--- a/app/javascript/controllers/tree_nav_controller.js
+++ b/app/javascript/controllers/tree_nav_controller.js
@@ -1,0 +1,22 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  connect() {
+    this.element.querySelectorAll("button.tree-node-toggle").forEach(button => {
+        button.setAttribute("aria-expanded", "false")
+    })
+  }
+
+  toggle(event) {
+    console.debug(event.currentTarget)
+    const button = event.currentTarget;
+
+    if (button.getAttribute("aria-expanded") === "true") {
+        button.setAttribute("aria-expanded", "false")
+    } else {
+        button.setAttribute("aria-expanded", "true")
+    }
+    button.querySelector("i").classList.toggle("icon-arrow-right")
+    button.querySelector("i").classList.toggle("icon-arrow-down")
+  }
+}

--- a/app/javascript/controllers/tree_nav_controller.js
+++ b/app/javascript/controllers/tree_nav_controller.js
@@ -31,7 +31,6 @@ export default class extends Controller {
   }
 
   toggle(event) {
-    console.debug(event.currentTarget)
     const button = event.currentTarget;
     this.toggleButton(button);
   }

--- a/app/javascript/controllers/tree_nav_controller.js
+++ b/app/javascript/controllers/tree_nav_controller.js
@@ -2,15 +2,41 @@ import { Controller } from "stimulus"
 
 export default class extends Controller {
   connect() {
-    this.element.querySelectorAll("button.tree-node-toggle").forEach(button => {
-        button.setAttribute("aria-expanded", "false")
-    })
+    try {
+      const location = window.location.href.toLowerCase();
+      const url = new URL(location);
+      const id = url.searchParams.get("category");
+
+      if (!id) {
+        return;
+      }
+
+      let listItem = this.element.querySelector(`li.tree-node[data-id="${id}"]`);
+      if (!listItem) {
+        return;
+      }
+
+      listItem.querySelector("a").classList.add("text-bold");
+      while (listItem) {
+        const button = listItem.querySelector("button")
+        if (button) {
+          this.toggleButton(button);
+        }
+        listItem = listItem.parentElement.closest("li.tree-node")
+      }
+    } catch (err) {
+      console.error(err)
+      // issue handling category id
+    }
   }
 
   toggle(event) {
     console.debug(event.currentTarget)
     const button = event.currentTarget;
+    this.toggleButton(button);
+  }
 
+  toggleButton(button) {
     if (button.getAttribute("aria-expanded") === "true") {
         button.setAttribute("aria-expanded", "false")
     } else {

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -13,6 +13,7 @@
 @import 'admin';
 @import 'public';
 @import 'account';
+@import 'tree_nav';
 
 body {
   background-color: $background-color;

--- a/app/javascript/stylesheets/partials/_index.scss
+++ b/app/javascript/stylesheets/partials/_index.scss
@@ -3,5 +3,6 @@
 @import './admin_appointments';
 @import './appointments';
 @import './item_header';
+@import './items_index';
 @import './appointment_form';
 @import './admin_memberships';

--- a/app/javascript/stylesheets/partials/_items_index.scss
+++ b/app/javascript/stylesheets/partials/_items_index.scss
@@ -1,0 +1,19 @@
+.items-index {
+  .category-nav {
+    button.toggle-categories {
+      margin-bottom: .3rem;
+      @media all and (min-width: 641px)  {
+        display: none;
+      }
+    }
+    .categories {
+      margin-bottom: 1rem;
+
+      @media all and (max-width: 640px)  {
+        &.hidden {
+          display: none;
+        }
+      }
+    }
+  }
+}

--- a/app/javascript/stylesheets/public.scss
+++ b/app/javascript/stylesheets/public.scss
@@ -106,3 +106,19 @@
     }
   }
 }
+
+.accessibility-links a {
+  position: absolute;
+  left: 0;
+  top: -3.2rem;
+  transition: top 1s ease-out;
+  padding: 1rem;
+  background: white;
+  font-size: 1.2;
+  z-index: 1000;
+ 
+  &:focus {
+    top: 0;
+    transition: 0.1s ease-in;
+  }
+}

--- a/app/javascript/stylesheets/tree_nav.scss
+++ b/app/javascript/stylesheets/tree_nav.scss
@@ -4,12 +4,12 @@ nav.tree-nav {
     margin: 0;
   }
   .tree-node {
-    padding-left: 1.3rem;
+    padding-left: 1.2rem;
     position: relative;
     line-height: 1.2;
     margin-top: .5rem;
     ul {
-      margin-left: -1rem;
+      margin-left: -.6rem;
     }
   }
   .tree-node-toggle {
@@ -23,6 +23,9 @@ nav.tree-nav {
     &:hover {
       cursor: pointer;
       color: $secondary-color;
+    }
+    .icon {
+      font-size: 14px;
     }
   }
   .tree-node button[aria-expanded='false'] + a + ul.tree-node-children {

--- a/app/javascript/stylesheets/tree_nav.scss
+++ b/app/javascript/stylesheets/tree_nav.scss
@@ -1,0 +1,31 @@
+nav.tree-nav {
+  ul {
+    list-style: none;
+    margin: 0;
+  }
+  .tree-node {
+    padding-left: 1.3rem;
+    position: relative;
+    line-height: 1.2;
+    margin-top: .5rem;
+    ul {
+      margin-left: -1rem;
+    }
+  }
+  .tree-node-toggle {
+    border: 0;
+    background: transparent;
+    padding-right: 0.4rem;
+    position: absolute;
+    left: 0;
+    top: -2px;
+    color: $dark-color;
+    &:hover {
+      cursor: pointer;
+      color: $secondary-color;
+    }
+  }
+  .tree-node button[aria-expanded='false'] + a + ul.tree-node-children {
+    display: none;
+  }
+}

--- a/app/models/category_node.rb
+++ b/app/models/category_node.rb
@@ -5,6 +5,8 @@ class CategoryNode < ApplicationRecord
     foreign_key: "category_id"
   has_many :items, through: :categorizations
 
+  scope :with_items, -> { where("tree_categorizations_count > 0") }
+
   def full_name
     path_names.join("  ")
   end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,43 +1,46 @@
-<div class="columns">
-  <div class="column col-12">
+<div class="columns items-index">
 
+  <div class="column col-sm-12 col-3 category-nav" data-controller="collapse">
+    <button class="btn toggle-categories" data-target="collapse.button" data-action="collapse#toggle" class="btn">Show Categories</button>
+    <div class="categories" data-target="collapse.content">
+      <h5>Categories</h5>
+      <%= category_tree_nav(@categories, @category) %>
+    </div>
+  </div>
+
+  <div class="column col-sm-12 col-9">
     <h1 class="title">
-      <%= link_to "Items", items_path %>
+      <%= @category ? @category.name : "All Items" %>
     </h1>
 
     <div class="items-summary">
       Viewing
-      <% if @tag %>
-        <strong><%= pluralize @pagy.count, "item" %></strong> tagged with
+      <% if @category %>
+        <strong><%= pluralize @pagy.count, "item" %></strong> in category
         <span class="chip">
-          <%= @tag.name %>
+          <%= @category.name %>
           <%= link_to "", items_path, :class => "btn btn-clear", "aria-label" => "Clear filter", :role => "button", title: "Clear filter" %>
         </span>,
       <% else %>
-        all <strong><%= pluralize @pagy.count, "item" %></strong>,
+        <strong><%= pluralize @pagy.count, "item" %></strong>,
       <% end %>
 
       sorted by: 
 
       <div class="btn-group">
-        <%= link_to_unless params[:sort] == "name" || params[:sort].blank?, "name", {tag: params[:tag]}, class: "btn btn-sm" do %>
+        <%= link_to_unless params[:sort] == "name" || params[:sort].blank?, "name", {category: params[:category]}, class: "btn btn-sm" do %>
           <button class="btn btn-sm active">name</button>
         <% end %>
-        <%= link_to_unless_current "number", {sort: "number", tag: params[:tag]}, class: "btn btn-sm" do %>
+        <%= link_to_unless_current "number", {sort: "number", category: params[:category]}, class: "btn btn-sm" do %>
           <button class="btn btn-sm active">number</button>
         <% end %>
-        <%= link_to_unless_current "added", {sort: "added", tag: params[:tag]}, class: "btn btn-sm" do %>
+        <%= link_to_unless_current "added", {sort: "added", category: params[:category]}, class: "btn btn-sm" do %>
           <button class="btn btn-sm active">added</button>
         <% end %>
       </div>
 
     </div> 
 
-  </div>
-</div>
-
-<div class="columns">
-  <div class="column col-sm-12 col-9">
     <% if @items.any? %>
       <div class="items-table">
         <% @items.each do |item| %>
@@ -82,11 +85,6 @@
     <% else %>
       <%= empty_state "There are no matching items" %>
     <% end %>
-  </div>
-
-  <div class="column col-sm-12 col-3">
-    <h5>Categories</h5>
-    <%= category_tree_nav(@categories, @category) %>
   </div>
 
 </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -85,8 +85,8 @@
   </div>
 
   <div class="column col-sm-12 col-3">
-    <strong>View items tagged with:</strong><br/>
-    <%= category_nav(@categories, @category) %>
+    <h5>Categories</h5>
+    <%= category_tree_nav(@categories, @category) %>
   </div>
 
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Circulate</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
-    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <meta charset="utf-8">
     <% unless request.get? && !form_request? # prevent turbolinks for caching form redisplays, which will often contain validation messages %>
       <meta name="turbolinks-cache-control" content="no-cache">
     <% end %>
@@ -23,6 +23,11 @@
   </head>
 
   <%= tag.body class: "public #{@body_class}" do %>
+
+    <div class="accessibility-links" role="navigation" data-turbolinks="false">
+      <%= link_to "Skip to content", "#content-start" %>
+    </div>
+
     <div class="off-canvas" data-controller="sidebar">
 
       <div id="sidebar-id" class="off-canvas-sidebar" data-target="sidebar.menu">
@@ -31,7 +36,7 @@
         </ul>
       </div>
 
-      <a class="off-canvas-overlay" href="#close" data-action="sidebar#close"></a>
+      <a class="off-canvas-overlay" href="#close" data-action="sidebar#close" title="close sidebar"></a>
 
       <div class="off-canvas-content show-sm mobile-banner">
         <div class="mobile-banner-content">
@@ -49,7 +54,7 @@
         </div>
       </div>
 
-      <a class="off-canvas-toggle btn btn-action btn-lg show-sm" href="#sidebar-id" data-action="sidebar#open">
+      <a class="off-canvas-toggle btn btn-action btn-lg show-sm" href="#sidebar-id" data-action="sidebar#open" title="show sidebar nvigation"
         <i class="icon icon-menu"></i>
       </a>
     </div>
@@ -60,7 +65,7 @@
         <section class="navbar-section">
           <span class="navbar-brand mr-3">
             <a href="https://chicagotoollibrary.org/">
-              <%= image_pack_tag "logo_small.png" %>
+              <%= image_pack_tag "logo_small.png", alt: "Chicago Tool Library logo" %>
             </a>
           </span>
           <ul class="navbar-links">
@@ -70,7 +75,7 @@
         <section class="navbar-section search-section">
           <%= form_with url: search_path, method: :get, class: "mr-2 search-box", local: true do |form| %>
             <div class="has-icon-left">
-              <%= form.text_field :query, class: "form-input input-sm", placeholder: "search items" %>
+              <%= form.text_field :query, class: "form-input input-sm", placeholder: "search items", id: "navbarQuery" %>
               <i class="form-icon icon icon-search"></i>
             </div>
           <% end %>
@@ -79,24 +84,26 @@
       
       <%= render partial: "shared/time_override" if Rails.env.development? %>
 
-      <% if content_for? :header %>
-        <div class="app-header">
-          <div class="header-header">
-            <%= yield :header %>
+      <main id="content-start">
+        <% if content_for? :header %>
+          <div class="app-header">
+            <div class="header-header">
+              <%= yield :header %>
+            </div>
           </div>
+        <% end %>
+
+        <div class="app-body">
+          <%= flash_message :success  %>
+          <%= flash_message :warning  %>
+          <%= flash_message :error  %>
+          <%= flash_message :alert, "error"  %>
+
+          <%= render(partial: "account/membership_renewal_message") if user_signed_in? %>
+
+          <%= yield %>
         </div>
-      <% end %>
-
-      <div class="app-body">
-        <%= flash_message :success  %>
-        <%= flash_message :warning  %>
-        <%= flash_message :error  %>
-        <%= flash_message :alert, "error"  %>
-
-        <%= render(partial: "account/membership_renewal_message") if user_signed_in? %>
-
-        <%= yield %>
-      </div>
+      </main>
     </div>
 
     <%= render partial: 'layouts/footer', object: @member, as: :member %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -54,7 +54,7 @@
         </div>
       </div>
 
-      <a class="off-canvas-toggle btn btn-action btn-lg show-sm" href="#sidebar-id" data-action="sidebar#open" title="show sidebar nvigation"
+      <a class="off-canvas-toggle btn btn-action btn-lg show-sm" href="#sidebar-id" data-action="sidebar#open" title="show sidebar nvigation">
         <i class="icon icon-menu"></i>
       </a>
     </div>

--- a/app/views/shared/_time_override.html.erb
+++ b/app/views/shared/_time_override.html.erb
@@ -8,15 +8,15 @@
       <li class="menu-item">
         <%= form_with url: dev_time_path, class: "form" do |form| %>
           <div class="input-group input-inline">
-            <%= form.text_field :new_time, value: Time.zone.now.to_s, class: "form-input" %>
-            <%= form.hidden_field :return_to, value: request.path %>
+            <%= form.text_field :new_time, value: Time.zone.now.to_s, class: "form-input", title: "Enter new time" %>
+            <%= form.hidden_field :return_to, value: request.path, id: "returnTo" %>
           </div>
         <% end %>
       </li>
       <li class="divider" data-content="Clear override">
       <li class="menu-item">
         <%= form_with url: dev_time_path, method: :delete, class: "form" do |form| %>
-          <%= form.hidden_field :return_to, value: request.path %>
+          <%= form.hidden_field :return_to, value: request.path, id: "returnTo2" %>
           <%= form.button "Reset", type: "submit", class: "btn btn-sm" %>
         <% end %>
       </li>


### PR DESCRIPTION
# What it does

This change replaces the existing category list (which had some semantic, accessibility, and usability issues) with a collapsible tree.

# Why it is important

* In addition to addressing the issues mentioned above, this will allow us to have more granular (and hopefully more useful) categories as they won't all display on the page by default.
* There are some other accessibility improvements including a skip link that were added while developing this feature.
* The categories now appear on the left of the page to better reflect the information hierarchy.
* Categories are hidden on mobile, and a button is provided to toggle their display.

# UI Change Screenshot

![image](https://user-images.githubusercontent.com/3331/129450243-66afc5f9-6a7e-47ac-bf30-4acad6e0228a.png)
![image](https://user-images.githubusercontent.com/3331/129450351-01cd8f9c-4d6f-4fe3-9f6a-7b89f21a1154.png)
