### PR TITLE
update item index to automatically sort by date added

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -34,6 +34,6 @@ class ItemsController < ApplicationController
       "number" => "items.number ASC",
       "added" => "items.created_at DESC"
     }
-    options.fetch(params[:sort]) { options["name"] }
+    options.fetch(params[:sort]) { options["added"] }
   end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -28,14 +28,14 @@
       sorted by: 
 
       <div class="btn-group">
-        <%= link_to_unless params[:sort] == "name" || params[:sort].blank?, "name", {category: params[:category]}, class: "btn btn-sm" do %>
+        <%= link_to_unless_current "name", {sort: "name", category: params[:category]}, class: "btn btn-sm" do %>
           <button class="btn btn-sm active">name</button>
         <% end %>
         <%= link_to_unless_current "number", {sort: "number", category: params[:category]}, class: "btn btn-sm" do %>
           <button class="btn btn-sm active">number</button>
         <% end %>
-        <%= link_to_unless_current "added", {sort: "added", category: params[:category]}, class: "btn btn-sm" do %>
-          <button class="btn btn-sm active">added</button>
+        <%= link_to_unless params[:sort] == "added" || params[:sort].blank?, "added", {sort: "added", category: params[:category]}, class: "btn btn-sm" do %>
+          <button class="btn btn-sm active">date added</button>
         <% end %>
       </div>
 
@@ -59,6 +59,7 @@
             <%= item_status_label(item) %>
             <br>
             <%= link_to item.name, item_path(item) %>
+            <%#= item.added %>
             <% if item.size.present? %>
               <span class="label"><%= item.size %></span>
             <% end %>


### PR DESCRIPTION
# What it does

- Updates view inventory page to automatically sort by date added instead of name
- Changes "added" tab to "date added"

# Why it is important

See Issue #671

# UI Change Screenshot

Original View Inventory Page:

![Uploading Screen Shot 2021-09-24 at 4.42.11 PM.png…]()

Updated View Inventory

<img width="1230" alt="Screen Shot 2021-09-24 at 4 43 06 PM" src="https://user-images.githubusercontent.com/37967627/134738143-7d86be2c-77ac-4866-a145-57524a81aad8.png">


# Implementation notes

N/A

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [ X ] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
