### PR TITLE
Comment out check out and check in all buttons

### DIFF
--- a/app/views/admin/appointments/_checkins.html.erb
+++ b/app/views/admin/appointments/_checkins.html.erb
@@ -2,7 +2,7 @@
   <div class="columns col-oneline">
     <div class="column col-8"><h4>Items to be checked-in (<%= checkin_items_quantity_for_appointment %>)</h4></div>
     <div class="column col-sm-12 col-4 text-right">
-      <%= button_to "Check-in All", admin_appointment_checkins_path(@appointment, loan_ids: appointment_return_items.checked_out.pluck(:id)), class: "btn btn-primary", data: { disable_with: "Checking-in...", confirm: "Are you sure you want to check-in all items?" }, disabled: !appointment_return_items.checked_out.exists? %>
+      <%#= button_to "Check-in All", admin_appointment_checkins_path(@appointment, loan_ids: appointment_return_items.checked_out.pluck(:id)), class: "btn btn-primary", data: { disable_with: "Checking-in...", confirm: "Are you sure you want to check-in all items?" }, disabled: !appointment_return_items.checked_out.exists? %>
     </div>
   </div>
   <% appointment_return_items.each do |return_item| %>

--- a/app/views/admin/appointments/_checkouts.html.erb
+++ b/app/views/admin/appointments/_checkouts.html.erb
@@ -2,7 +2,7 @@
   <div class="columns col-oneline">
     <div class="column col-8"><h4>Items to be checked-out (<%= checkout_items_quantity_for_appointment %>)</h4></div>
     <div class="column col-sm-12 col-4 text-right">
-      <%= button_to "Check-out All", admin_appointment_checkouts_path(@appointment, hold_ids: appointment_pickup_items.active.pluck(:id)), class: "btn btn-primary", data: { disable_with: "Checking-out...", confirm: "Are you sure you want to check-out all items?" }, disabled: !appointment_pickup_items.active.exists? || !member.borrow? %>
+      <%#= button_to "Check-out All", admin_appointment_checkouts_path(@appointment, hold_ids: appointment_pickup_items.active.pluck(:id)), class: "btn btn-primary", data: { disable_with: "Checking-out...", confirm: "Are you sure you want to check-out all items?" }, disabled: !appointment_pickup_items.active.exists? || !member.borrow? %>
     </div>
   </div>
 


### PR DESCRIPTION
- Commented out since we may want these back later

# What it does

Remove buttons to "Check out all" and "Check in all"

# Why it is important

See #669 -- buttons are currently causing errors in workflow. May want to reimplement later.

# UI Change Screenshot

Before:
![Uploading Screen Shot 2021-09-24 at 10.48.32 AM.png…]()


After:
<img width="1523" alt="Screen Shot 2021-09-24 at 10 46 55 AM" src="https://user-images.githubusercontent.com/37967627/134694505-703d5750-a21c-4889-8b51-f6e4a8d2393e.png">

# Implementation notes

N/A

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [ X ] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
