### PR TITLE
Don't delete holds when item goes maintenance

### DIFF
--- a/app/models/hold.rb
+++ b/app/models/hold.rb
@@ -113,6 +113,11 @@ class Hold < ApplicationRecord
     started = 0
 
     active(now).includes(item: :borrow_policy).find_each do |hold|
+      if hold.item.status == Item.statuses[:maintenance]
+        Rails.logger.debug "[hold #{hold.id}]: item in maintenance mode"
+        next
+      end
+
       unless hold.item.holdable?
         Rails.logger.debug "[hold #{hold.id}]: item is not holdable"
         next

--- a/test/models/hold_test.rb
+++ b/test/models/hold_test.rb
@@ -254,6 +254,18 @@ class HoldTest < ActiveSupport::TestCase
     end
   end
 
+  test "does not start a hold on an item in maintenance" do
+    hammer = create(:item)
+    create(:hold, item: hammer)
+    hammer.update!(status: Item.statuses[:maintenance])
+
+    assert_no_difference("Hold.started.count") do
+      Hold.start_waiting_holds do |hold|
+        fail "should not be called"
+      end
+    end
+  end
+
   test "is ready for pickup if item is uncounted" do
     item = create(:uncounted_item)
 

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -137,7 +137,18 @@ class ItemTest < ActiveSupport::TestCase
     assert_equal item.active_holds.count, 1
 
     item.update!(status: Item.statuses[:maintenance])
+    assert_equal item.active_holds.count, 1
+
+    item.update!(status: Item.statuses[:retired])
     assert_equal item.active_holds.count, 0
+  end
+
+  test "clears next hold when changed to maintenance" do
+    item = create(:item)
+    hold = create(:started_hold, item: item)
+
+    item.update!(status: Item.statuses[:maintenance])
+    assert_nil hold.reload.started_at
   end
 
   test "the for_category scope returns all items for that category" do


### PR DESCRIPTION
# What it does

Pauses holds instead of deleting them when an item is put into maintenance mode. I generally followed the steps mentioned in the issue but added an additional callback for updating the `next_hold`

# Why it is important

#629

# Implementation notes

* I'm calling `update_columns` instead of `update!` for clearing the `next_hold` to avoid validations. This was because once the item is updated to `maintenance` all hold validations fail because the item is no longer holdable. Initially I tried to fix this by moving the callback into `before_save`, but I still ran into the same issue

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
