### PR TITLE
Improve error message on admissible postal codes

### DIFF
--- a/app/models/library.rb
+++ b/app/models/library.rb
@@ -18,6 +18,13 @@ class Library < ApplicationRecord
     /#{member_postal_code_pattern}/ =~ postal_code.to_s
   end
 
+  def admissible_postal_codes
+    member_postal_code_pattern
+      .delete("^")
+      .split("|")
+      .map { |postal_code| postal_code.ljust(5, "x") }
+  end
+
   private
 
   def create_docs

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -138,7 +138,7 @@ class Member < ApplicationRecord
     return unless library && postal_code.present?
 
     unless library.allows_postal_code?(postal_code)
-      errors.add :postal_code, "must be admissible in #{library.name}"
+      errors.add :postal_code, "must be one of: #{library.admissible_postal_codes.join(", ")}"
     end
   end
 end

--- a/test/models/library_test.rb
+++ b/test/models/library_test.rb
@@ -37,4 +37,16 @@ class LibraryTest < ActiveSupport::TestCase
     assert library.allows_postal_code?("19011")
     assert library.allows_postal_code?("90310")
   end
+
+  test "#admissible_postal_codes returns list of admissible postal codes" do
+    library = build(:library, member_postal_code_pattern: "12345|67890")
+
+    assert_equal %w[12345 67890], library.admissible_postal_codes
+  end
+
+  test "#admissible_postal_codes pads results with the letter x if needed" do
+    library = build(:library, member_postal_code_pattern: "00000|^1111|^222|^33|^4")
+
+    assert_equal %w[00000 1111x 222xx 33xxx 4xxxx], library.admissible_postal_codes
+  end
 end

--- a/test/models/member_test.rb
+++ b/test/models/member_test.rb
@@ -60,7 +60,8 @@ class MemberTest < ActiveSupport::TestCase
       member.postal_code = "90210"
       assert member.invalid?
       assert member.errors.messages.include?(:postal_code)
-      assert member.errors.messages[:postal_code].include?("must be admissible in #{library.name}")
+      error_message = "must be one of: 60707, 60827, 606xx"
+      assert member.errors.messages[:postal_code].include?(error_message)
     end
   end
 


### PR DESCRIPTION
# What it does

This clarifies the error message on admissible postal codes by displaying the list of postal codes that are accepted.

If all postal codes starting with a specific sequence are allowed, the letter "x" is used to signify "any digit". For example, ^123 will result in 123xx.

# Why it is important

While following the setup instructions, I started the new member signup flow, and found myself stuck because I didn't know what postal code I could use.

Using a random 5 digit sequence resulted in an error message that only said "must be admissible in Chicago Tool Library". I had no idea what postal codes were admissible so I searched for Chicago postal codes online. Unfortunately, even using some of the real Chicago postal codes, I got the same error.

To finish the signup flow, I had to read the code and find the validation to see what postal codes can be used.

This isn't ideal because new contributors, as well as users, can be put off by unclear error messages, and decide to abandon the signup flow.

# UI Change Videos

## Before

https://user-images.githubusercontent.com/14851208/138975146-6def0f2f-5f9a-4d5e-bb08-998c4af584c8.mov

## After

https://user-images.githubusercontent.com/14851208/138975234-59ee93a3-6fad-4817-84bd-d572eb54f1b1.mov

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
