### PR TITLE
Remove duplicate information in gift membership email

### DIFF
--- a/app/views/gift_purchaser_mailer/confirmation.mjml
+++ b/app/views/gift_purchaser_mailer/confirmation.mjml
@@ -32,14 +32,3 @@
     </mj-text>
   </mj-column>
 </mj-section>
-<mj-section background-color="#F4F4F4">
-  <mj-column>
-    <mj-text font-size="14px" line-height="20px" align="center">
-      <p>
-        <a href="https://chicagotoollibrary.org">The Chicago Tool Library</a><br>
-            1048 W 37th Street Suite 102<br>
-            Chicago, IL 60609
-      </p>
-    </mj-text>
-  </mj-column>
-</mj-section>

--- a/app/views/gift_purchaser_mailer/confirmation.mjml
+++ b/app/views/gift_purchaser_mailer/confirmation.mjml
@@ -14,7 +14,7 @@
       <p>Hello <%= @gift_membership.purchaser_name %>,</p>
       <p>You have successfully purchased a One Year Gift Membership to the <%= @library.name %>. Go you!</p>
       <p><strong>Your gift code is: <code class="gift-code"><%= @gift_membership.code.format %></code></strong></p>
-      <p>The recipient of this gift membership needs to use this code to complete the membership sign-up on <a href="http://chicagotoollibrary.org/">our website</a> or in-person <a href="https://chicagotoollibrary.org/library">at the Tool Library</a>.<p>
+      <p>The recipient of this gift membership needs to use this code to complete the membership sign-up on <a href="http://chicagotoollibrary.org/">our website</a> or in-person at the Tool Library.<p>
       <p>After completing their sign-up, they will need to bring the following into the library:<p>
       <ul>
         <li><strong>Proof of their address</strong><br>This needs to include their name and current address in Chicago. Utility bills, leases, and other official mail work well.</li>

--- a/app/views/gift_purchaser_mailer/confirmation.mjml
+++ b/app/views/gift_purchaser_mailer/confirmation.mjml
@@ -21,7 +21,6 @@
         <li><strong>A photo ID</strong><br>This needs to show their name and a photo and can be from the state, their job, school, etc.</li>
       </ul >
       <p>Once we review the above, their one-year membership will begin on the day they borrow their first tool.</p>
-      <p>Don't hesitate to email us at <a href="mailto:team@chicagotoollibrary.org">team@chicagotoollibrary.org</a> with any questions!</p>
     </mj-text>
   </mj-column>
 </mj-section>

--- a/app/views/gift_purchaser_mailer/confirmation.mjml
+++ b/app/views/gift_purchaser_mailer/confirmation.mjml
@@ -15,13 +15,6 @@
       <p>You have successfully purchased a One Year Gift Membership to the <%= @library.name %>. Go you!</p>
       <p><strong>Your gift code is: <code class="gift-code"><%= @gift_membership.code.format %></code></strong></p>
       <p>The recipient of this gift membership needs to use this code to complete the membership sign-up on <a href="http://chicagotoollibrary.org/">our website</a> or in-person <a href="https://chicagotoollibrary.org/library">at the Tool Library</a>.<p>
-
-      <div class="warning">
-        <p><strong>
-          We are open <em>by appointment only</em> in response to COVID-19.<br><a href="https://chicagotoollibrary.org/covid-19">Please check our COVID-19 page for more information and our current hours.</a>
-        </strong></p>
-      </div>
-
       <p>After completing their sign-up, they will need to bring the following into the library:<p>
       <ul>
         <li><strong>Proof of their address</strong><br>This needs to include their name and current address in Chicago. Utility bills, leases, and other official mail work well.</li>

--- a/app/views/gift_purchaser_mailer/confirmation.text.erb
+++ b/app/views/gift_purchaser_mailer/confirmation.text.erb
@@ -17,7 +17,3 @@ After completing their sign-up, they will need to bring the following into the l
 Once we review the above, their one-year membership will begin on the day they borrow their first tool.
 
 Don't hesitate to email us at <%= @library.email %> with any questions!
-
----
-
-<%= @library.address %>

--- a/app/views/layouts/mailer.html.mjml
+++ b/app/views/layouts/mailer.html.mjml
@@ -44,7 +44,7 @@
     <mj-section>
       <mj-column>
         <mj-text>
-          <p>If you have any questions, please email us at <a href="mailto:team@chicagotoollibrary.org">team@chicagotoollibrary.org</a>.</p>
+          <p>If you have any questions, please email us at <%= mail_to @library.email %>.</p>
           <p>See you at the library!</p>
         </mj-text>
       </mj-column>

--- a/app/views/layouts/mailer.text.erb
+++ b/app/views/layouts/mailer.text.erb
@@ -1,1 +1,13 @@
 <%= yield %>
+
+We are open by appointment only in response to COVID-19.
+
+Please check our COVID-19 page for more information: https://chicagotoollibrary.org/covid-19
+
+---
+
+If you have any questions, please email us at <%= @library.email  %>.
+
+See you at the library!
+
+<%= @library.address %>

--- a/app/views/signup/confirmations/_hours.html.erb
+++ b/app/views/signup/confirmations/_hours.html.erb
@@ -1,5 +1,8 @@
 <div class="warning">
-  <p><strong>
-    We are open <em>by appointment only</em> in response to COVID-19. <a href="https://chicagotoollibrary.org/covid-19">Please check our COVID-19 page for more information.</a>
-  </strong></p>
+  <p>
+    <strong>
+      We are open <em>by appointment only</em> in response to COVID-19.
+      <%= link_to("Please check our COVID-19 page for more information.", "https://chicagotoollibrary.org/covid-19") %>
+    </strong>
+  </p>
 </div>


### PR DESCRIPTION
# What it does

This PR:
- removes duplicate information in gift membership email
- brings plain text confirmation email on par with the html confirmation email (content parity)
- introduces some minor improvements (see commit messages for detail)

_**This is best reviewed commit by commit.**_

# Why it is important

Fixes https://github.com/rubyforgood/circulate/issues/860

# UI Change Video


https://user-images.githubusercontent.com/14851208/143787665-2fada2a9-e87e-4ac7-94b3-f691bed83b9c.mov



# Your bandwidth for additional changes to this PR

I have the time and interest to make additional changes to this PR based on feedback.