### PR TITLE
Update dockerfile to explictly add node-gyp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ RUN apk add --update --no-cache --virtual .ms-fonts msttcorefonts-installer && \
  fc-cache -f && \
  apk del .ms-fonts
 
+RUN yarn global add node-gyp
 RUN yarn global add heroku
 
 RUN adduser --disabled-password --gecos '' --uid $USER_ID user


### PR DESCRIPTION
# What it does
This may be a known issue or have an undocumented workaround but in following along with `DOCKER.md` and running `docker_build.sh`, I was seeing a non-zero exit status with the following output:
```
Step 17/25 : RUN yarn global add heroku
 ---> Running in ae2440267056                                                                     
yarn global v1.22.10                                
[1/4] Resolving packages...                                                                                          
warning heroku > debug@4.1.1: Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)
warning heroku > @heroku-cli/plugin-git > debug@4.1.1: Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)
warning heroku > uuid@3.3.2: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
warning heroku > @heroku-cli/plugin-pg-v5 > strip-eof@2.0.0: Renamed to `strip-final-newline` to better represent its functionality.
warning heroku > @heroku-cli/plugin-ps-exec > heroku-exec-util > uuid@3.2.1: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
[2/4] Fetching packages...                                                                                                                                                                                                                                                                                                                                                                                                                                                           
[3/4] Linking dependencies...           
[4/4] Building fresh packages...       
info This package requires node-gyp, which is not currently installed. Yarn will attempt to automatically install it. If this fails, you can run "yarn global add node-gyp" to manually install it.                                       
[1/4] Resolving packages...                                    
[2/4] Fetching packages...     
[3/4] Linking dependencies...                                                                                                                                                                                                             
[4/4] Building fresh packages...                               
success Installed "node-gyp@8.3.0" with binaries:                                                 
      - node-gyp                                                                                                                                                                                                                          
info This module is OPTIONAL, you can safely ignore this error
warning Error running install script for optional dependency: "/usr/local/share/.config/yarn/global/node_modules/cpu-features: Couldn't find the binary node-gyp rebuild"
info Visit https://yarnpkg.com/en/docs/cli/global for documentation about this command.
error /usr/local/share/.config/yarn/global/node_modules/tunnel-ssh/node_modules/ssh2: Couldn't find the binary node install.js
ERROR: Service 'web' failed to build: The command '/bin/sh -c yarn global add heroku' returned a non-zero code: 1
```

It looks like explicitly updating the `Dockerfile` to add this `node-gyp` dependency fixes this error.

# Why it is important
It's nice to meet developers where they are at. Fixing this script ensure that developers can choose to develop dockerized or not :tada: 

# UI Change Screenshot
Not applicable

# Implementation notes
I was able to find others talking about similar issues that required doing a `yarn global add node-gyp` -- [this issue](https://github.com/yarnpkg/yarn/issues/3728) is a nice inroad into lots of similar complaints. I'd personally like to understand the root of this a bit more. There was some talk about this being a concurrency problem but adding `CHILD_CONCURRENCY=1` to the `yarn global add heroku` produced the same error state. Since following the suggestion of the command output itself fixes this, I'm willing to just close my eyes and move on. Very happy to take feedback that this needs more investigation.

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
