### PR TITLE
Add member pronunciation to librarian view

### DIFF
--- a/app/controllers/admin/members_controller.rb
+++ b/app/controllers/admin/members_controller.rb
@@ -65,7 +65,7 @@ module Admin
 
     def member_params
       params.require(:member).permit(
-        :full_name, :preferred_name, :email, :phone_number, :postal_code,
+        :full_name, :pronunciation, :preferred_name, :email, :phone_number, :postal_code,
         :desires, :reminders_via_email, :reminders_via_text, :receive_newsletter, :volunteer_interest,
         :status, :address1, :address2, pronouns: []
       )

--- a/app/views/admin/members/_fields.html.erb
+++ b/app/views/admin/members/_fields.html.erb
@@ -1,6 +1,7 @@
 <%= form.errors %>
 
   <%= form.text_field :full_name, hint: "Your full name, first and last, found on your ID and other official documents" %>
+  <%= form.text_field :pronunciation if local_assigns[:librarian_view] %>
   <%= form.text_field :preferred_name, hint: "What you like to be called (we'll use this instead of your full name)" %>
 
   <%= render partial: 'account/members/pronoun_fields' , locals: { object: form.object } %>

--- a/app/views/admin/members/_form.html.erb
+++ b/app/views/admin/members/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_with(model: [:admin, member], builder: SpectreFormBuilder) do |form| %>
-  <%= render partial: 'fields', locals: { form: form, show_password_inputs: true } %>
+  <%= render partial: 'fields', locals: { form: form, show_password_inputs: true, librarian_view: true } %>
 
   <%= form.text_area :bio %>
   <%= form.select :status, options_for_select(member_status_options, member.status), prompt: true %>

--- a/app/views/admin/members/_member_details.html.erb
+++ b/app/views/admin/members/_member_details.html.erb
@@ -5,6 +5,7 @@
   <div class="panel-body">
     <ul class="member-stats member">
       <%= icon_stat "message-square", member.display_pronouns, title: "pronouns", placeholder: "No pronouns" %>
+      <%= icon_stat "volume-2", member.pronunciation, title: "pronunciation", placeholder: "No pronunciation" %>
       <%= icon_stat "user", member.full_name, title: "full_name", placeholder: "No name" %>
       <%= icon_stat "mail", member.email, title: "email", placeholder: "No email" %>
       <% phone_number = format_phone_number member.phone_number%>

--- a/db/migrate/20210911202001_add_pronunciation_to_members.rb
+++ b/db/migrate/20210911202001_add_pronunciation_to_members.rb
@@ -1,0 +1,5 @@
+class AddPronunciationToMembers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :members, :pronunciation, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_03_205105) do
+ActiveRecord::Schema.define(version: 2021_09_11_202001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -338,6 +338,7 @@ ActiveRecord::Schema.define(version: 2021_09_03_205105) do
     t.string "region"
     t.integer "number"
     t.text "pronouns", default: [], array: true
+    t.string "pronunciation"
     t.index ["number"], name: "index_members_on_number", unique: true
   end
 

--- a/test/factories/members.rb
+++ b/test/factories/members.rb
@@ -15,6 +15,10 @@ FactoryBot.define do
       bio { "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua." }
     end
 
+    trait :with_pronunciation do
+      pronunciation { "ˈaɪdə welz" }
+    end
+
     factory :complete_member do
       preferred_name { "Ida" }
       pronouns { ["she/her"] }

--- a/test/models/member_test.rb
+++ b/test/models/member_test.rb
@@ -153,6 +153,13 @@ class MemberTest < ActiveSupport::TestCase
     assert_equal Member.last.bio, member.bio
   end
 
+  test "a member can have an optional pronunciation" do
+    member = FactoryBot.build(:member, :with_pronunciation)
+    member.save
+
+    assert_equal Member.last.pronunciation, member.pronunciation
+  end
+
   test "last_membership finds the only membership" do
     member = create(:member)
     membership = create(:membership, member: member)


### PR DESCRIPTION
# What it does

* Add pronunciation column of string type to members table
* Show pronunciation only in librarian view's show and edit pages

# Why it is important

Resolve https://github.com/rubyforgood/circulate/issues/630

# UI Change Screenshot

* Librarian view
    * Show with pronunciation
![with_pronunciation](https://user-images.githubusercontent.com/57126452/132966863-3757ab04-8292-466b-bd4b-6c6594155ad8.PNG)
    * Show without pronunciation    
![no_pronunciation](https://user-images.githubusercontent.com/57126452/132966868-1524ad93-62a2-4483-9f9d-71feb70af336.PNG)
    * Edit
![librarian_view_form](https://user-images.githubusercontent.com/57126452/132966878-69e8fb18-7447-45e9-b8a0-fb79e7b76fc8.PNG)
* Member view (no change)
    * Show
![member_view](https://user-images.githubusercontent.com/57126452/132966943-30da3729-51ec-4607-a42b-8ee730de8534.PNG)
    * Edit
![member_view_form](https://user-images.githubusercontent.com/57126452/132966946-0478b1f5-6fca-4f4f-be10-75c0b509bd61.PNG)
    * Sign up form
![sign_up_form](https://user-images.githubusercontent.com/57126452/132966949-239a226a-930b-424b-8ff9-a8f2cb2c399d.PNG)

# Implementation notes

* I don't see any existed integration test for show and edit member page of librarian view, so I only add a model test. Is that OK? 

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
