### PR TITLE
Only list overdue items in the overdue notice emails

### DIFF
--- a/app/lib/activity_notifier.rb
+++ b/app/lib/activity_notifier.rb
@@ -15,7 +15,7 @@ class ActivityNotifier
     members_with_overdue_items = Member.verified.joins(:loans).merge(Loan.checked_out.due_whole_weeks_ago).pluck(:id)
 
     each_member(members_with_overdue_items) do |member, summaries|
-      MemberMailer.with(member: member, summaries: summaries, now: @now).overdue_notice.deliver
+      MemberMailer.with(member: member, summaries: summaries.overdue_as_of(@now.tomorrow.beginning_of_day), now: @now).overdue_notice.deliver
     end
   end
 

--- a/app/mailers/member_mailer.rb
+++ b/app/mailers/member_mailer.rb
@@ -40,7 +40,7 @@ class MemberMailer < ApplicationMailer
   def overdue_notice
     @subject = "You have overdue items!"
     @warning = "Please return all overdue items as soon as possible so other members can check them out."
-    summary_mail
+    summary_mail(template_name: "overdue_notice")
   end
 
   def return_reminder

--- a/app/mailers/member_mailer.rb
+++ b/app/mailers/member_mailer.rb
@@ -86,13 +86,13 @@ class MemberMailer < ApplicationMailer
 
   private
 
-  def summary_mail
+  def summary_mail(template_name: "summary")
     @member = params[:member]
     @library = @member.library
     @summaries = params[:summaries]
     @now = params[:now] || Time.current
 
-    mail(to: @member.email, subject: @subject, template_name: "summary")
+    mail(to: @member.email, subject: @subject, template_name: template_name)
   end
 
   def generate_uuid

--- a/app/views/member_mailer/_overdue.erb
+++ b/app/views/member_mailer/_overdue.erb
@@ -1,0 +1,18 @@
+<p class="overdue"><strong><%= warning %></strong></p>
+
+<ul>
+<% summaries.each do |summary| %>
+  <li>
+    <strong><%= full_item_number(summary.item) %> - <%= summary.item.name %></strong>
+    <span class="overdue">
+      <%= _("was due %{date}") % { date: checked_out_date(summary.due_at) } %>
+    </span>
+    <% if (count = summary.item.holds.active.count) && count > 0 %>
+      <br>
+      <span class="people-waiting">
+        <%= n_("One member is waiting for this item", "%{n} members are waiting for this item", count) % {n: count} %>
+      </span>
+    <% end %>
+  </li>
+<% end %>
+</ul>

--- a/app/views/member_mailer/_summaries.erb
+++ b/app/views/member_mailer/_summaries.erb
@@ -1,7 +1,3 @@
-<% unless warning.blank? %>
-  <p class="overdue"><strong><%= warning %></strong></p>
-<% end %>
-
 <ul>
 <% summaries.each do |summary| %>
   <li>
@@ -18,7 +14,7 @@
         <span class="overdue">
           <%= _("was due %{date}") % { date: checked_out_date(summary.due_at) } %>
         </span>
-      <% else %> 
+      <% else %>
         <% if summary.renewed? # and was active today %>
           <%= _("renewed until") %>
         <% else %>

--- a/app/views/member_mailer/overdue_notice.mjml
+++ b/app/views/member_mailer/overdue_notice.mjml
@@ -1,0 +1,36 @@
+<mj-section>
+  <mj-column padding-top="20px">
+    <mj-image src="<%= asset_pack_url "media/images/logo.jpg" %>" width="100px" />
+  </mj-column>
+</mj-section>
+<mj-section>
+  <mj-column>
+    <mj-text font-size="36px" line-height="28px" font-weight="bold" align="center"><%= @subject %></mj-text>
+  </mj-column>
+</mj-section>
+<mj-section>
+  <mj-column>
+    <mj-text>
+      <%= render partial: "member_mailer/overdue", locals: {summaries: @summaries, warning: @warning, now: @now} %>
+    </mj-text>
+  </mj-column>
+</mj-section>
+<mj-section>
+  <mj-column>
+    <mj-text>
+      <div class="info">
+        <p><strong>
+          You can view more information about the items you have checked out in <%= link_to "your account", account_home_url %>.
+        </strong></p>
+        <p><strong>
+          Need to return or pick-up tools?
+          <a href="https://app.chicagotoollibrary.org/account/appointments/new">Schedule a time here!</a>
+        </strong></p>
+        <p><strong>
+          Request a renewal for your tools or schedule a drop-off
+          <a href="https://app.chicagotoollibrary.org/account">here.</a>
+        </strong></p>
+      </div>
+    </mj-text>
+  </mj-column>
+</mj-section>

--- a/app/views/member_mailer/overdue_notice.text.erb
+++ b/app/views/member_mailer/overdue_notice.text.erb
@@ -1,0 +1,19 @@
+<%= @subject %>
+
+<%= HTMLToMarkdown.new.convert(render(partial: "member_mailer/overdue", locals: {summaries: @summaries, warning: @warning, now: @now})) %>
+
+You can view more information about the items you have checked out in your account: <%= account_home_url %>
+
+Need to return or pick-up tools? Schedule a time here: https://app.chicagotoollibrary.org/account/appointments/new
+
+Request a renewal for your tools or schedule a drop-off here: https://app.chicagotoollibrary.org/account
+
+We are open *by appointment only* in response to COVID-19. Please check our COVID-19 page for more information and our current hours: https://chicagotoollibrary.org/covid-19
+
+If you have any questions, please email us at team@chicagotoollibrary.org.
+
+See you at the library!
+
+---
+
+<%= @library.address %>

--- a/app/views/member_mailer/summary.mjml
+++ b/app/views/member_mailer/summary.mjml
@@ -11,7 +11,7 @@
 <mj-section>
   <mj-column>
     <mj-text>
-      <%= render partial: "member_mailer/summaries", locals: {summaries: @summaries, warning: @warning, now: @now} %>
+      <%= render partial: "member_mailer/summaries", locals: {summaries: @summaries, now: @now} %>
     </mj-text>
   </mj-column>
 </mj-section>
@@ -24,7 +24,7 @@
           <a href="https://app.chicagotoollibrary.org/account/appointments/new">Schedule a time here!</a>
         </strong></p>
         <p><strong>
-          Request a renewal for your tools or schedule a drop-off 
+          Request a renewal for your tools or schedule a drop-off
           <a href="https://app.chicagotoollibrary.org/account">here.</a>
         </strong></p>
       </div>

--- a/app/views/member_mailer/summary.text.erb
+++ b/app/views/member_mailer/summary.text.erb
@@ -1,6 +1,6 @@
 <%= @subject %>
 
-<%= HTMLToMarkdown.new.convert(render(partial: "member_mailer/summaries", locals: {summaries: @summaries, warning: @warning, now: @now})) %>
+<%= HTMLToMarkdown.new.convert(render(partial: "member_mailer/summaries", locals: {summaries: @summaries, now: @now})) %>
 
 Need to return or pick-up tools? Schedule a time here: https://app.chicagotoollibrary.org/account/appointments/new
 

--- a/test/lib/activity_notifier_test.rb
+++ b/test/lib/activity_notifier_test.rb
@@ -86,25 +86,26 @@ class ActivityNotifierTest < ActiveSupport::TestCase
     assert ActionMailer::Base.deliveries.empty?
   end
 
-  test "sends emails to folks with overdue items" do
-    loan = Time.use_zone("America/Chicago") {
-      create(:loan, due_at: Time.current.end_of_day, created_at: 1.week.ago)
-    }
-
+  test "sends overdue notice emails only to folks with overdue items" do
     Time.use_zone("America/Chicago") do
-      notifier = ActivityNotifier.new
+      @overdue_loan = create(:loan, due_at: Time.current.end_of_day, created_at: 1.week.ago)
+      @not_overdue_loan = create(:loan, due_at: Time.current.tomorrow.end_of_day, created_at: 6.days.ago)
+
       assert_difference "Notification.count" do
-        notifier.send_overdue_notices
+        ActivityNotifier.new.send_overdue_notices
       end
     end
 
-    refute ActionMailer::Base.deliveries.empty?
+    mails = ActionMailer::Base.deliveries
+    assert_equal 1, mails.count
 
-    assert mail = ActionMailer::Base.deliveries.find { |delivery| delivery.to == [loan.member.email] }
+    mail = mails.first
+    assert_includes mail.to, @overdue_loan.member.email
+    assert_not_includes mail.to, @not_overdue_loan.member.email
 
     assert_equal "You have overdue items!", mail.subject
-    assert_includes mail.encoded, loan.item.complete_number
     assert_includes mail.encoded, "return all overdue items as soon as possible"
+    assert_includes mail.encoded, @overdue_loan.item.complete_number
   end
 
   test "doesn't send overdue notices to folks with returned overdue items" do


### PR DESCRIPTION
# What it does

It changes overdue notice emails to only list overdue items, instead of all items that a member has recently interacted with.

See individual commit messages for more detail.

Fixes #814

# Why it is important

Decluttering overdue notice emails, it makes it clearer for members what items are overdue and need to be returned or renewed.

# UI Change Video

https://user-images.githubusercontent.com/14851208/141201125-66be895f-db30-441d-8c6c-9edbd2d89f64.mov

# Implementation notes

I decided to create new templates specific for the overdue notice emails. Instead of adding logic to the summary email templates, this approach allowed me to remove some conditional logic from there.

# Suggested review approach

This is best reviewed commit by commit as they are self-contained and with explicit commit messages.

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
