### PR TITLE
feat: create notification on password reset

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,14 @@
+class UserMailer < Devise::Mailer
+  default from: "Chicago Tool Library <team@chicagotoollibrary.org>"
+  after_action :store_notification, only: [:reset_password_instructions]
+
+  def reset_password_instructions(record, token, opts = {})
+    @user = record
+    @subject = "You requested a password reset"
+    super
+  end
+
+  def store_notification
+    Notification.create!(member: @user.member, uuid: SecureRandom.uuid, action: action_name, address: @user.email, subject: @subject)
+  end
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -18,10 +18,10 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "team@chicagotoollibrary.org"
+  # config.mailer_sender = "team@chicagotoollibrary.org"
 
   # Configure the class responsible to send e-mails.
-  # config.mailer = 'Devise::Mailer'
+  config.mailer = "UserMailer"
 
   # Configure the parent class responsible to send e-mails.
   # config.parent_mailer = 'ActionMailer::Base'


### PR DESCRIPTION
# What it does

Overrides the Devise default mailer to add an `after_action` creating a notification whenever a user requests a password reset.

# Why it is important

#632

# UI Change Screenshot

![password-notification](https://user-images.githubusercontent.com/8291663/131767136-c2a82d37-df21-43c1-ad40-50fc588c1645.png)

# Implementation notes

Overriding the Devise mailer seemed like the most straightforward way and shouldn't have any other side effects

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [x] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
