### PR TITLE
fix: Correct local variable name to prevent undefined variable error

### DIFF
--- a/app/views/admin/appointments/_checkins.html.erb
+++ b/app/views/admin/appointments/_checkins.html.erb
@@ -21,7 +21,7 @@
       </div>
       <div class="column col-sm-6 col-4">
         <p><%= return_item.item.name %></p>
-        <p><%= link_to full_item_number(pickup_item.item), item_path(pickup_item.item) %></p>
+        <p><%= link_to full_item_number(return_item.item), item_path(return_item.item) %></p>
       </div>
       <div class="column col-sm-12 col-4 text-right">
         <%= button_to "Check-in", admin_appointment_checkins_path(@appointment, loan_ids: [return_item.id]), class: "btn btn-primary", data: { disable_with: "Checking-in..." }, disabled: !return_item.checked_out? %>

--- a/test/controllers/admin/appointments_controller_test.rb
+++ b/test/controllers/admin/appointments_controller_test.rb
@@ -8,8 +8,10 @@ module Admin
       @appointment = FactoryBot.build(:appointment)
       @user = FactoryBot.create(:user)
       @member = FactoryBot.create(:member, user: @user)
-      @hold = FactoryBot.create(:hold, creator: @member.user)
+      @hold = FactoryBot.create(:hold, member: @member)
       @appointment.holds << @hold
+      @loan = create(:loan, member: @member)
+      @appointment.loans << @loan
       @appointment.member = @member
       @appointment.starts_at = "2020-10-05 7:00AM"
       @appointment.ends_at = "2020-10-05 8:00AM"
@@ -37,6 +39,10 @@ module Admin
       @appointment.reload
       assert_equal @appointment.starts_at.to_i, starts_at.to_i
       assert_equal @appointment.ends_at.to_i, ends_at.to_i
+    end
+
+    test "renders show page with items to pickup and drop off" do
+      get admin_appointment_path(@appointment)
     end
   end
 end


### PR DESCRIPTION
# What it does

There was a local variable that was misnamed and causing the appointment page to break when a member was returning an item.