### PR TITLE
fix: Select library_id column to prevent tenant scoping from breaking memberships report

### DIFF
--- a/app/controllers/admin/reports/memberships_controller.rb
+++ b/app/controllers/admin/reports/memberships_controller.rb
@@ -9,7 +9,7 @@ module Admin
         members_and_loan_counts = Member
           .open
           .left_joins(:loan_summaries)
-          .select(:id, :email, :status, :full_name, :preferred_name, "count(loan_summaries.initial_loan_id) as loans_count")
+          .select(:id, :email, :status, :full_name, :preferred_name, :library_id, "count(loan_summaries.initial_loan_id) as loans_count")
           .group("members.id", "members.email", "members.status", "members.full_name", "members.preferred_name")
 
         @members = Member

--- a/test/controllers/admin/reports/memberships_controller_test.rb
+++ b/test/controllers/admin/reports/memberships_controller_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+module Admin
+  module Reports
+    class MembershipsControllerTest < ActionDispatch::IntegrationTest
+      include Devise::Test::IntegrationHelpers
+
+      setup do
+        3.times do
+          create(:member)
+        end
+        @user = create(:admin_user)
+        sign_in @user
+      end
+
+      test "should get index" do
+        get admin_reports_memberships_url
+        assert_response :success
+      end
+    end
+  end
+end


### PR DESCRIPTION
# What it does

The tenant-scoping code adds some additional where clauses to queries throughout the system. This report needed to be tweaked so that this auto-scoping worked properly.