### PR TITLE
feat: create job for async neon crm updates

### DIFF
--- a/app/jobs/neon_member_job.rb
+++ b/app/jobs/neon_member_job.rb
@@ -1,0 +1,10 @@
+class NeonMemberJob < ApplicationJob
+  include SuckerPunch::Job
+
+  def perform(member_id)
+    member = Member.find(member_id)
+    organization_id, api_key = Neon.credentials_for_library(member.library)
+    client = Neon::Client.new(organization_id, api_key)
+    client.update_account_with_member(member)
+  end
+end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -112,9 +112,7 @@ class Member < ApplicationRecord
   end
 
   def update_neon_crm
-    organization_id, api_key = Neon.credentials_for_library(library)
-    client = Neon::Client.new(organization_id, api_key)
-    client.update_account_with_member(self)
+    NeonMemberJob.perform_async(id)
   end
 
   def can_update_neon_crm?

--- a/test/models/member_test.rb
+++ b/test/models/member_test.rb
@@ -175,4 +175,15 @@ class MemberTest < ActiveSupport::TestCase
 
     assert_nil member.last_membership
   end
+
+  test "schedules a job for updating Neon membership when enabled" do
+    member = create(:member)
+
+    NeonMemberJob.stub :perform_async, true do
+      member.stub :can_update_neon_crm?, true do
+        member.update(city: "#{member.city} Test")
+        assert_send([NeonMemberJob, :perform_async])
+      end
+    end
+  end
 end

--- a/test/models/member_test.rb
+++ b/test/models/member_test.rb
@@ -187,6 +187,6 @@ class MemberTest < ActiveSupport::TestCase
       end
     end
 
-    assert mock
+    assert_mock mock
   end
 end

--- a/test/models/member_test.rb
+++ b/test/models/member_test.rb
@@ -178,12 +178,15 @@ class MemberTest < ActiveSupport::TestCase
 
   test "schedules a job for updating Neon membership when enabled" do
     member = create(:member)
+    mock = Minitest::Mock.new
+    mock.expect :call, true, [Integer]
 
-    NeonMemberJob.stub :perform_async, true do
+    NeonMemberJob.stub :perform_async, mock do
       member.stub :can_update_neon_crm?, true do
         member.update(city: "#{member.city} Test")
-        assert_send([NeonMemberJob, :perform_async])
       end
     end
+
+    assert mock
   end
 end


### PR DESCRIPTION
# What it does

Creates a new job for running the Neon CRM sync in the background

# Why it is important

https://github.com/rubyforgood/circulate/pull/789/files#r735003294

# Implementation notes

* It looks like `sucker_punch` is a pretty standard implementation of ActiveJob, but I might have missed something

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
