### PR TITLE
feat: Add inventory page titles

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@ require "active_support/testing/time_helpers"
 class ApplicationController < ActionController::Base
   include Pundit
   include ActiveSupport::Testing::TimeHelpers
+  include PageAttributes
 
   set_current_tenant_through_filter
   before_action :set_tenant

--- a/app/controllers/concerns/page_attributes.rb
+++ b/app/controllers/concerns/page_attributes.rb
@@ -1,0 +1,27 @@
+# PageAttributes provides a consise API for declaring bits of page metadata
+# within controller methods, stored as a Hash on the controller instance.
+#
+# These values can be retrieved in views using the same method.
+module PageAttributes
+  def self.included(base)
+    base.helper_method :page_attr
+    base.helper_method :page_attr?
+  end
+
+  private
+
+  def set_page_attr(key, value)
+    @page_attributes ||= {}
+    @page_attributes[key] = value
+    value
+  end
+
+  def page_attr(key)
+    @page_attributes ||= {}
+    @page_attributes[key]
+  end
+
+  def page_attr?(key)
+    @page_attributes&.has_key?(key)
+  end
+end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,6 +9,7 @@ class ItemsController < ApplicationController
       redirect_to(items_path, error: "Category not found") && return unless @category
 
       item_scope = @category.items.listed_publicly.distinct
+      set_page_attr :title, @category.name
     end
 
     item_scope = item_scope.includes(:categories, :borrow_policy, :active_holds).with_attached_image.order(index_order)
@@ -19,6 +20,8 @@ class ItemsController < ApplicationController
 
   def show
     @item = Item.listed_publicly.find(params[:id])
+
+    set_page_attr :title, "#{@item.name} (#{@item.complete_number})"
 
     if user_signed_in?
       @current_hold = current_member.active_holds.active.where(item_id: @item.id).first

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -10,5 +10,7 @@ class SearchesController < ApplicationController
       @items = Item.search_by_anything(query).by_name
       @items_by_number = Item.number_contains(query)
     end
+
+    set_page_attr :title, "Search results for #{query}"
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,4 +27,12 @@ module ApplicationHelper
       link_to(text, link, class: "btn btn-link #{options.delete(:class)}", **options)
     end
   end
+
+  def page_title
+    if page_attr?(:title)
+      "#{page_attr(:title)} - #{current_library.name}"
+    else
+      "#{current_library.name} Inventory"
+    end
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>Circulate</title>
+    <title><%= page_title %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">

--- a/test/controllers/concerns/page_attributes_test.rb
+++ b/test/controllers/concerns/page_attributes_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class PageAttributesTest < ActiveSupport::TestCase
+  def self.helper_method(_name)
+  end
+
+  include PageAttributes
+
+  test "sets and retrieves page attributes" do
+    set_page_attr :title, "important things"
+
+    assert_equal "important things", page_attr(:title)
+    assert page_attr?(:title)
+  end
+
+  test "handles attributes that aren't set" do
+    assert_nil page_attr(:title)
+    refute page_attr?(:title)
+  end
+end


### PR DESCRIPTION
# What it does

This PR adds page titles to some of the public inventory pages.

# Why it is important

Titles are crucial for usability and accessibility- otherwise the entries in the browser history are indistinguishable.

# Implementation notes

* I pulled some of the code from an older app I have. It's not open source, but this pattern worked fairly well for that one.

# Screenshots

![image](https://user-images.githubusercontent.com/3331/141047895-16ce2745-fc7c-4f70-a121-ada5e3c3575e.png)
![image](https://user-images.githubusercontent.com/3331/141047912-092f2f2d-18bf-4d16-88f1-b65627f90063.png)


# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
