### PR TITLE
Update circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,8 @@
-version: 2
+version: 2.1
+
 orbs:
-  browser-tools: circleci/browser-tools@1.1
+  browser-tools: circleci/browser-tools@1.2.1
+
 jobs:
   bundler_dependencies:
     working_directory: ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   bundler_dependencies:
     working_directory: ~/repo
     docker:
-      - image: cimg/ruby:2.7.2-node-browsers
+      - image: cimg/ruby:2.7.2-browsers
         environment:
           BUNDLE_JOBS: 4
           BUNDLE_RETRY: 3
@@ -29,7 +29,7 @@ jobs:
   yarn_dependencies:
     working_directory: ~/repo
     docker:
-      - image: cimg/ruby:2.7.2-node-browsers
+      - image: cimg/ruby:2.7.2-browsers
     steps:
       - checkout
       - restore_cache:
@@ -45,7 +45,7 @@ jobs:
   build_assets:
     working_directory: ~/repo
     docker:
-      - image: cimg/ruby:2.7.2-node-browsers
+      - image: cimg/ruby:2.7.2-browsers
         environment:
           BUNDLE_JOBS: 4
           BUNDLE_RETRY: 3
@@ -74,7 +74,7 @@ jobs:
   test:
     working_directory: ~/repo
     docker:
-      - image: cimg/ruby:2.7.2-node-browsers
+      - image: cimg/ruby:2.7.2-browsers
         environment:
           BUNDLE_JOBS: 4
           BUNDLE_RETRY: 3
@@ -112,7 +112,7 @@ jobs:
   test_system:
     working_directory: ~/repo
     docker:
-      - image: cimg/ruby:2.7.2-node-browsers
+      - image: cimg/ruby:2.7.2-browsers
         environment:
           BUNDLE_JOBS: 4
           BUNDLE_RETRY: 3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
           at: ~/repo
       - run:
           name: install prereqs
-          command: sudo apt-get update && sudo apt-get install -y gsfonts
+          command: sudo apt-get update && sudo apt-get install -y gsfonts imagemagick
       - restore_cache:
           keys:
             - v1-dependencies-{{ checksum "Gemfile.lock" }}
@@ -133,7 +133,7 @@ jobs:
           at: ~/repo
       - run:
           name: install prereqs
-          command: sudo apt-get update && sudo apt-get install -y gsfonts
+          command: sudo apt-get update && sudo apt-get install -y gsfonts imagemagick
       - restore_cache:
           keys:
             - v1-dependencies-{{ checksum "Gemfile.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 version: 2
+orbs:
+  browser-tools: circleci/browser-tools@1.1
 jobs:
   bundler_dependencies:
     working_directory: ~/repo
@@ -83,6 +85,7 @@ jobs:
           PARALLEL_WORKERS: 4
       - image: circleci/postgres:11.5-ram
     steps:
+      - browser-tools/install-browser-tools
       - checkout
       - attach_workspace:
           at: ~/repo
@@ -122,6 +125,7 @@ jobs:
           HEADLESS: 1
       - image: circleci/postgres:11.5-ram
     steps:
+      - browser-tools/install-browser-tools
       - checkout
       - attach_workspace:
           at: ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   bundler_dependencies:
     working_directory: ~/repo
     docker:
-      - image: circleci/ruby:2.7.2-node-browsers
+      - image: cimg/ruby:2.7.2-node-browsers
         environment:
           BUNDLE_JOBS: 4
           BUNDLE_RETRY: 3
@@ -12,7 +12,7 @@ jobs:
       - checkout
       - run:
           name: install bundler
-          command: gem install bundler:2.1.4
+          command: gem install bundler:2.2.21
       - restore_cache:
           keys:
             - v1-dependencies-{{ checksum "Gemfile.lock" }}
@@ -29,7 +29,7 @@ jobs:
   yarn_dependencies:
     working_directory: ~/repo
     docker:
-      - image: circleci/ruby:2.7.2-node-browsers
+      - image: cimg/ruby:2.7.2-node-browsers
     steps:
       - checkout
       - restore_cache:
@@ -45,7 +45,7 @@ jobs:
   build_assets:
     working_directory: ~/repo
     docker:
-      - image: circleci/ruby:2.7.2-node-browsers
+      - image: cimg/ruby:2.7.2-node-browsers
         environment:
           BUNDLE_JOBS: 4
           BUNDLE_RETRY: 3
@@ -60,7 +60,7 @@ jobs:
             - v1-yarn-dependencies-{{ checksum "yarn.lock" }}
       - run:
           name: install bundler
-          command: gem install bundler:2.1.4
+          command: gem install bundler:2.2.21
       - run: yarn install --frozen-lockfile
       - run: bundle check || bundle install
       - run: bin/rails webpacker:compile
@@ -74,7 +74,7 @@ jobs:
   test:
     working_directory: ~/repo
     docker:
-      - image: circleci/ruby:2.7.2-node-browsers
+      - image: cimg/ruby:2.7.2-node-browsers
         environment:
           BUNDLE_JOBS: 4
           BUNDLE_RETRY: 3
@@ -98,7 +98,7 @@ jobs:
       - run: dockerize -wait tcp://localhost:5432 -timeout 1m
       - run:
           name: install bundler
-          command: gem install bundler:2.1.4
+          command: gem install bundler:2.2.21
       - run: yarn install --frozen-lockfile
       - run: bundle check || bundle install
       - run: bundle exec rake db:test:prepare
@@ -112,7 +112,7 @@ jobs:
   test_system:
     working_directory: ~/repo
     docker:
-      - image: circleci/ruby:2.7.2-node-browsers
+      - image: cimg/ruby:2.7.2-node-browsers
         environment:
           BUNDLE_JOBS: 4
           BUNDLE_RETRY: 3
@@ -136,7 +136,7 @@ jobs:
             - v1-yarn-dependencies-{{ checksum "yarn.lock" }}
       - run:
           name: install bundler
-          command: gem install bundler:2.1.4
+          command: gem install bundler:2.2.21
       - run: yarn install --frozen-lockfile
       - run: bundle check || bundle install
       - run: dockerize -wait tcp://localhost:5432 -timeout 1m
@@ -150,16 +150,6 @@ jobs:
           destination: test-screenshots
       - store_test_results:
           path: ~/repo/test/reports
-
-  deploy:
-    docker:
-      - image: buildpack-deps:trusty
-    steps:
-      - checkout
-      - run:
-          name: Deploy Development to Heroku
-          command: |
-            git push https://heroku:$HEROKU_API_KEY@git.heroku.com/$HEROKU_APP_NAME.git development:master
 
 workflows:
   version: 2
@@ -177,10 +167,3 @@ workflows:
       - test_system:
           requires:
             - build_assets
-      # - deploy:
-      #     requires:
-      #       - test
-      #       - test_system
-      #     filters:
-      #       branches:
-      #         only: development


### PR DESCRIPTION
# What it does

Builds started to fail on steps that called `apt-get`, likely because a new version of Debian shipped and the one that was used by the Docker images was no longer the latest.

This PR:

* Updates the circleci config to use the newer `cimg` images
* Makes a few tweaks to install imagemagick as needed since it's no longer included in the base image
* Adds an "orb" to facilitate access to browsers for system tests