### PR TITLE
Disable parallel workers in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ env:
   CI: "true"
   RUBYOPT: "-W0"
   SECRET_KEY_BASE: "secret_key_base"
+  PARALLEL_WORKERS: 1
 
 jobs:
   test:


### PR DESCRIPTION
There has been an ongoing issue with the system tests that this might fix.

# What it does

Sets an environment variable that prevents more than one worker from running tests at a time. This will likely slow the build a little, but we don't have that many tests and stability is far more important than speed. We can invest time in removing this workaround in the future if needed.