### PR TITLE
Fix system test for custom drivers

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -23,7 +23,7 @@ end
 
 Capybara.register_driver(:headless_chrome) do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: {args: %w[headless disable-gpu no-sandbox disable-dev-shm-usage]}
+    "goog:chromeOptions": {args: %w[headless disable-gpu no-sandbox disable-dev-shm-usage window-size=1400x1800]}
   )
 
   Capybara::Selenium::Driver.new(
@@ -65,9 +65,14 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driver = if ENV["DOCKER"]
     ENV["HEADLESS"] == "true" ? :headless_chrome_in_container : :chrome_in_container
   else
-    ENV["HEADLESS"] == "true" ? :headless_chrome : :chrome
+    ENV["HEADLESS"] == "true" ? :headless_chrome : nil
   end
-  driven_by :selenium, using: driver, screen_size: [1400, 1800]
+
+  if driver
+    driven_by driver
+  else
+    driven_by :selenium, using: :chrome, screen_size: [1400, 1800]
+  end
 
   include Warden::Test::Helpers
   include ActionMailer::TestHelper

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -21,15 +21,15 @@ Capybara.add_selector :rich_text_area do
   end
 end
 
-Capybara.register_driver(:headless_chrome) do |app|
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    "goog:chromeOptions": {args: %w[headless disable-gpu no-sandbox disable-dev-shm-usage window-size=1400x1800]}
+Capybara.register_driver :headless_chrome do |app|
+  options = Selenium::WebDriver::Chrome::Options.new(
+    args: %w[headless disable-gpu no-sandbox disable-dev-shm-usage window-size=1400x1800]
   )
 
   Capybara::Selenium::Driver.new(
     app,
     browser: :chrome,
-    desired_capabilities: capabilities
+    options: options
   )
 end
 


### PR DESCRIPTION
# What it does

This fixes the way we use registered drivers with `driven_by`, so that system test can run with those custom defined drivers.

# Why it is important

Solve https://github.com/rubyforgood/circulate/issues/660

# Implementation notes

About my approach here:
I checked the signature of `driven_by` and found that we need to pass the driver to the first argument, and the browser to `using:`. In our case here, when we call `Capybara.register_driver`, we define a driver, not a browser, so that `driver` should be passed as the first argument.
https://github.com/rails/rails/blob/main/actionpack/lib/action_dispatch/system_test_case.rb#L154-L158

The default value for `using:` is `:chrome`, so I also checked if there is any problem when we don't pass `using:` into `driven_by`. It seems like when we pass a custom driver, value of `using:` is ignored, so it will not cause any issue.
https://github.com/rails/rails/blob/main/actionpack/lib/action_dispatch/system_testing/driver.rb#L20-L26

For `headless_chrome` driver, I couldn't run it in headless mode, so I did some research. Seems like the driver API has been changed, so we must use `goo:chromeOptions` instead of `chromeOptions`, or change to use `Chrome::Options` class instead of `Remote::Capabilities.chrome`. Because we use `browser: :chrome` here, as opposed to `browser: :remote`, I decided to use `Chrome::Options` class.
https://bugs.chromium.org/p/chromium/issues/detail?id=971227#c17

I tested `bin/rails test:system` for headless and no-headless modes, with and without Docker.

By the way, there are some messages about deprecation and 422 error, but I guess they are not related to this fix.
```
$ bin/rails test:system
Run options: --seed 20613

# Running:

Capybara starting Puma...
* Version 5.3.1 , codename: Sweetnighter
* Min threads: 0, max threads: 4
* Listening on http://0.0.0.0:4000
DEPRECATION WARNING: Rendering actions with '.' in the name is deprecated: admin/appointments/_appointment.html.erb (called from render_to_portal at /usr/src/app/app/controllers/concerns/portal_rendering.rb:7)
.................S...........JS console (severe): http://example.com:4000/admin/items/703/notes - Failed to load resource: the server responded with a status of 422 (Unprocessable Entity)
..SS.................................SS..........
[Minitest::CI] Generating test report in JUnit XML format...


Finished in 61.926151s, 1.2596 runs/s, 6.3786 assertions/s.
78 runs, 395 assertions, 0 failures, 0 errors, 5 skips

You have skipped tests. Run with --verbose for details.
```

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
