### PR TITLE
increase spacing on admin checkout buttons

### DIFF
--- a/app/javascript/stylesheets/partials/_admin_appointments.scss
+++ b/app/javascript/stylesheets/partials/_admin_appointments.scss
@@ -42,3 +42,11 @@
 .appointments-date {
 	flex-basis: 1!important;
 }
+.checkout-button-column,
+.checkout-button-group {
+	display: flex;
+	flex-direction: column;
+}
+.checkout-button-column {
+	justify-content: space-between;
+}

--- a/app/views/admin/appointments/_checkouts.html.erb
+++ b/app/views/admin/appointments/_checkouts.html.erb
@@ -22,15 +22,17 @@
         <p><%= pickup_item.item.name %></p>
         <p><%= full_item_number(pickup_item.item) %></p>
       </div>
-      <div class="column col-sm-12 col-4 text-right">
+      <div class="column col-sm-12 col-4 text-right checkout-button-column">
         <%= button_to "Check-out", admin_appointment_checkouts_path(@appointment, hold_ids: [pickup_item.id]), class: "btn btn-primary btn-sm", data: { disable_with: "Checking-out..." }, disabled: !pickup_item.active? || !member.borrow? %>
-        <% if pickup_item.active? %>
-          <%= button_to 'Cancel Hold', admin_appointment_hold_path(@appointment, pickup_item, cancel_hold: true), class: "btn btn-sm mt-2 float-right", method: :delete, data: { disable_with: "Canceling...", confirm: "Are you sure you want to remove this item from the appointment and cancel the member's hold?" } %>
-          <%= button_to 'Remove Item', admin_appointment_hold_path(@appointment, pickup_item, cancel_hold: false), class: "btn btn-sm mt-2 float-right", method: :delete, data: { disable_with: "Removing...", confirm: "Are you sure you want to remove this item from the appointment?" } %>
-        <% end %>
-        <% if !pickup_item.active? %>
-          <em>Item checked-out</em>
-        <% end %>
+        <div class="checkout-button-group">
+          <% if pickup_item.active? %>
+            <%= button_to 'Cancel Hold', admin_appointment_hold_path(@appointment, pickup_item, cancel_hold: true), class: "btn btn-sm mt-2 float-right", method: :delete, data: { disable_with: "Canceling...", confirm: "Are you sure you want to remove this item from the appointment and cancel the member's hold?" } %>
+            <%= button_to 'Remove Item', admin_appointment_hold_path(@appointment, pickup_item, cancel_hold: false), class: "btn btn-sm mt-2 float-right", method: :delete, data: { disable_with: "Removing...", confirm: "Are you sure you want to remove this item from the appointment?" } %>
+          <% end %>
+          <% if !pickup_item.active? %>
+            <em>Item checked-out</em>
+          <% end %>
+        </div>
       </div>
     </div>
   <% end %>


### PR DESCRIPTION
# What it does

Adds some spacing to the admin checkout buttons. To make resizing and spacing easier I've got the flex direction set to column consistently

# Why it is important

#670

# UI Change Screenshot

![admin-checkout](https://user-images.githubusercontent.com/8291663/134268120-4aa06bef-2c47-4dbf-8db7-138b31cfa3b8.png)

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [x] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
