### PR TITLE
Add method to swallow js errors when they are intentional

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -104,6 +104,12 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
   private
 
+  def ignore_js_errors(reason: "I know what I am doing")
+    Rails.logger.info("Swallowed JS error because: #{reason}")
+    yield if block_given?
+    page.driver.browser.manage.logs.get(:browser)
+  end
+
   def sign_in_as_admin
     @user = FactoryBot.create(:user, role: "admin")
     login_as(@user, scope: :user)

--- a/test/system/admin/notes_test.rb
+++ b/test/system/admin/notes_test.rb
@@ -6,18 +6,20 @@ class NotesTest < ApplicationSystemTestCase
   end
 
   test "adding a note to an item" do
-    @item = create(:item)
-    visit admin_item_url(@item)
+    ignore_js_errors(reason: "This intentionally causes a 422 error") do
+      @item = create(:item)
+      visit admin_item_url(@item)
 
-    click_on "Add a Note"
-    click_on "Create Note"
+      click_on "Add a Note"
+      click_on "Create Note"
 
-    assert_content "can't be blank"
+      assert_content "can't be blank"
 
-    fill_in_rich_text_area "note_body", with: "Information you should know"
-    click_on "Create Note"
+      fill_in_rich_text_area "note_body", with: "Information you should know"
+      click_on "Create Note"
 
-    assert_selector ".note", text: "Information you should know"
+      assert_selector ".note", text: "Information you should know"
+    end
   end
 
   test "editing a note on an item" do


### PR DESCRIPTION
# What it does

This adds a method that clears the js console errors and prevents them from littering the test output when they are caused intentionally.

# Why it is important

Any noise in the test output has the potential to distract a developer from seeing actual errors versus the extraneous output. In cases where you will cause a console error intentionally, you should be able to prevent that from showing in the test output.

# Implementation notes

There are two ways you can use the `ignore_js_errors` method in your tests: inline and block form.

In the block form, surround the code you know will cause the errors.

```ruby
test "it gives an error when you submit without filling in the form" do
  ignore_js_errors(reason: "Creating without filling in the fields gives a 422") do
    visit edit_item_url(@item)
    click_on "Submit"
    expect(page).to have_text("field needs to be filled out")
  end
end
```

The same test can be written the inline form of `ignore_js_errors` by calling it at the end of the test.

```ruby
test "it gives an error when you submit without filling in the form" do
  visit edit_item_url(@item)
  click_on "Submit"
  expect(page).to have_text("field needs to be filled out")
  ignore_js_errors(reason: "Creating without filling in the fields gives a 422")
end
```
# Your bandwidth for additional changes to this PR

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
