### PR TITLE
Fix link to code of conduct from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ## Contributing
 
-We ♥ contributors! By participating in this project, you agree to abide by our [code of conduct](./CODE_OF_CONDUCT).
+We ♥ contributors! By participating in this project, you agree to abide by our [code of conduct](./CODE_OF_CONDUCT.md).
 
 If you're unsure about an issue or have any questions or concerns, just ask in an *existing issue* or *open a new issue*. If you would like to talk to other contributors and get more context about the project before jumping in, you can request to join [RubyForGood Slack](https://rubyforgood.herokuapp.com/). Once you are in Slack, come by `#circulate` channel, introduce yourself, and ask us questions!
 


### PR DESCRIPTION
# What it does

This fixes a broken link to the Code of Conduct in the first line of `CONTRIBUTING.md`. The link is currently missing the `.md` extension, so it results in a 404.

Broken: https://github.com/rubyforgood/circulate/blob/c363c461f737ee5d24756cc634a61cbb4d36641c/CONTRIBUTING.md
Fixed: https://github.com/AlanGabbianelli/circulate/blob/2768a618b7caf78b0ad2650b9830b88ed92d167e/CONTRIBUTING.md

# Why it is important

Without this fix, potential contributors can miss the Code of Conduct.

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
