### PR TITLE
fix: use attribute to find day in shift system test

### DIFF
--- a/app/lib/volunteer/day.rb
+++ b/app/lib/volunteer/day.rb
@@ -11,6 +11,10 @@ module Volunteer
       @date.day
     end
 
+    def date
+      @date.to_date
+    end
+
     def today?
       @today == @date
     end

--- a/app/views/volunteer/shifts/_month_calendar.html.erb
+++ b/app/views/volunteer/shifts/_month_calendar.html.erb
@@ -16,7 +16,7 @@
 
     <div class="calendar-body">
       <% month_calendar.each_day do |day| %>
-        <div class="calendar-date <%= calendar_day_class(day) %>">
+        <div class="calendar-date <%= calendar_day_class(day) %>" data-test-date="<%= day.date.to_s %>">
           <span class="date-item <%= calendar_date_item_class(day) %>" <%= "disabled" unless day.events? %>><%= day.number %></span>
           <div class="calendar-events">
             <% day.each_shift do |shift| %>

--- a/test/system/volunteer/shifts_test.rb
+++ b/test/system/volunteer/shifts_test.rb
@@ -46,10 +46,7 @@ module Volunteer
     end
 
     def within_day(date, &block)
-      month = find(".calendar", text: date.strftime("%B"))
-      within(month) do
-        within(find(".calendar-date", text: date.mday), &block)
-      end
+      within(find(".calendar-date[data-test-date='#{date.to_date}']"), &block)
     end
   end
 end


### PR DESCRIPTION
# What it does

This fixes a system test that was very sensitive to the current day. It replaces naive text matching with a `data-test-date` attribute, which should insulate this test from timezone and other temporal shenanigans in the future.

# Why it is important

We have a broken test on the main branch.