### PR TITLE
Add circleci cli install to README, fix typo in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ Some things that will increase the chance that your pull request is accepted:
 
   ```
   bundle exec rails test
-  bundle exec tails test:system
+  bundle exec rails test:system
   bundle exec standardrb
   ```
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ Note, in order to get system tests to run, you will need `chromedriver` installe
 
 Circulate uses [Lefthook](https://github.com/Arkweid/lefthook) to run a few linters before creating commits, including [Standard](https://github.com/testdouble/standard). [Follow these instructions](https://github.com/Arkweid/lefthook/blob/master/docs/ruby.md) to configure your local git repository to run pre-commit checks.
 
+One of the linters run by Lefthook, circleci, will need to be installed. [Follow Circleci's cli installation instructions](https://circleci.com/docs/2.0/local-cli/#installation).
+
 ### Documentation
 
 Circulate leans heavily on a handful of open source frameworks and libraries, the documentation for which will be useful to developers:


### PR DESCRIPTION
# What it does

Updating the install instructions in the README to include installing circleci. Corrected a typo (tails instead of rails) in the CONTRIBUTING guide.

# Why it is important

Make contributing setup easier for new contributors

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
