### PR TITLE
configure Pagy to return last page on overflow

### DIFF
--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,2 +1,5 @@
 require "pagy/extras/bootstrap"
 require "pagy/extras/arel"
+require "pagy/extras/overflow"
+
+Pagy::DEFAULT[:overflow] = :last_page


### PR DESCRIPTION
# What it does

By default, Pagy throws an exception when given a page parameter greater than the number of pages available in a result. This change adds in [Pagy's Overflow extra](https://ddnexus.github.io/pagy/extras/overflow) (included in the gem already) and configures overflow to return the last page of results when page param is too large (in other words, when page overflows).

# Why it is important

Closes #850, addressing an unhandled exception when a request is received with a page parameter that's too high.

# Implementation notes

This is probably the simplest fix for quieting the unhandled exception.

While the only "user" experiencing this error is a web crawler, returning the last page of results (say, page 10) when ever a page param is given that overflows (say, page 11 or 100, or 1,000,000) implies at the protocol level of HTTP that the last page of results is the valid collection of resources at the actually-erroneous URL with the overflowing page param. This probably isn't a huge issue because the library is predominantly focused on a web UI and does not provide API-only access to things. Noting this behavior here in case of future API considerations.

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- ✔️ I have the time and interest to make additional changes to this PR based on feedback.
- ~I am interested in feedback but don't need to make the changes myself.~
- ~I don't have time or interest in making additional changes to this work.~
- ~Other or not sure (please describe):~
