### PR TITLE
refactor: update to 6.1 defaults

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -19,11 +19,24 @@ Bundler.require(*Rails.groups)
 module Circulate
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 6.0
+    config.load_defaults 6.1
     # config.autoloader = :classic
+
+    config.active_record.has_many_inversing = false
+    config.active_record.legacy_connection_handling = true
+
+    config.active_storage.track_variants = false
+    config.active_storage.queues.analysis = :active_storage_analysis
 
     # config.active_storage.variant_processor = :vips
     config.active_job.queue_adapter = :sucker_punch
+    config.active_job.skip_after_callbacks_if_terminated = true
+
+    config.action_dispatch.cookies_same_site_protection = nil
+
+    config.action_view.form_with_generates_remote_forms = true
+
+    ActiveSupport.utc_to_local_returns_utc_offset_times = false
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers


### PR DESCRIPTION
# What it does

Updates the configuration to start from the 6.1 defaults, but stays pretty conservative about going against defaults if they seem to change behavior.

# Why it is important

#631

# Implementation notes

* `legacy_connection_handling` is required to be true or the tests will fail. This could be possible for production, but to be cautious I'm applying it for all objects for now
* `form_with_generates_remote_forms` is required to be true otherwise multiple tests fail
* The rest are mostly assumptions about what could cause changes, in particular on ActiveStorage and not wanting to change anything with timezones

# Your bandwidth for additional changes to this PR

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [x] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
