### PR TITLE
Hide schedule appointment link if hold is not ready

### DIFF
--- a/app/views/items/place_hold_on/_item_already_with_a_hold.html.erb
+++ b/app/views/items/place_hold_on/_item_already_with_a_hold.html.erb
@@ -4,7 +4,7 @@
 
 <% if hold.upcoming_appointment %>
   You are scheduled to pick this item up on <%= appointment_date_and_time hold.upcoming_appointment %>.
-<% else %>
+<% elsif hold.ready_for_pickup? %>
   <% if @current_library.allow_appointments? %>
     <%= link_to "Schedule an appointment", new_account_appointment_path %> to choose when to pick it up.
   <% end %>


### PR DESCRIPTION
# What it does

Hides the schedule appointment link for an item if the hold is not ready for pickup

# Why it is important

#950 

# UI Change Screenshot

Before:

![circulate-1](https://user-images.githubusercontent.com/8291663/151633803-db5bd1c4-2ee6-46ed-904c-6c565cf5f5fd.png)

After:

![circulate-2](https://user-images.githubusercontent.com/8291663/151633816-719530ec-c4f8-400e-9ac4-6e0bb4699e99.png)

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
