### PR TITLE
add 'Overdue' item status label

### DIFF
--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -150,7 +150,11 @@ module ItemsHelper
   def css_class_and_status_label(item)
     if item.active?
       if item.checked_out_exclusive_loan
-        ["label-warning", "Checked Out"]
+        if item.overdue?
+          ["label-error", "Overdue"]
+        else
+          ["label-warning", "Checked Out"]
+        end
       elsif item.borrow_policy.uniquely_numbered? && item.active_holds.size > 0
         ["label-warning", "On Hold"]
       else
@@ -166,20 +170,6 @@ module ItemsHelper
   def item_status_label(item)
     class_name, label = css_class_and_status_label(item)
     tag.span label, class: "label item-checkout-status #{class_name}"
-  end
-
-  def item_status_class(item)
-    if item.active?
-      if item.checked_out_exclusive_loan
-        "status-checked-out"
-      elsif item.active_holds.count > 0
-        "status-on-hold"
-      else
-        "status-available"
-      end
-    else
-      "status-unavailable"
-    end
   end
 
   def item_holds_label(item)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -105,6 +105,10 @@ class Item < ApplicationRecord
     checked_out_exclusive_loan.due_at.to_date
   end
 
+  def overdue?
+    due_on.past?
+  end
+
   def available?
     !checked_out_exclusive_loan.present?
   end

--- a/test/factories/loans.rb
+++ b/test/factories/loans.rb
@@ -12,6 +12,11 @@ FactoryBot.define do
       ended_at { Time.current - 1.week }
     end
 
+    factory :overdue_loan do
+      created_at { Time.current - 2.weeks }
+      due_at { Time.current - 1.week }
+    end
+
     factory :nonexclusive_loan do
       uniquely_numbered { false }
     end

--- a/test/helpers/items_helper_test.rb
+++ b/test/helpers/items_helper_test.rb
@@ -94,6 +94,14 @@ class ItemsHelperTest < ActionView::TestCase
       assert_equal ["label-warning", "Checked Out"], css_class_and_status_label(item)
     end
 
+    test "item status for an overdue uniquely numbered item" do
+      item = create(:item)
+      create(:overdue_loan, item: item)
+      item.reload
+
+      assert_equal ["label-error", "Overdue"], css_class_and_status_label(item)
+    end
+
     test "item status for a uniquely numbered item with a hold" do
       item = create(:item)
       create(:hold, item: item)


### PR DESCRIPTION
# What it does

Resolves #888 

Overdue items now appear with an "Overdue" status label, instead of "Checked Out".

Also, the method `ItemsHelper#item_status_class` is deleted since it is not used anywhere.

# Why it is important

This will help members avoid putting items on hold that are overdue (and unlikely to return soon or possibly at all).

# UI Change Screenshot

![circulate-#888-before](https://user-images.githubusercontent.com/9300391/144910089-3a9db384-5c09-4817-a457-b0e96326a3d1.jpeg)

![circulate-#888-after](https://user-images.githubusercontent.com/9300391/144910099-e710eebc-c3f6-461a-aa49-0edfce91f4a9.jpeg)

The same change appears at the item page's "Status" label.

# Your bandwidth for additional changes to this PR

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
