### PR TITLE
Send membership renewal email 30 days before expiration

### DIFF
--- a/lib/tasks/email.rake
+++ b/lib/tasks/email.rake
@@ -29,7 +29,7 @@ namespace :email do
 
   desc "Send membership renewal reminder emails"
   task send_membership_renewal_reminders: :environment do
-    Membership.expiring_before(Date.new(2021, 2, 1)).each do |membership|
+    Membership.where(ended_at: (Date.today + 30.days).all_day).each do |membership|
       member = membership.member
       amount = member.last_membership&.amount || Money.new(0)
       MemberMailer.with(member: member, amount: amount).membership_renewal_reminder.deliver_now


### PR DESCRIPTION
# What it does

Updates the rake task for membership renewal emails to pull users 30 whose memberships expire 30 days from the current date

# Why it is important

Closes #442

# Implementation notes

* I'm using the [`Date#all_day`](https://apidock.com/rails/DateAndTime/Calculations/all_day) helper to return a range in UTC of the full datetime for a given day. This should handle any timezone issues

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [x] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
