### PR TITLE
ci: add github actions for ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,93 @@
+name: CI
+on:
+  pull_request:
+    types: [opened, synchronize]
+  workflow_dispatch:
+
+env:
+  RAILS_ENV: test
+  CI: "true"
+  RUBYOPT: "-W0"
+  SECRET_KEY_BASE: "secret_key_base"
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    strategy:
+      matrix:
+        test: [test, system]
+        include:
+          - test: test
+            command: test
+          - test: system
+            command: test:system
+
+    services:
+      postgres:
+        image: postgres:11
+        env:
+          POSTGRES_HOST: localhost
+          POSTGRES_USER: postgres
+          POSTGRES_DB: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - uses: nanasess/setup-chromedriver@master
+        if: matrix.test == 'system'
+
+      - uses: actions/setup-node@v2.4.1
+        with:
+          node-version: 14.x
+
+      - uses: actions/cache@v2
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - run: yarn install --frozen-lockfile
+
+      - run: bin/rails webpacker:compile
+
+      - name: Setup database
+        env:
+          PGHOST: localhost
+          PGUSER: postgres
+          PGPASSWORD: postgres
+          PGPORT: ${{ job.services.postgres.ports[5432] }}
+        run: |
+          bundle exec rake db:test:prepare
+
+      - name: Run tests
+        env:
+          PGHOST: localhost
+          PGUSER: postgres
+          PGPASSWORD: postgres
+          PGPORT: ${{ job.services.postgres.ports[5432] }}
+        run: |
+          bundle exec rails ${{ matrix.command }}
+
+      - uses: actions/upload-artifact@v2
+        if: matrix.test == 'system'
+        with:
+          path: tmp/screenshots
+          name: test-screenshots
+
+      - uses: actions/upload-artifact@v2
+        if: matrix.test == 'system'
+        with:
+          path: test/reports
+          name: test-reports


### PR DESCRIPTION
# What it does

Adds a GitHub Actions workflow for running tests. We could also add linting in here if you want to double check in addition to the pre-commit hooks.

# Why it is important

#747 

# Implementation notes

* Not 100% sure this will work immediately, but the overall setup should be right.
* We don't necessarily need the artifacts piece at the end, but I was trying to match CircleCI as much as possible
* I didn't install imagemagick or other libraries here, so it'll be worth seeing which ones are potentially pre-installed

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
