### PR TITLE
remove vestigial category record from test

### DIFF
--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -87,7 +87,6 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
 
   test "only displays active items from the category on the items index, when filtering by active items and category" do
     active_item_category = create(:category)
-    create(:category)
     active_item = create(:item, categories: [active_item_category])
     active_item_with_hold = create(:item, status: :active, categories: [active_item_category])
     create(:hold, item: active_item_with_hold)


### PR DESCRIPTION
 I meant to include [this removal in PR #813](https://github.com/rubyforgood/circulate/pull/813#discussion_r732217993), but got excited with merging

# What it does

All of the assertions in this test are scoped to items in a specific category.

# Why it is important

The presence of a second unnamed category is not required to test the scoping and its presence in the spec could confuse future readers. (It confused me at least!)

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- I am interested in feedback but don't need to make the changes myself.
- I don't have time or interest in making additional changes to this work.
- Other or not sure (please describe):
