### PR TITLE
Gracefully handle retired items being on hold. Fixes #946

### DIFF
--- a/app/models/hold.rb
+++ b/app/models/hold.rb
@@ -113,6 +113,11 @@ class Hold < ApplicationRecord
     started = 0
 
     active(now).includes(item: :borrow_policy).find_each do |hold|
+      unless hold.item.holdable?
+        Rails.logger.debug "[hold #{hold.id}]: item is not holdable"
+        next
+      end
+
       if hold.started?
         Rails.logger.debug "[hold #{hold.id}]: already started"
         next

--- a/test/models/hold_test.rb
+++ b/test/models/hold_test.rb
@@ -242,6 +242,18 @@ class HoldTest < ActiveSupport::TestCase
     assert hold2.started?
   end
 
+  test "handles a hold on a retired item" do
+    hammer = create(:item)
+    create(:hold, item: hammer)
+    hammer.update!(status: "retired")
+
+    assert_no_difference("Hold.started.count") do
+      Hold.start_waiting_holds do |hold|
+        fail "should not be called"
+      end
+    end
+  end
+
   test "is ready for pickup if item is uncounted" do
     item = create(:uncounted_item)
 


### PR DESCRIPTION
# What it does

This change fixes an issue where the holds system that starts holds stopped working because an item's status was set to "retired" after it was placed on hold.

# Why it is important

We need the holds system to be resilient and always running.

# Implementation notes

* This fixes the symptom, but not the underlying cause.

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
