### PR TITLE
add renewal copy to item email summary

### DIFF
--- a/app/views/member_mailer/summary.mjml
+++ b/app/views/member_mailer/summary.mjml
@@ -23,6 +23,10 @@
           Need to return or pick-up tools?
           <a href="https://app.chicagotoollibrary.org/account/appointments/new">Schedule a time here!</a>
         </strong></p>
+        <p><strong>
+          Request a renewal for your tools or schedule a drop-off 
+          <a href="https://app.chicagotoollibrary.org/account">here.</a>
+        </strong></p>
       </div>
     </mj-text>
   </mj-column>

--- a/app/views/member_mailer/summary.text.erb
+++ b/app/views/member_mailer/summary.text.erb
@@ -4,6 +4,8 @@
 
 Need to return or pick-up tools? Schedule a time here: https://app.chicagotoollibrary.org/account/appointments/new
 
+Request a renewal for your tools or schedule a drop-off here: https://app.chicagotoollibrary.org/account
+
 We are open *by appointment only* in response to COVID-19. Please check our COVID-19 page for more information and our current hours: https://chicagotoollibrary.org/covid-19
 
 If you have any questions, please email us at team@chicagotoollibrary.org.


### PR DESCRIPTION
# What it does

Adds the following copy to the summary mailer partials:

Request a renewal for your tools or schedule a drop-off here

Where "here" is a link to /account.

# Why it is important

See issue #695 

# UI Change Screenshot

<img width="568" alt="Screen Shot 2021-10-17 at 2 17 42 PM" src="https://user-images.githubusercontent.com/37967627/137639848-248f89d5-0270-4d74-ac88-b480f5a36ed1.png">
<img width="940" alt="Screen Shot 2021-10-17 at 2 18 17 PM" src="https://user-images.githubusercontent.com/37967627/137639871-96b847e9-37ff-4257-b30a-85687f8a234d.png">

# Implementation notes
N/A

# Your bandwidth for additional changes to this PR

- [ X ] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
