### PR TITLE
extend wait on two flaky tests Fixes #729

### DIFF
--- a/test/system/user_signup_test.rb
+++ b/test/system/user_signup_test.rb
@@ -46,7 +46,7 @@ class UserSignupTest < ApplicationSystemTestCase
     perform_enqueued_jobs do
       click_on "Complete in Person"
 
-      assert_selector "li.step-item.active", text: "Complete", wait: 5
+      assert_selector "li.step-item.active", text: "Complete", wait: 10
     end
 
     assert_emails 1
@@ -62,7 +62,7 @@ class UserSignupTest < ApplicationSystemTestCase
     perform_enqueued_jobs do
       click_on "Complete in Person"
 
-      assert_selector "li.step-item.active", text: "Complete", wait: 5
+      assert_selector "li.step-item.active", text: "Complete", wait: 10
     end
 
     visit root_url


### PR DESCRIPTION
# What it does

There were two tests that would fail occasionally. This PR extends the timeout on the assert-selector in those two tests to allow more time for the background job to complete.

# Implementation notes

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
