### PR TITLE
re-initialize weglot on turbolinks load

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,8 +15,10 @@
     <% if Rails.env.production? %>
       <script type="text/javascript" src="https://cdn.weglot.com/weglot.min.js"></script>
       <script>
-          Weglot.initialize({
-              api_key: '<%= ENV.fetch("WEGLOT_API_KEY", "weglot key") %>'
+          document.addEventListener("turbolinks:load", function() {
+              Weglot.initialize({
+                  api_key: '<%= ENV.fetch("WEGLOT_API_KEY", "weglot key") %>'
+              });
           });
       </script>
     <% end %>


### PR DESCRIPTION
# What it does

Based on the conversation I'm re-initializing WeGlot on every page load. I haven't dug too deeply into the WeGlot docs, so I'm not sure if there's another function I should be calling here. From some local testing it looks like `turbolinks:load` is fired on initial page load as well so I'm always calling it as an event handler

# Why it is important

#627

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
