### PR TITLE
Selenuim config update

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       - config/docker.env
     stdin_open: true
     tty: true
+    tmpfs:
+      - /tmp
     networks:
       default:
         aliases:


### PR DESCRIPTION
# What it does

This PR resolves a few issues (including #978) involving deprecation warnings or errors from the selenium driver configuration getting out of date with the latest updates to the library.

# Why it is important

System tests should work for everyone, and ideally there should be no deprecation warnings to add noise to the test output.

# Implementation notes

* There is some duplication in the configuration that we can look into addressing in the future, but in the past we needed to control each combination of headless/dockerness individually. So I'm inclined to leave the duplication there for now should we need to do that again.
* It's possible that we don't need all of the options (in particular `disable-dev-shm-usage`) but I didn't fully test this in all situations.

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
