### PR TITLE
New export function for categories

### DIFF
--- a/app/models/categorization.rb
+++ b/app/models/categorization.rb
@@ -1,6 +1,7 @@
 class Categorization < ApplicationRecord
   belongs_to :item
   belongs_to :category, counter_cache: true
+  belongs_to :category_node, foreign_key: "category_id"
   validates :category_id, uniqueness: {scope: :item_id}
 
   after_commit :refresh_category_nodes

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -14,6 +14,7 @@ class Item < ApplicationRecord
   has_many :categories, through: :categorizations,
                         before_add: :cache_category_ids,
                         before_remove: :cache_category_ids
+  has_many :category_nodes, through: :categorizations
 
   has_many :loans, dependent: :nullify
   has_one :checked_out_exclusive_loan, -> { checked_out.exclusive.readonly }, class_name: "Loan"

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -84,11 +84,14 @@ namespace :export do
 
   desc "Export items to CSV"
   task items_to_csv: :environment do
+    now = Time.current.rfc3339
+    path = Rails.root + "exports" + "all-items-#{now}.csv"
+    puts "writing items to #{path}"
     columns = %w[
       id name description size brand model serial strength
       quantity checkout_notice status created_at updated_at
     ]
-    CSV.open(Rails.root + "exports" + "all_items.csv", "wb") do |csv|
+    CSV.open(path, "wb") do |csv|
       csv << [
         "complete_number",
         "code",
@@ -96,14 +99,39 @@ namespace :export do
         "categories",
         *columns
       ]
-      Item.includes(:borrow_policy, :categories).in_batches(of: 100) do |items|
+      Item.includes(:borrow_policy, :category_nodes).in_batches(of: 100) do |items|
         items.each do |item|
           csv << [
             item.complete_number,
             item.borrow_policy.code,
             item.number,
-            item.categories.map(&:name).sort.join(", "),
+            item.category_nodes.map{|cn| cn.path_names.join("//")}.sort.join("; "),
             *item.attributes.values_at(*columns)
+          ]
+        end
+      end
+    end
+  end
+
+  desc "Export categories to CSV"
+  task categories_to_csv: :environment do
+    now = Time.current.rfc3339
+    path = Rails.root + "exports" + "all-categories-#{now}.csv"
+    puts "writing categories to #{path}"
+    CSV.open(path, "wb") do |csv|
+      csv << [
+        "id",
+        "name",
+        "complete_name",
+        "items_count"
+      ]
+      CategoryNode.in_batches(of: 100) do |nodes|
+        nodes.each do |node|
+          csv << [ 
+            node.id,
+            node.name,
+            node.path_names.join("//"),
+            node.categorizations_count
           ]
         end
       end


### PR DESCRIPTION
# What it does

CTL wants to edit item categories in a bulk fashion, so we're exporting the categories and items to spreadsheets and will reimport the changes when that process is complete.