### PR TITLE
Use correct email address in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Open an internet browser, type `localhost:3000`, and hit enter. You should see t
 
 After you have the application running, here are some places to explore:
 
-1. Sign in to [the admin interface](http://localhost:3000/admin/items) using `admin@chicagotoollibrary.org` as the username and `password` as the password. (Please note, this is very rare, and only for the purposes of building at this moment. Please do not share your password on GitHub files!)
+1. Sign in to [the admin interface](http://localhost:3000/admin/items) using `admin@example.com` as the username and `password` as the password. (Please note, this is very rare, and only for the purposes of building at this moment. Please do not share your password on GitHub files!)
 2. Complete the [new member signup flow](http://localhost:3000/signup).
 
 ### Multi-tenancy


### PR DESCRIPTION
# What it does
This changes the email address referenced in the readme to use one that is present in the database after running the setup: `admin@chicagotoollibrary.org` isn't present in `db/seeds.rb` so isn't automatically created, whereas `admin@example.com` is.

# Why it is important

It can be confusing to new contributors.

# Video demonstration


https://user-images.githubusercontent.com/14851208/138950353-8f4c1689-001e-43a8-8041-627feaec0800.mov



# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
