### PR TITLE
Admins can renew memberships early unless there is a pending membership.

### DIFF
--- a/app/controllers/admin/members/memberships_controller.rb
+++ b/app/controllers/admin/members/memberships_controller.rb
@@ -2,7 +2,7 @@ module Admin
   module Members
     class MembershipsController < BaseController
       def index
-        @memberships = @member.memberships
+        @memberships = @member.memberships.order(created_at: :desc)
         @adjustments = @member.adjustments.order(created_at: :desc)
       end
 
@@ -13,7 +13,7 @@ module Admin
       def create
         @form = MembershipForm.new(@member, membership_form_params)
         if @form.save
-          redirect_to admin_member_path(@member), success: "Membership created."
+          redirect_to admin_member_memberships_path(@member), success: "Membership created."
         else
           render :new
         end
@@ -25,7 +25,7 @@ module Admin
 
         if @membership
           @membership.start!
-          redirect_to admin_member_path(@member), success: "Membership started."
+          redirect_to admin_member_memberships_path(@member), success: "Membership started."
         else
           redirect_to admin_member_path(@member), error: "Could not start membership"
         end

--- a/app/forms/member_signup_form.rb
+++ b/app/forms/member_signup_form.rb
@@ -34,6 +34,7 @@ class MemberSignupForm
       @user.email = @member.email
       @member.user = @user
       @member.save
+      @user.save
 
       raise ActiveRecord::Rollback unless @user.persisted? && @member.persisted?
       true

--- a/app/forms/membership_form.rb
+++ b/app/forms/membership_form.rb
@@ -13,7 +13,7 @@ class MembershipForm
     @payment = Admin::Payment.new(params.slice(*PAYMENT_ATTRIBUTES))
 
     @with_payment = params.key?("with_payment") ? params["with_payment"] == "true" : true
-    @start_membership = params["start_membership"] == "1"
+    @start_membership = params["start_membership"] != "0"
   end
 
   def errors

--- a/app/javascript/stylesheets/admin.scss
+++ b/app/javascript/stylesheets/admin.scss
@@ -89,3 +89,7 @@ body.admin {
     vertical-align: top;
   }
 }
+
+.member-tabs {
+  margin-bottom: 1rem;
+}

--- a/app/javascript/stylesheets/overrides.scss
+++ b/app/javascript/stylesheets/overrides.scss
@@ -233,3 +233,7 @@ trix-toolbar {
     width: 10px;
   }
 }
+
+.mt-5 {
+  margin-top: 1rem;
+}

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -47,8 +47,8 @@ class Membership < ApplicationRecord
     # no safe start date if there is a pending membership
     return nil if member.pending_membership
 
-    # renewal memberships should start on the day after the active one ends
-    return member.active_membership.ended_at + 1.day if member.active_membership
+    # renewal memberships should start on the day after the last one ends
+    return member.last_membership.ended_at + 1.day if member.active_membership
 
     # if there isn't an active membership (this includes if there was one that
     # has already ended), it can start today

--- a/app/views/admin/members/_profile.html.erb
+++ b/app/views/admin/members/_profile.html.erb
@@ -37,7 +37,7 @@
       <% end %>
     </div>
 
-    <ul class="tab">
+    <ul class="tab member-tabs">
       <%= tab_link "Current Loans", admin_member_path(@member) %>
       <%= tab_link "Holds", admin_member_holds_path(@member) %>
       <% if @current_library.allow_appointments? %>
@@ -47,7 +47,9 @@
       <%= tab_link "Membership", admin_member_memberships_path(@member) %>
     </ul>
 
-    <%= yield %>
+    <div class="member-tabs-content">
+      <%= yield %>
+    </div>
 
   </div>
 </div>

--- a/app/views/admin/members/memberships/index.html.erb
+++ b/app/views/admin/members/memberships/index.html.erb
@@ -1,6 +1,9 @@
 <%= render "admin/members/profile" do %>
-<h2>Membership Periods</h2>
-  <table class="table table-scroll">
+  <% unless @member.pending_membership %>
+    <%= link_to @memberships.any? ? "Renew Membership" : "Create Membership", new_admin_member_membership_path, class: "btn" %>
+  <% end %>
+
+  <table class="table memberships">
     <thead>
       <tr>
         <th>Started on</th>
@@ -24,8 +27,8 @@
     </tbody>
   </table>
 
-<h2>Transactions</h2>
-  <table class="table table-scroll">
+  <h3 class="mt-5">Transactions</h3>
+  <table class="table">
     <thead>
       <tr>
         <th>Date</th>

--- a/app/views/admin/members/memberships/new.html.erb
+++ b/app/views/admin/members/memberships/new.html.erb
@@ -1,38 +1,40 @@
-<% content_for :header do %>
-  <%= index_header "New Membership" %>
-<% end %>
+<%= render "admin/members/profile" do %>
+  <h3>
+    <% if @member.active_membership.present? %>
+      Renew Membership
+    <% else %>
+      New Membership
+    <% end%>
+  </h3>
 
-<div class="instructions">
-  <p class="main">Memberships provide one year of borrowing privileges.</p>
-  <p class="sub">The Chicago Tool Library's main source of funding is membership fees. It's important to us that you pay what you want for your year of tool access. Pay more if you can, pay less if you can't - no questions asked. Your payment will go directly towards funding the tools and materials needed to make the Tool Library the magical place that it is.</p>
-    <p>Our recommendation is that folks pay $1 for every $1,000 of income they make in a year.<br>For example, if a person makes $40,000 each year, we recommend their membership fee be $40.</p>
-</div>
+  <%= form_with model: @form, url: admin_member_memberships_path(@member), builder: SpectreFormBuilder do |form| %>
+    <div class="columns">
+      <div class="column col-12">
+        <fieldset>
+          <legend>
+            <%= form.radio_button :with_payment, true, label: "Accept payment today", required: false %>
+          </legend>
+          <div class="fieldset-radio-inputs">
+            <%= form.money_field :amount_dollars, label: "This year's membership fee", class: "input-lg" %>
+            <%= form.select :payment_source, options_for_select(membership_payment_source_options, @form.payment_source || "cash"), prompt: true %>
+          </div>
+        </fieldset>
 
-<%= form_with model: @form, url: admin_member_memberships_path(@member), builder: SpectreFormBuilder do |form| %>
-  <div class="columns">
-    <div class="column col-12">
-      <fieldset>
-        <legend>
-          <%= form.radio_button :with_payment, true, label: "Accept payment today", required: false %>
-        </legend>
-        <div class="fieldset-radio-inputs">
-          <%= form.money_field :amount_dollars, label: "This year's membership fee", class: "input-lg" %>
-          <%= form.select :payment_source, options_for_select(membership_payment_source_options, @form.payment_source || "cash"), prompt: true %>
-        </div>
-      </fieldset>
+        <fieldset>
+          <legend>
+            <%= form.radio_button :with_payment, false, label: "Create without payment", required: false %>
+          </legend>
+          <div class="fieldset-radio-inputs">
+            <p>Remember that we don't turn anyone away because they can't pay. Use this option to create a membership without accepting a payment.</p>
+          </div>
+        </fieldset>
 
-      <fieldset>
-        <legend>
-          <%= form.radio_button :with_payment, false, label: "Create without payment", required: false %>
-        </legend>
-        <div class="fieldset-radio-inputs">
-          <p>Remember that we don't turn anyone away because they can't pay. Use this option to create a membership without accepting a payment.</p>
-        </div>
-      </fieldset>
+        <% unless @member.active_membership.present? %>
+          <%= form.check_box :start_membership, label: "Start this membership", hint: "If unchecked, this membership will be pending and can be started at a later time.", checked: true %>
+        <% end %>
 
-      <%= form.check_box :start_membership, label: "Start this membership", hint: "If unchecked, this membership can be started at a later time.", checked: true %>
-
-      <%= form.submit "Save Membership" %>
+        <%= form.submit "Save Membership" %>
+      </div>
     </div>
-  </div>
+  <% end %>
 <% end %>


### PR DESCRIPTION
# What it does

This PR allows admins to renew memberships for members before their current membership expires. This has started coming up from time to time.

# Why it is important

It's better to be able to do this when members ask than remember to do it when the time comes. 

# UI Change Screenshot

![image](https://user-images.githubusercontent.com/3331/149832535-3bebfa04-a933-4598-ab7b-65ff5a4f8b71.png)

# Implementation notes

* The system already mostly handled this, so this change is mostly adding a link to the existing form and a few UI tweaks to accommodate having multiple "started" memberships.

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
