### PR TITLE
Remove Loan#within_borrow_policy_duration method

### DIFF
--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -92,12 +92,12 @@ class Loan < ApplicationRecord
 
   # Can a member renew this loan themselves without approval?
   def member_renewable?
-    renewable? && within_borrow_policy_duration? && item.borrow_policy.member_renewable? && ended_at.nil?
+    renewable? && item.borrow_policy.member_renewable? && ended_at.nil?
   end
 
   # Can a member request this loan be renewed?
   def member_renewal_requestable?
-    renewable? && within_borrow_policy_duration? && ended_at.nil? && !any_active_holds? && !renewal_requests.any?
+    renewable? && ended_at.nil? && !any_active_holds? && !renewal_requests.rejected.any?
   end
 
   # Does the item have any active holds?
@@ -105,13 +105,8 @@ class Loan < ApplicationRecord
     item.active_holds.any?
   end
 
-  # Is it after the loan was created? This method is basically a no-op and can likely be removed.
-  def within_borrow_policy_duration?
-    due_at - Time.current <= item.borrow_policy.duration.days
-  end
-
   def status
-    if due_at < Time.now
+    if due_at < Time.current
       "overdue"
     else
       "checked-out"

--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -97,7 +97,7 @@ class Loan < ApplicationRecord
 
   # Can a member request this loan be renewed?
   def member_renewal_requestable?
-    renewable? && ended_at.nil? && !any_active_holds? && !renewal_requests.rejected.any?
+    renewable? && ended_at.nil? && !any_active_holds? && !renewal_requests.any?
   end
 
   # Does the item have any active holds?

--- a/app/views/account/home/index.html.erb
+++ b/app/views/account/home/index.html.erb
@@ -43,7 +43,7 @@
                   <% else %>
                     Renewal requested
                   <% end %>
-                <% elsif !loan.within_borrow_policy_duration? && loan.renewal? %>
+                <% elsif loan.renewal? %>
                   Renewed
                 <% elsif loan.member_renewable? %>
                   <span class="message">You can renew this loan without librarian approval if you need it for more time.</span> <%= button_to 'Renew Loan', account_renewals_path(loan_id: loan), method: :post, class: "btn" %>

--- a/test/models/loan_test.rb
+++ b/test/models/loan_test.rb
@@ -161,35 +161,27 @@ class LoanTest < ActiveSupport::TestCase
     refute loan.member_renewable?
   end
 
-  test "is not member_renewable if not within original loan duration" do
+  test "is not member_renewable if loan has end date" do
     borrow_policy = create(:member_renewable_borrow_policy)
     item = create(:item, borrow_policy: borrow_policy)
-    loan = create(:loan, item: item, due_at: (borrow_policy.duration + 1).days.from_now)
-
-    refute loan.member_renewable?
-  end
-
-  test "is not member_renewable if loan has end date" do
-    borrow_policy = build(:member_renewable_borrow_policy)
-    item = build(:item, borrow_policy: borrow_policy)
-    loan = build(:loan, item: item, ended_at: Time.current)
+    loan = create(:loan, item: item, created_at: Time.current, ended_at: Time.current)
 
     refute loan.member_renewable?
   end
 
   test "is member_renewal_requestable without a renewable borrow policy" do
-    borrow_policy = build(:borrow_policy, member_renewable: false)
-    item = build(:item, borrow_policy: borrow_policy)
-    loan = build(:loan, item: item)
+    borrow_policy = create(:borrow_policy, member_renewable: false)
+    item = create(:item, borrow_policy: borrow_policy)
+    loan = create(:loan, item: item)
 
     assert loan.member_renewal_requestable?
   end
 
   test "is member_renewal_requestable if there is a previous approved renewal request" do
-    borrow_policy = build(:borrow_policy, member_renewable: false)
-    item = build(:item, borrow_policy: borrow_policy)
-    loan = build(:loan, item: item)
-    build(:renewal_request, loan: loan, status: RenewalRequest.statuses[:approved])
+    borrow_policy = create(:borrow_policy, member_renewable: false)
+    item = create(:item, borrow_policy: borrow_policy)
+    loan = create(:loan, item: item)
+    create(:renewal_request, loan: loan, status: RenewalRequest.statuses[:approved])
 
     assert loan.member_renewal_requestable?
   end

--- a/test/models/loan_test.rb
+++ b/test/models/loan_test.rb
@@ -177,15 +177,6 @@ class LoanTest < ActiveSupport::TestCase
     assert loan.member_renewal_requestable?
   end
 
-  test "is member_renewal_requestable if there is a previous approved renewal request" do
-    borrow_policy = create(:borrow_policy, member_renewable: false)
-    item = create(:item, borrow_policy: borrow_policy)
-    loan = create(:loan, item: item)
-    create(:renewal_request, loan: loan, status: RenewalRequest.statuses[:approved])
-
-    assert loan.member_renewal_requestable?
-  end
-
   test "is not member_renewal_requestable if there are active holds" do
     borrow_policy = create(:borrow_policy, member_renewable: false)
     item = create(:item, borrow_policy: borrow_policy)


### PR DESCRIPTION
This method had a reference to `Time.current` that was causing tests to break when loans straddled a daylight savings time change and was additionally really difficult to reason about. There was a comment mentioning that it could be removed, so I went ahead and did that.

It's possible that this will make renewals more open than we wish, but we can lock things back down when we identify the situation where that is relevant.

