### PR TITLE
Neon update improvements

### DIFF
--- a/app/lib/neon.rb
+++ b/app/lib/neon.rb
@@ -23,20 +23,7 @@ module Neon
           "firstName" => member.full_name.split[0],
           "lastName" => member.full_name.split[1..].join(" "),
           "preferredName" => member.preferred_name,
-          "email1" => member.email,
-          "addresses" => [
-            {"addressLine1" => member.address1,
-             "addressLine2" => member.address2,
-             "city" => member.city,
-             "stateProvince" => {
-               "code" => member.region,
-               "name" => "Illinois"
-             },
-             "type" => {
-               "id" => "1",
-               "name" => "Home"
-             }}
-          ]
+          "email1" => member.email
         },
         "accountCustomFields" => [
           {"id" => "77", "name" => "Member number", "value" => member.number.to_s},
@@ -47,6 +34,20 @@ module Neon
     }
   end
 
+  def self.member_to_address(member)
+    {"addressLine1" => member.address1,
+     "addressLine2" => member.address2,
+     "city" => member.city,
+     "stateProvince" => {
+       "code" => member.region,
+       "name" => "Illinois"
+     },
+     "type" => {
+       "id" => "0",
+       "name" => "Home"
+     }}
+  end
+
   def self.boolean_to_yes_no(value)
     value ? "Yes" : "No"
   end
@@ -54,16 +55,15 @@ module Neon
   class Client
     BASE_URL = "https://api.neoncrm.com/v2"
 
+    # [{"code"=>"13", "message"=>"Api key is invalid."}] is returned
+    # when requests fail to auth successfully
+
     def initialize(organization_id, api_key)
       @organization_id = organization_id
       @api_key = api_key
 
       logger = Logger.new($stdout)
       @http = HTTP.use(logging: {logger: logger})
-    end
-
-    def get(path)
-      @http.basic_auth(user: @organization_id, pass: @api_key).get(BASE_URL + path)
     end
 
     def new_request
@@ -100,14 +100,35 @@ module Neon
 
       data = response.parse
 
-      id = data["searchResults"][0]["Account ID"]
+      matching_account = data["searchResults"][0]
 
+      return nil unless matching_account
+
+      id = matching_account["Account ID"]
       get_account(id)
     end
 
     def update_account(id, payload)
       response = new_request.patch("#{BASE_URL}/accounts/#{id}", json: payload)
       response.parse
+    end
+
+    def update_account_with_member(member)
+      account = search_account(member.email)
+
+      if account
+        Rails.logger.info "Updating Neon account for member #{member.email}"
+
+        account_payload = account.deep_merge(Neon.member_to_account(member))
+
+        # Merge the address attributes separately, otherwise the array is simply
+        # overwritten and the address ID and other values are lost
+        account_payload["individualAccount"]["primaryContact"]["addresses"][0].deep_merge!(Neon.member_to_address(member))
+
+        update_account(account["individualAccount"]["accountId"], account_payload)
+      else
+        Rails.logger.info "No Neon account found for member #{member.email}"
+      end
     end
   end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -114,6 +114,7 @@ class Member < ApplicationRecord
   def update_neon_crm
     organization_id, api_key = Neon.credentials_for_library(library)
     client = Neon::Client.new(organization_id, api_key)
+    client.update_account_with_member(self)
   end
 
   def can_update_neon_crm?


### PR DESCRIPTION
# What it does

I did some testing with the new Neon syncing code and ran into a few situations where the address wasn't able to update and that was preventing the entire member from updating.

I ended up moving a little code around so that I could get the address to properly sync more often:

> In order to update and not re-create addresses on the account,
the parameters need to be updated in a way that requires access
to the account payload retrieved from the server. Moving the
updating logic into the Client makes it easier to share this state
between different parts of the operation.

I also added a tenant-specific suffix to the environment variables we're using to store credentials until we have a better way to handle that.

# Your bandwidth for additional changes to this PR

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [x] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
