### PR TITLE
Use "in_container" driver when in docker setup

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -56,17 +56,16 @@ FactoryBot::SyntaxRunner.class_eval do
 end
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driver = ENV["HEADLESS"] ? :headless_chrome : :chrome
-  driven_by :selenium, using: driver, screen_size: [1400, 1800]
-
   setup do
     if ENV["DOCKER"]
-      Capybara.javascript_driver = ENV["HEADLESS"] == "true" ? :headless_chrome_in_container : :chrome_in_container
-      Capybara.current_driver = Capybara.javascript_driver
+      driver = ENV["HEADLESS"] == "true" ? :headless_chrome_in_container : :chrome_in_container
       Capybara.server_host = "0.0.0.0"
       Capybara.server_port = 4000
       Capybara.app_host = "http://example.com:4000"
+    else
+      driver = ENV["HEADLESS"] == "true" ? :headless_chrome : :chrome
     end
+    driven_by :selenium, using: driver, screen_size: [1400, 1800]
   end
 
   include Warden::Test::Helpers


### PR DESCRIPTION
# What it does

Fix issue https://github.com/rubyforgood/circulate/issues/644

When using docker environment, the driver (`headless_chrome_in_container` or `chrome_in_contaier`) is set, but the driver being used is the one passed to `driven_by` method, which is `headless_chrome` or `chrome`. Because the driver in use does not use Chrome in the `selenium_chrome` container, and there is no Chrome installed in `web` container, Rails cannot find Chrome browser to run test.

I changed the code so that the correct driver is passed into `driven_by` method.

# Why it is important

To let developers with Docker environment run `docker-compose exec web rails test`.

# Implementation notes

Because we've already used `driven_by` method, I think we don't need to setup `Capybara.javascript_driver` and `Capybara.current_driver` so I removed those lines.

I have tested running `rails test` or `docker-exec web rails test` in following environments:

* Windows with/without docker
* Mac with/without docker

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
