### PR TITLE
fix: show renewal buttons for renewals on account home

### DIFF
--- a/app/views/account/home/index.html.erb
+++ b/app/views/account/home/index.html.erb
@@ -31,6 +31,7 @@
                 </span>
                 <span class="status">
                   <span class=<%= loan.due_at - Time.now < 3.days ? "warning text-bold" : "" %>><%= "Due #{humanize_due_date(loan)}" %></span>
+                  <% if loan.renewal? %>(renewed <%= pluralize(loan.renewal_count, "time")%>)<% end%>
                   <% if @current_library.allow_appointments? %>
                     <span class="pickup"><%= loan_pickup_status(loan) %></span>
                   <% end %>
@@ -43,8 +44,6 @@
                   <% else %>
                     Renewal requested
                   <% end %>
-                <% elsif loan.renewal? %>
-                  Renewed
                 <% elsif loan.member_renewable? %>
                   <span class="message">You can renew this loan without librarian approval if you need it for more time.</span> <%= button_to 'Renew Loan', account_renewals_path(loan_id: loan), method: :post, class: "btn" %>
                 <% elsif loan.member_renewal_requestable? %>


### PR DESCRIPTION
# What it does

There is an issue where we aren't showing the renewal request buttons for loans that are renewals.

# Your bandwidth for additional changes to this PR

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
