### PR TITLE
fix: reference to wrong instance variable was breaking renewal emails

### DIFF
--- a/app/views/member_mailer/renewal_request_updated.mjml
+++ b/app/views/member_mailer/renewal_request_updated.mjml
@@ -12,7 +12,7 @@
 <% if @item.image.attached? %>
   <mj-section>
     <mj-column padding-top="20px">
-      <mj-image src="<%= item_image_url(@hold.item.image, resize_to_limit: [600, 300]) %>" />
+      <mj-image src="<%= item_image_url(@item.image, resize_to_limit: [600, 300]) %>" />
     </mj-column>
   </mj-section>
 <% end %>

--- a/test/mailers/member_mailer_test.rb
+++ b/test/mailers/member_mailer_test.rb
@@ -9,7 +9,7 @@ class MemberMailerTest < ActionMailer::TestCase
 
   [:approved, :rejected].each do |status|
     test "renders renewal request #{status} email for a renewed loan" do
-      item = create(:item)
+      item = create(:item, :with_image)
       loan = create(:loan, item: item)
       renewed_loan = renew_loan(loan)
       renewal_request = create(:renewal_request, loan: renewed_loan, status: status)
@@ -21,7 +21,7 @@ class MemberMailerTest < ActionMailer::TestCase
     end
 
     test "renders renewal request #{status} email for the first loan" do
-      item = create(:item)
+      item = create(:item, :with_image)
       loan = create(:loan, item: item)
       renewal_request = create(:renewal_request, loan: loan, status: status)
 

--- a/test/mailers/previews/member_mailer_preview.rb
+++ b/test/mailers/previews/member_mailer_preview.rb
@@ -79,20 +79,24 @@ class MemberMailerPreview < ActionMailer::Preview
   end
 
   def renewal_request_approved
-    tomorrow = Time.current.end_of_day + 1.day
-    member = Member.verified.first
-    loan = Loan.create!(item: Item.available.order("RANDOM()").first, member: member, library: member.library, due_at: tomorrow, uniquely_numbered: false)
-    renew_loan(loan)
-    renewal_request = RenewalRequest.create!(loan: loan, status: :approved)
-    MemberMailer.with(renewal_request: renewal_request).renewal_request_updated
+    ActsAsTenant.with_tenant(Library.first) do
+      tomorrow = Time.current.end_of_day + 1.day
+      member = Member.verified.first
+      loan = Loan.create!(item: Item.available.order("RANDOM()").first, member: member, library: member.library, due_at: tomorrow, uniquely_numbered: false)
+      renew_loan(loan)
+      renewal_request = RenewalRequest.create!(loan: loan, status: :approved)
+      MemberMailer.with(renewal_request: renewal_request).renewal_request_updated
+    end
   end
 
   def renewal_request_rejected
-    tomorrow = Time.current.end_of_day + 1.day
-    member = Member.verified.first
-    loan = Loan.create!(item: Item.available.order("RANDOM()").first, member: member, library: member.library, due_at: tomorrow, uniquely_numbered: false)
-    renewal_request = RenewalRequest.create!(loan: loan, status: :rejected)
-    MemberMailer.with(renewal_request: renewal_request).renewal_request_updated
+    ActsAsTenant.with_tenant(Library.first) do
+      tomorrow = Time.current.end_of_day + 1.day
+      member = Member.verified.first
+      loan = Loan.create!(item: Item.available.order("RANDOM()").first, member: member, library: member.library, due_at: tomorrow, uniquely_numbered: false)
+      renewal_request = RenewalRequest.create!(loan: loan, status: :rejected)
+      MemberMailer.with(renewal_request: renewal_request).renewal_request_updated
+    end
   end
 
   def appointment_confirmation


### PR DESCRIPTION
# What it does

A bug in one of the email templates is breaking the messages we send to members when their renewal requests are responded to by staff.

# Why it is important

We'd like our emails to reach our members 😄 

# Implementation notes

* The issue only came up when an item had an attached image, and our tests didn't create items with images. This has been addressed.

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
