### PR TITLE
chore: Add run-scripts GitHub actions workflow job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,17 @@ jobs:
         bundler-cache: true
 
     - name: Run bin/setup script
+      env:
+        PGHOST: localhost
+        PGUSER: postgres
+        PGPASSWORD: postgres
+        PGPORT: ${{ job.services.postgres.ports[5432] }}
       run: ./bin/setup
 
     - name: Run bin/reset script
+      env:
+        PGHOST: localhost
+        PGUSER: postgres
+        PGPASSWORD: postgres
+        PGPORT: ${{ job.services.postgres.ports[5432] }}
       run: ./bin/reset


### PR DESCRIPTION
# What it does

Runs the `bin/setup` and `bin/reset` scripts in the GitHub actions CI as a new job in the on pull request workflow.

# Why it is important

Closes #786.

# UI Change Screenshot

N/A

# Implementation notes

There is some duplication across steps, as well as across the `test` and `run-scripts` jobs. Would it be better to find a way to set these duplicate configurations at a higher level?

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
