### PR TITLE
Set tenant when syncing calendars.

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -51,10 +51,12 @@ class Event < ApplicationRecord
         calendar_id: gcal_event.calendar_id
       ).delete_all
     else
-      Event.find_or_initialize_by(
+      event = Event.find_or_initialize_by(
         calendar_event_id: gcal_event.id,
         calendar_id: gcal_event.calendar_id
-      ).update(
+      )
+
+      event.update!(
         description: gcal_event.description,
         start: gcal_event.start,
         finish: gcal_event.finish,

--- a/lib/tasks/sync.rake
+++ b/lib/tasks/sync.rake
@@ -1,8 +1,10 @@
 namespace :sync do
   desc "Syncronizes calendars with the events database"
   task calendars: :environment do
-    sync_calendar Event.appointment_slot_calendar_id
-    sync_calendar Event.volunteer_shift_calendar_id
+    ActsAsTenant.with_tenant(Library.first) do
+      sync_calendar Event.appointment_slot_calendar_id
+      sync_calendar Event.volunteer_shift_calendar_id
+    end
   end
 
   def sync_calendar(calendar_id)


### PR DESCRIPTION
# What it does

Calendar syncing has been broken for a while since we deployed some of the multitenant code. Events were failing to save to the database, but we didn't notice because no exceptions were being raised.

This PR:
* Raises exceptions when Events don't save. These will appear in our usual tools and we'll be notified
* Sets the current tenant around the calendar syncing to that events will save without error.