### PR TITLE
Calendar bugs

### DIFF
--- a/app/lib/google/calendar.rb
+++ b/app/lib/google/calendar.rb
@@ -118,6 +118,12 @@ module Google
       http.auth("Bearer #{token}")
     end
 
+    def parse_gcal_time(time)
+      zone_name = time["timeZone"]
+      datetime = time["dateTime"]
+      ActiveSupport::TimeZone[zone_name].iso8601(datetime)
+    end
+
     def gcal_event_to_event(gcal_event)
       # skip all day events
       unless gcal_event["start"]["dateTime"] && gcal_event["end"]["dateTime"]
@@ -129,8 +135,8 @@ module Google
         calendar_id: @calendar_id,
         summary: gcal_event["summary"],
         description: gcal_event["description"],
-        start: Time.iso8601(gcal_event["start"]["dateTime"]),
-        finish: Time.iso8601(gcal_event["end"]["dateTime"]),
+        start: parse_gcal_time(gcal_event["start"]),
+        finish: parse_gcal_time(gcal_event["end"]),
         status: gcal_event["status"],
         attendees: gcal_event.fetch("attendees", []).map { |attendee|
           Attendee.new(email: attendee["email"], name: attendee["displayName"], status: attendee["responseStatus"])

--- a/app/lib/google/calendar.rb
+++ b/app/lib/google/calendar.rb
@@ -17,7 +17,7 @@ module Google
       })
 
       if events_response.status == 200
-        events = events_response.parse.fetch("items", []).map { |event| gcal_event_to_event(event) }
+        events = events_response.parse.fetch("items", []).map { |event| gcal_event_to_event(event) }.compact
         Result.success(events)
       else
         Result.failure(events_response.body)
@@ -119,6 +119,11 @@ module Google
     end
 
     def gcal_event_to_event(gcal_event)
+      # skip all day events
+      unless gcal_event["start"]["dateTime"] && gcal_event["end"]["dateTime"]
+        Rails.logger.info "skipping all-day event #{gcal_event["id"]} in calendar #{@calendar_id}"
+        return nil
+      end
       CalendarEvent.new(
         id: gcal_event["id"],
         calendar_id: @calendar_id,

--- a/app/lib/volunteer/month_calendar.rb
+++ b/app/lib/volunteer/month_calendar.rb
@@ -6,8 +6,8 @@ module Volunteer
     def initialize(events, today = nil)
       @events = events
       @today = today || Time.zone.now.to_date
-      @first_date = @today.beginning_of_month.beginning_of_week
-      @last_date = @today.end_of_month.end_of_week
+      @first_date = @today.beginning_of_month.beginning_of_week(:sunday)
+      @last_date = @today.end_of_month.end_of_week(:sunday)
     end
 
     def title


### PR DESCRIPTION
# What it does

This fixes a bug where volunteer shifts were appearing on the wrong day of the week. I also tweaked the date parsing to consider a timezone in the event JSON, although in testing this didn't seem to matter since the values are all in UTC anyway.