### PR TITLE
Move appointment loans to the renewal when a loan is renewed.

### DIFF
--- a/app/controllers/concerns/lending.rb
+++ b/app/controllers/concerns/lending.rb
@@ -44,6 +44,10 @@ module Lending
     loan.transaction do
       next unless return_loan(loan, now: now)
       new_loan.save!
+
+      # update any appointments connected with the old loan
+      AppointmentLoan.where(loan_id: loan).update_all(loan_id: new_loan.id)
+
       success = true
     end
 
@@ -63,6 +67,10 @@ module Lending
         loan.initial_loan
       end
       target.update!(ended_at: nil)
+
+      # update any appointments connected with the reverted loan
+      AppointmentLoan.where(loan_id: loan).update_all(loan_id: target.id)
+
       success = true
     end
 


### PR DESCRIPTION
# What it does

This fixes a bug where a loan that was renewed after being added to an appointment would be shown as being checked in.

# Why it is important

This bug could create confusion and cause staff to not check in items that should be checked in.

# Implementation notes

* I did this by updating the `loan_id` association on `AppointmentLoan`. The other option was to change `AppointmentLoan` to be associated with `LoanSummary` instead of `Loan`, but since that is a more intrusive change I went with this option.

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
