### PR TITLE
677 make item numbers into hyperlinks

### DIFF
--- a/app/views/admin/appointments/_checkins.html.erb
+++ b/app/views/admin/appointments/_checkins.html.erb
@@ -21,7 +21,7 @@
       </div>
       <div class="column col-sm-6 col-4">
         <p><%= return_item.item.name %></p>
-        <p><%= full_item_number(return_item.item) %></p>
+        <p><%= link_to full_item_number(return_item.item), full_item_number(return_item.item) %></p>
       </div>
       <div class="column col-sm-12 col-4 text-right">
         <%= button_to "Check-in", admin_appointment_checkins_path(@appointment, loan_ids: [return_item.id]), class: "btn btn-primary", data: { disable_with: "Checking-in..." }, disabled: !return_item.checked_out? %>

--- a/app/views/admin/appointments/_checkouts.html.erb
+++ b/app/views/admin/appointments/_checkouts.html.erb
@@ -20,7 +20,7 @@
       </div>
       <div class="column col-sm-6 col-4">
         <p><%= pickup_item.item.name %></p>
-        <p><%= full_item_number(pickup_item.item) %></p>
+        <p><%= link_to full_item_number(pickup_item.item), item_path(pickup_item.item) %></p>
       </div>
       <div class="column col-sm-12 col-4 text-right checkout-button-column">
         <%= button_to "Check-out", admin_appointment_checkouts_path(@appointment, hold_ids: [pickup_item.id]), class: "btn btn-primary btn-sm", data: { disable_with: "Checking-out..." }, disabled: !pickup_item.active? || !member.borrow? %>


### PR DESCRIPTION
# What it does

When a librarian views an appointment, the item number is now a hyperlink to the item page.

# Why it is important

See issue #677

# UI Change Screenshot

Before:


After:


Hyperlink leads to this page:
![Uploading Screen Shot 2021-09-25 at 9.46.30 AM.png…]()


# Implementation notes

One note -- do we want to link to the member view or the librarian view? Right now, the link goes to the member view.

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [ X ] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
