### PR TITLE
Clarify info on hosts file & add urls to visit

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,14 +160,16 @@ denver.circulate.local
 
 Users are not currently shared between libraries; check `db/seeds.rb` for the full set of users as whom you can login to each of these libraries.
 
-In order to access libraries other than the first one on your local machine, add the following to your hosts file:
+In order to access libraries other than the first one on your local machine, you need to edit your hosts file.
+This file is located at `/etc/hosts` on macOS and Linux, and `C:\Windows\System32\drivers\etc` on Windows or under WSL (Windows Subsystem for Linux).
+Add the following lines to the file:
 
 ```
 127.0.0.1 chicago.circulate.local
-127.0.0.1	denver.circulate.local
+127.0.0.1 denver.circulate.local
 ```
 
-This file is located at `/etc/hosts` on macOS and Linux and `C:\Windows\System32\drivers\etc` on Windows or under WSL.
+You can now access these libraries at http://chicago.circulate.local:3000 and http://denver.circulate.local:3000.
 
 You will need to add additional lines to your hosts file if you need to work with additional libraries locally.
 


### PR DESCRIPTION
# What it does

This clarifies the multi-tenancy section on how to edit the hosts file to add two libraries and point both to localhost.

More importantly, it adds a short sentence with links to access these two libraries locally.

# Why it is important

It wasn't clear that the new urls still needed the port to work. With direct links that include the port, new contributors that might not know it was needed won't have problems accessing the two libraries.

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
