### PR TITLE
fix: Pre-accept font license for MS font install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,11 +49,10 @@ jobs:
         if: matrix.test == 'system'
 
       - name: Setup fonts
-        if: matrix.test == 'system'
         run: |
           sudo apt-get update -y
           echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
-          sudo apt-get install ttf-mscorefonts-installer
+          sudo apt-get install gsfonts
           sudo fc-cache -f -v
 
       - uses: actions/setup-node@v2.4.1


### PR DESCRIPTION
# What it does

This PR is an attempt to fix the font warning that is appearing in all GitHub Actions builds:

```
convert-im6.q16: unable to read font `helvetica' @ error/annotate.c/RenderFreetype/1338.
convert-im6.q16: non-conforming drawing primitive definition `text' @ error/draw.c/RenderMVGContent/4300.
convert-im6.q16: unable to read font `helvetica' @ error/annotate.c/RenderFreetype/1338.
convert-im6.q16: non-conforming drawing primitive definition `text' @ error/draw.c/RenderMVGContent/4300.
```

My suspicion is that the license isn't being accepted and therefore the fonts aren't actually being installed. If this doesn't work, we might try installing `gsfonts` which will provide a virtual font instead of a real copy of Helvetica.

Edit: I ended up going with `gsfonts` as the other approach didn't fix the issue.
