### PR TITLE
Hide Appointment Form if there's no hold nor return.

### DIFF
--- a/app/views/account/appointments/_form.html.erb
+++ b/app/views/account/appointments/_form.html.erb
@@ -8,112 +8,111 @@
     </ul>
   <% end %>
 
-  <% if !can_schedule_appointment %>
-    <div class="toast toast-warning">
-      <p>You can only schedule an appointment if you have a tool on hold or that can be returned.</p>
-      <%= link_to "View Inventory", items_path, class: "btn btn-lg btn-default" %>
-    </div>
-  <% end %>
+  <% if can_schedule_appointment %>
+    <%= form_with(model: [:account, @appointment]) do |form| %>
+      <div class="columns">
 
-  <%= form_with(model: [:account, @appointment]) do |form| %>
+        <% if loans.any? %>
+          <div class="column col-5 col-sm-12 col-mr-auto">
+            <h2 class="h3">Select Items to Return</h2>
 
-    <div class="columns">
+            <ul class="loan-list">
+              <% @loans.each do |loan| %>
+                <li class="clearfix">
+                  <% if loan.item.image.attached? %>
+                    <div class="image">
+                      <%= image_tag item_image_url(loan.item.image, resize_to_limit: [134, 94]), class: "p-centered" %>
+                    </div>
+                  <% end %>
+                  <div class="details">
+                    <div class="form-group">
+                      <label class="form-checkbox checkbox-lg">
+                      <%= check_box_tag("appointment[loan_ids][]", loan.id, @appointment.loans.include?(loan),
+                            disabled: loan.upcoming_appointment.present? && loan.upcoming_appointment != @appointment) %>
+                      <i class="form-icon"></i>
+                      <%= loan.item.name %> (<%= loan.item.complete_number %>)
+                      </label>
+                    </div>
+                    <span class="status">
+                      <%= tag.span "Due #{humanize_due_date(loan)}", class: ("warning text-bold" if loan.due_at - Time.now < 3.days) %>
+                      <span class="pickup">
+                        <%= loan_pickup_status(loan) %>
+                      </span>
+                    </span>
+                  </div>
+                </li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
 
-      <% if loans.any? %>
         <div class="column col-5 col-sm-12 col-mr-auto">
-          <h2 class="h3">Select Items to Return</h2>
+          <h2 class="h3">Select Items to Pick-Up</h2>
 
-          <ul class="loan-list">
-            <% @loans.each do |loan| %>
-              <li class="clearfix">
-                <% if loan.item.image.attached? %>
+          <ul class="hold-list">
+            <% @holds.each do |hold| %>
+              <li>
+                <% if hold.item.image.attached? %>
                   <div class="image">
-                    <%= image_tag item_image_url(loan.item.image, resize_to_limit: [134, 94]), class: "p-centered" %>
+                    <%= image_tag item_image_url(hold.item.image, resize_to_limit: [134, 94]), class: "p-centered" %>
                   </div>
                 <% end %>
+                <div class="form-group">
+                  <label class="form-checkbox checkbox-lg">
+                  <%= check_box_tag("appointment[hold_ids][]", hold.id, @appointment.holds.include?(hold),
+                        disabled: !hold.ready_for_pickup? || (hold.upcoming_appointment.present? && hold.upcoming_appointment != @appointment)) %>
+                  <i class="form-icon"></i>
+                  <%= hold.item.name %> (<%= hold.item.complete_number %>)
+                  </label>
+                </div>
                 <div class="details">
-                  <div class="form-group">
-                    <label class="form-checkbox checkbox-lg">
-                    <%= check_box_tag("appointment[loan_ids][]", loan.id, @appointment.loans.include?(loan),
-                          disabled: loan.upcoming_appointment.present? && loan.upcoming_appointment != @appointment) %>
-                    <i class="form-icon"></i>
-                    <%= loan.item.name %> (<%= loan.item.complete_number %>)
-                    </label>
-                  </div>
                   <span class="status">
-                    <%= tag.span "Due #{humanize_due_date(loan)}", class: ("warning text-bold" if loan.due_at - Time.now < 3.days) %>
-                    <span class="pickup">
-                      <%= loan_pickup_status(loan) %>
-                    </span>
+                    <%= render_hold_status(hold) %>
                   </span>
                 </div>
               </li>
             <% end %>
           </ul>
-        </div>
-      <% end %>
 
-      <div class="column col-5 col-sm-12 col-mr-auto">
-        <h2 class="h3">Select Items to Pick-Up</h2>
-
-        <ul class="hold-list">
-          <% @holds.each do |hold| %>
-            <li>
-              <% if hold.item.image.attached? %>
-                <div class="image">
-                  <%= image_tag item_image_url(hold.item.image, resize_to_limit: [134, 94]), class: "p-centered" %>
-                </div>
-              <% end %>
-              <div class="form-group">
-                <label class="form-checkbox checkbox-lg">
-                <%= check_box_tag("appointment[hold_ids][]", hold.id, @appointment.holds.include?(hold),
-                      disabled: !hold.ready_for_pickup? || (hold.upcoming_appointment.present? && hold.upcoming_appointment != @appointment)) %>
-                <i class="form-icon"></i>
-                <%= hold.item.name %> (<%= hold.item.complete_number %>)
-                </label>
-              </div>
-              <div class="details">
-                <span class="status">
-                  <%= render_hold_status(hold) %>
-                </span>
-              </div>
-            </li>
-          <% end %>
-        </ul>
-
-      </div>
-    </div>
-
-    <div class="columns">
-      <div class="column col-8 col-sm-12 col-mr-auto">
-        <div class="form-group" data-controller="appointment-date">
-          <label class="form-label h3" for="time_range_string">Select a time for the appointment</label>
-          <%= select("appointment", "time_range_string", grouped_options_for_select(@appointment_slots, @appointment.time_range_string), {include_blank: "Select a Date"},
-                class: "form-select", data: {action: "appointment-date#sync", target: "appointment-date.select"}, disabled: !can_schedule_appointment) %>
-            <span data-target="appointment-date.display"></span>
-            <p>Don't worry if you arrive a little bit early or late, as long as it's within the library's open hours.</p>
-        </div>
-
-        <div class="form-group mb-2">
-          <label class="form-label" for="appointment_comment">Tell us about the project you're working on. We may be able to recommend a different or additional tool. If you're dropping off, please let us know if you had any issues with the items you're returning.</label>
-          <%= form.text_area :comment, class: "form-input", disabled: !can_schedule_appointment %>
-        </div>
-
-        <div>
-          <%= form.submit "#{@appointment.new_record? ? "Schedule" : "Update"} Appointment", class: "btn btn-block btn-lg btn-primary", disabled: !can_schedule_appointment %>
         </div>
       </div>
 
-    </div>
-  <% end %>
+      <div class="columns">
+        <div class="column col-8 col-sm-12 col-mr-auto">
+          <div class="form-group" data-controller="appointment-date">
+            <label class="form-label h3" for="time_range_string">Select a time for the appointment</label>
+            <%= select("appointment", "time_range_string", grouped_options_for_select(@appointment_slots, @appointment.time_range_string), {include_blank: "Select a Date"},
+                  class: "form-select", data: {action: "appointment-date#sync", target: "appointment-date.select"}, disabled: !can_schedule_appointment) %>
+              <span data-target="appointment-date.display"></span>
+              <p>Don't worry if you arrive a little bit early or late, as long as it's within the library's open hours.</p>
+          </div>
 
-  <% unless @appointment.new_record? %>
-    <div class="columns cancel-appointment">
-      <div class="column col-8 col-sm-12 col-mr-auto">
-        <h4 class="h5">Need to cancel?</h4>
-        <p>You can make a new appointment to pick up or return items at a later time.</p>
-        <%= button_to "Cancel Appointment", account_appointment_path(@appointment), class: "btn", method: :delete, data: {disabled_with: "Canceling appointment...", confirm: "Are you sure to cancel this appointment?"} %>
+          <div class="form-group mb-2">
+            <label class="form-label" for="appointment_comment">Tell us about the project you're working on. We may be able to recommend a different or additional tool. If you're dropping off, please let us know if you had any issues with the items you're returning.</label>
+            <%= form.text_area :comment, class: "form-input", disabled: !can_schedule_appointment %>
+          </div>
+
+          <div>
+            <%= form.submit "#{@appointment.new_record? ? "Schedule" : "Update"} Appointment", class: "btn btn-block btn-lg btn-primary", disabled: !can_schedule_appointment %>
+          </div>
+        </div>
+
       </div>
+    <% end %>
+
+    <% unless @appointment.new_record? %>
+      <div class="columns cancel-appointment">
+        <div class="column col-8 col-sm-12 col-mr-auto">
+          <h4 class="h5">Need to cancel?</h4>
+          <p>You can make a new appointment to pick up or return items at a later time.</p>
+          <%= button_to "Cancel Appointment", account_appointment_path(@appointment), class: "btn", method: :delete, data: {disabled_with: "Canceling appointment...", confirm: "Are you sure to cancel this appointment?"} %>
+        </div>
+      </div>
+    <% end %>
+  <% else %>
+    <div class="toast toast-warning">
+      <p>You can only schedule an appointment if you have a tool on hold or that can be returned.</p>
+      <%= link_to "View Inventory", items_path, class: "btn btn-lg btn-default" %>
     </div>
   <% end %>
 </div>

--- a/test/system/appointments_test.rb
+++ b/test/system/appointments_test.rb
@@ -77,6 +77,20 @@ class AppointmentsTest < ApplicationSystemTestCase
     within(list_item_containing(@held_item2.complete_number)) { assert_text "Ready for pickup" }
   end
 
+  test "attempts to schedule an appointment with no holds" do
+    @member = create(:verified_member_with_membership)
+
+    login_as @member.user
+
+    visit account_appointments_url
+
+    click_on "Schedule an Appointment"
+
+    assert_text "You can only schedule an appointment if you have a tool on hold or that can be returned."
+
+    refute_text "Select Items to Return"
+  end
+
   test "multiple members can make an appointment for an uncounted tool" do
     create(:event, calendar_id: Event.appointment_slot_calendar_id, start: 27.hours.since, finish: 28.hours.since)
 


### PR DESCRIPTION
# What it does

closes #940 

Instead of showing the appointment form, we show a blurb explaining they cannot make an appointment with no holds nor returns.

# Why it is important

This makes the appointment page less cluttered for folks who can't make an appointment because they don't have a hold nor an item to return.

# UI Change Screenshot

Before | After
--- | ---
![blurb telling user they cannot make an appointment, and then a form to make an appointment.](https://user-images.githubusercontent.com/3331/149863217-05cceca7-5aad-439d-acd3-e58a4824f54e.png) | ![form is gone on schedule appointment page](https://user-images.githubusercontent.com/8124558/153765531-054c2996-e51c-43b9-a37e-46df8a375b3a.png)


# Implementation notes

* I moved the form into an if/else instead of it living outside the if. I handled it inside _form, so if this form is used anywhere else, the change will also apply.

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [x] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):

_My weekday schedule is a little full, but every weekend, I have time to contribute._