### PR TITLE
Holds record and can extend expiration date

### DIFF
--- a/app/controllers/admin/holds_controller.rb
+++ b/app/controllers/admin/holds_controller.rb
@@ -3,7 +3,7 @@ module Admin
     include Pagy::Backend
 
     def index
-      holds_scope = Hold.active
+      holds_scope = Hold.active.includes(:member, item: :borrow_policy).order("expires_at ASC NULLS LAST, created_at ASC")
       @pagy, @holds = pagy(holds_scope, items: 100)
     end
 

--- a/app/controllers/admin/settings/closing_controller.rb
+++ b/app/controllers/admin/settings/closing_controller.rb
@@ -1,0 +1,28 @@
+class Admin::Settings::ClosingController < Admin::BaseController
+  before_action :require_admin
+
+  def index
+    @form = ExtendHoldsForm.new
+    @dates = Hold.next_waiting_hold_dates
+  end
+
+  def extend_holds
+    @form = ExtendHoldsForm.new(form_params)
+    if @form.valid?
+      # Convert naive date into an ActiveSupport::TimeWithZone in the correct timezone
+      end_of_day = @form.date.in_time_zone(Time.zone).end_of_day
+      Hold.extend_started_holds_until(end_of_day)
+
+      redirect_to admin_settings_closing_path, success: "Started holds have been updated."
+    else
+      @dates = Hold.next_waiting_hold_dates
+      render :index
+    end
+  end
+
+  private
+
+  def form_params
+    params.require(:extend_holds_form).permit(:date)
+  end
+end

--- a/app/forms/extend_holds_form.rb
+++ b/app/forms/extend_holds_form.rb
@@ -1,0 +1,27 @@
+class ExtendHoldsForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :date, :date
+
+  # Only to allow for the current time to be stubbed in tests
+  attr_accessor :now
+
+  validate :date_in_near_future
+
+  def earliest_valid_date
+    (now || Date.current).tomorrow
+  end
+
+  def latest_valid_date
+    earliest_valid_date + 1.month
+  end
+
+  private
+
+  def date_in_near_future
+    unless (earliest_valid_date..latest_valid_date).cover?(date)
+      errors.add(:date, "must be a date within the next month")
+    end
+  end
+end

--- a/app/lib/spectre_form_builder.rb
+++ b/app/lib/spectre_form_builder.rb
@@ -130,6 +130,13 @@ class SpectreFormBuilder < ActionView::Helpers::FormBuilder
     ))
   end
 
+  def date_field(method, options = {})
+    options[:class] = "form-input"
+    sequence_layout(method, options) do
+      super method, options
+    end
+  end
+
   def actions(&block)
     @template.content_tag :div, class: "form-buttons" do
       yield
@@ -141,7 +148,7 @@ class SpectreFormBuilder < ActionView::Helpers::FormBuilder
   end
 
   def submit(label = nil, options = {}, &block)
-    parent_button(label, options.merge(type: "submit", class: "btn btn-primary btn-lg btn-block", data: {disable: true}), &block)
+    parent_button(label, options.deep_merge(type: "submit", class: "btn btn-primary btn-lg btn-block", data: {disable: true}), &block)
   end
 
   def errors

--- a/app/models/hold.rb
+++ b/app/models/hold.rb
@@ -99,6 +99,15 @@ class Hold < ApplicationRecord
     member.upcoming_appointment_of(self)
   end
 
+  def self.next_waiting_hold_dates
+    active.started.select("expires_at, count(holds.id)").group("expires_at").order("expires_at ASC")
+      .map { |hold| [hold.expires_at, hold.count] }
+  end
+
+  def self.extend_started_holds_until(date)
+    Hold.active.started.where("expires_at < ?", date).update_all(expires_at: date)
+  end
+
   def self.start_waiting_holds(now = Time.current, &block)
     started = 0
 

--- a/app/models/hold.rb
+++ b/app/models/hold.rb
@@ -9,15 +9,19 @@ class Hold < ApplicationRecord
   belongs_to :creator, class_name: "User"
   belongs_to :loan, required: false
 
-  scope :active, ->(now = Time.current) { where("ended_at IS NULL AND (started_at IS NULL OR started_at >= ?)", now.beginning_of_day - HOLD_LENGTH) }
+  scope :active, ->(now = Time.current) { where("ended_at IS NULL AND (started_at IS NULL OR expires_at >= ?)", now) }
   scope :inactive, ->(now = Time.current) { ended.or(expired(now)) }
   scope :ended, -> { where("ended_at IS NOT NULL") }
-  scope :expired, ->(now = Time.current) { where("started_at < ?", now.beginning_of_day - HOLD_LENGTH) }
+  scope :expired, ->(now = Time.current) { where("expires_at < ?", now) }
   scope :started, -> { where("started_at IS NOT NULL") }
 
   scope :recent_first, -> { order("created_at desc") }
 
   validates :item, presence: true
+  validates :expires_at, presence: {
+    message: "is required when started_at is set"
+  }, if: -> { started_at.present? }
+
   validates_each :item do |record, attr, value|
     if value
       value.reload
@@ -61,17 +65,14 @@ class Hold < ApplicationRecord
 
   def start!(now = Time.current)
     update!(
-      started_at: now
+      started_at: now,
+      expires_at: (now + HOLD_LENGTH).end_of_day
     )
-  end
-
-  def expires_at
-    (started_at + HOLD_LENGTH).end_of_day if started_at.present?
   end
 
   # A hold that timed out
   def expired?(now = Time.current)
-    started_at && expires_at < now
+    started? && expires_at < now
   end
 
   # A hold whose clock has started ticking

--- a/app/views/admin/settings/closing/index.html.erb
+++ b/app/views/admin/settings/closing/index.html.erb
@@ -1,0 +1,27 @@
+<%= content_for :header do %>
+  <%= index_header "Closing" %>
+<% end %>
+
+<h2>Upcoming Hold Expirations</h2>
+
+<div class="columns">
+  <div class="column col-6">
+    <table class="table">
+    <% @dates.each do |(date, count)| %>
+    <tr>
+      <td><%= checked_out_date date %></td>
+      <td><%= count %></td>
+    </tr>
+    <% end %>
+    </table>
+  </div>
+
+  <div class="column col-6">
+    <h3>Extend Holds</h3>
+    <p>Enter the next day that holds should expire. Any holds expiring before that day will be extended to that date.</p>
+    <%= form_with(model: @form, url: admin_settings_closing_extend_holds_url, builder: SpectreFormBuilder) do |form| %>
+      <%= form.date_field :date, min: @form.earliest_valid_date.iso8601, max: @form.latest_valid_date.iso8601 %>
+      <%= form.submit "Extend holds", data: { confirm: "This can't be undone. Click OK to extend holds that expire before the specified date."} %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -61,6 +61,7 @@
               <% if current_user.admin? %>
                 <li class="nav-item"><%= link_to "Users", admin_users_path %></li>
                 <li class="nav-item"><%= link_to "Manage Features", admin_manage_features_path %></li>
+                <li class="nav-item"><%= link_to "closing", admin_settings_closing_path %></li>
               <% end %>
             </ul>
           </li>
@@ -146,6 +147,7 @@
                 <% if current_user.has_role?(:admin) %>
                   <li class="menu-item"><%= link_to "Users", admin_users_path %></li>
                   <li class="menu-item"><%= link_to "Manage Features", admin_manage_features_path %></li>
+                  <li class="menu-item"><%= link_to "Closing", admin_settings_closing_path %></li>
                 <% end %>
                 <% if current_user.has_role?(:super_admin) %>
                   <li class="menu-item"><%= link_to "Libraries", super_admin_libraries_path %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -122,6 +122,7 @@ Rails.application.routes.draw do
 
     namespace :settings do
       get "closing", to: "closing#index"
+      post "closing/extend_holds", to: "closing#extend_holds"
     end
 
     resources :holds, only: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -120,6 +120,10 @@ Rails.application.routes.draw do
       get "money", to: "money#index"
     end
 
+    namespace :settings do
+      get "closing", to: "closing#index"
+    end
+
     resources :holds, only: [:index]
     resources :users
     resources :renewal_requests, only: [:index, :update]

--- a/db/migrate/20211120222110_add_expires_at_to_holds.rb
+++ b/db/migrate/20211120222110_add_expires_at_to_holds.rb
@@ -1,0 +1,5 @@
+class AddExpiresAtToHolds < ActiveRecord::Migration[6.1]
+  def change
+    add_column :holds, :expires_at, :datetime
+  end
+end

--- a/db/migrate/20211120222255_set_expires_at_on_existing_holds.rb
+++ b/db/migrate/20211120222255_set_expires_at_on_existing_holds.rb
@@ -1,0 +1,5 @@
+class SetExpiresAtOnExistingHolds < ActiveRecord::Migration[6.1]
+  def up
+    execute "UPDATE holds SET expires_at = started_at + interval '#{Hold::HOLD_LENGTH.to_i}' second"
+  end
+end

--- a/db/migrate/20211120222255_set_expires_at_on_existing_holds.rb
+++ b/db/migrate/20211120222255_set_expires_at_on_existing_holds.rb
@@ -1,5 +1,0 @@
-class SetExpiresAtOnExistingHolds < ActiveRecord::Migration[6.1]
-  def up
-    execute "UPDATE holds SET expires_at = started_at + interval '#{Hold::HOLD_LENGTH.to_i}' second"
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_14_184745) do
-
+ActiveRecord::Schema.define(version: 2021_11_20_222255) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,32 +18,32 @@ ActiveRecord::Schema.define(version: 2021_10_14_184745) do
     "fine",
     "membership",
     "donation",
-    "payment",
+    "payment"
   ], force: :cascade
 
   create_enum :adjustment_source, [
     "cash",
     "square",
-    "forgiveness",
+    "forgiveness"
   ], force: :cascade
 
   create_enum :hold_request_status, [
     "new",
     "completed",
-    "denied",
+    "denied"
   ], force: :cascade
 
   create_enum :item_attachment_kind, [
     "manual",
     "parts_list",
-    "other",
+    "other"
   ], force: :cascade
 
   create_enum :notification_status, [
     "pending",
     "sent",
     "bounced",
-    "error",
+    "error"
   ], force: :cascade
 
   create_enum :power_source, [
@@ -52,20 +51,20 @@ ActiveRecord::Schema.define(version: 2021_10_14_184745) do
     "gas",
     "air",
     "electric (corded)",
-    "electric (battery)",
+    "electric (battery)"
   ], force: :cascade
 
   create_enum :renewal_request_status, [
     "requested",
     "approved",
-    "rejected",
+    "rejected"
   ], force: :cascade
 
   create_enum :user_role, [
     "staff",
     "admin",
     "member",
-    "super_admin",
+    "super_admin"
   ], force: :cascade
 
   create_table "action_text_rich_texts", force: :cascade do |t|
@@ -269,6 +268,7 @@ ActiveRecord::Schema.define(version: 2021_10_14_184745) do
     t.bigint "loan_id"
     t.datetime "started_at"
     t.integer "library_id"
+    t.datetime "expires_at"
     t.index ["creator_id"], name: "index_holds_on_creator_id"
     t.index ["item_id"], name: "index_holds_on_item_id"
     t.index ["library_id"], name: "index_holds_on_library_id"

--- a/lib/tasks/holds.rake
+++ b/lib/tasks/holds.rake
@@ -7,4 +7,12 @@ namespace :holds do
       end
     end
   end
+
+  task set_expires_at: :environment do
+    Time.use_zone("America/Chicago") do
+      Hold.where("started_at IS NOT NULL AND ended_at IS NULL AND started_at > ?", 1.week.ago).each do |hold|
+        hold.start!(hold.started_at)
+      end
+    end
+  end
 end

--- a/test/controllers/account/appointments_controller_test.rb
+++ b/test/controllers/account/appointments_controller_test.rb
@@ -51,7 +51,8 @@ module Account
     end
 
     test "should not update appointment scheduled after any holds expire" do
-      @expired_hold = FactoryBot.create(:hold, member: @member, started_at: @appointment.starts_at - Hold::HOLD_LENGTH - 1.days)
+      @expired_hold = create(:hold, member: @member)
+      @expired_hold.start!(@appointment.starts_at - Hold::HOLD_LENGTH - 1.days)
       put account_appointment_path(@appointment), params: {appointment: {hold_ids: [@hold.id, @expired_hold.id], time_range_string: @appointment.time_range_string, comment: @appointment.comment}}
 
       assert_template :edit

--- a/test/factories/holds.rb
+++ b/test/factories/holds.rb
@@ -6,12 +6,13 @@ FactoryBot.define do
     creator { create(:user) }
     factory :expired_hold do
       started_at { 3.weeks.ago }
+      expires_at { 2.weeks.ago }
     end
     factory :ended_hold do
       ended_at { Time.current }
     end
     factory :started_hold do
-      started_at { Time.current }
+      after(:build) { |hold| hold.start! }
     end
   end
 end

--- a/test/forms/extend_holds_form_test.rb
+++ b/test/forms/extend_holds_form_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class ExtendHoldsFormTest < ActiveSupport::TestCase
+  test "invalid when date is blank" do
+    form = ExtendHoldsForm.new
+    refute form.valid?
+    assert_equal ["must be a date within the next month"], form.errors[:date]
+  end
+
+  test "invalid with invalid date" do
+    form = ExtendHoldsForm.new(date: "invalid date")
+    refute form.valid?
+    assert_equal ["must be a date within the next month"], form.errors[:date]
+  end
+
+  test "invalid with past date" do
+    form = ExtendHoldsForm.new(date: 1.day.ago.to_date.iso8601)
+    refute form.valid?
+    assert_equal ["must be a date within the next month"], form.errors[:date]
+  end
+
+  test "invalid with far future date" do
+    form = ExtendHoldsForm.new(date: 32.days.since.to_date.iso8601)
+    refute form.valid?
+    assert_equal ["must be a date within the next month"], form.errors[:date]
+  end
+
+  test "valid with valid date" do
+    form = ExtendHoldsForm.new(date: "2021-10-08")
+    form.now = Date.new(2021, 10, 1)
+    assert form.valid?
+  end
+end


### PR DESCRIPTION
# What it does

This PR changes how hold expiration works. The date that holds expire is now recorded when the hold is "started" instead of being determined dynamically within queries. This allows us to adjust the hold expiry date in situations such as temporary closures.

A new admin page has also been added with just such a form.

# Why it is important

CTL is going to be closed this week, and we don't want folks to lose their place in line because their holds expire when we're not open.