### PR TITLE
Add scheduling appointment reminder text and update admin new item form text

### DIFF
--- a/app/views/account/appointments/_form.html.erb
+++ b/app/views/account/appointments/_form.html.erb
@@ -92,6 +92,7 @@
           <%= select("appointment", "time_range_string", grouped_options_for_select(@appointment_slots, @appointment.time_range_string), { include_blank: 'Select a Date' },
             class: "form-select", data: { action: "appointment-date#sync", target: "appointment-date.select" }, disabled: !can_schedule_appointment) %>
             <span data-target="appointment-date.display"></span>
+            <p>Don't worry if you arrive a little bit early or late, as long as it's within the library's open hours.</p>
         </div>
 
         <div class="form-group mb-2">

--- a/app/views/admin/items/_form.html.erb
+++ b/app/views/admin/items/_form.html.erb
@@ -4,7 +4,7 @@
   <%= form.autocomplete_text_field :name, path: admin_ui_names_path(format: :json), autofocus: true,
       hint: "Generic name for the tool; e.g. Impact driver, Orchard ladder, Flathead screwdriver" %>
 
-  <%= form.text_field :other_names,
+  <%= form.text_field :other_names_and_keywords,
       hint: "Search terms that should return this item; typically slang or other names for the item" %>
 
   <%= form.tag_select :category_ids, @categories %>

--- a/app/views/admin/items/_form.html.erb
+++ b/app/views/admin/items/_form.html.erb
@@ -4,7 +4,7 @@
   <%= form.autocomplete_text_field :name, path: admin_ui_names_path(format: :json), autofocus: true,
       hint: "Generic name for the tool; e.g. Impact driver, Orchard ladder, Flathead screwdriver" %>
 
-  <%= form.text_field :other_names_and_keywords,
+  <%= form.text_field :other_names, label: "Other names and keywords",
       hint: "Search terms that should return this item; typically slang or other names for the item" %>
 
   <%= form.tag_select :category_ids, @categories %>


### PR DESCRIPTION
# What it does

Just tackling some small tickets from the board.
- Add reminder text when scheduling an appointment
- Update admin new item form field "Other names" -> "Other names and keywords"

# Why it is important

Resolves issues https://github.com/rubyforgood/circulate/issues/605, https://github.com/rubyforgood/circulate/issues/606

# UI Change Screenshot

![image](https://user-images.githubusercontent.com/12875392/131697297-ebdc3161-2b9c-4c0a-af0d-38f34e645202.png)

![image](https://user-images.githubusercontent.com/12875392/131697364-b6ef5f56-fdbc-4670-8193-6a5924c1c4dd.png)

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [x] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
