### PR TITLE
Include items in child categories in the for_category scope.

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -77,7 +77,7 @@ class Item < ApplicationRecord
   scope :strength_contains, ->(query) { where("strength ILIKE ?", "#{"%" if query.size > 1}#{query}%").limit(10).distinct }
   scope :listed_publicly, -> { where("status = ? OR status = ?", Item.statuses[:active], Item.statuses[:maintenance]) }
   scope :with_category, ->(category) { joins(:categories).merge(category.items) }
-  scope :for_category, ->(category) { joins(:categories).where(categories: {id: category}) }
+  scope :for_category, ->(category) { joins(:categorizations).where(categorizations: {category_id: CategoryNode.find(category.id).tree_ids}).distinct }
   scope :available, -> { left_outer_joins(:checked_out_exclusive_loan).where(loans: {id: nil}) }
   scope :without_attached_image, -> { left_joins(:image_attachment).where(active_storage_attachments: {record_id: nil}) }
   scope :in_maintenance, -> { where(status: Item.statuses.values_at(:maintenance)) }

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -170,4 +170,36 @@ class ItemTest < ActiveSupport::TestCase
     assert_not_includes(scope_for_category2, item1)
     assert_not_includes(scope_for_category2, item3)
   end
+
+  test "the for_category scope returns all items for child categories" do
+    parent = create(:category)
+    child = create(:category, parent: parent)
+    grandchild = create(:category, parent: child)
+
+    item1 = create(:item, categories: [parent])
+    item2 = create(:item, categories: [child])
+    item3 = create(:item, categories: [grandchild])
+    item4 = create(:item)
+
+    scope_for_parent = Item.for_category(parent)
+
+    assert_includes(scope_for_parent, item1)
+    assert_includes(scope_for_parent, item2)
+    assert_includes(scope_for_parent, item3)
+    assert_not_includes(scope_for_parent, item4)
+
+    scope_for_child = Item.for_category(child)
+
+    assert_not_includes(scope_for_child, item1)
+    assert_includes(scope_for_child, item2)
+    assert_includes(scope_for_child, item3)
+    assert_not_includes(scope_for_child, item4)
+
+    scope_for_grandchild = Item.for_category(grandchild)
+
+    assert_not_includes(scope_for_grandchild, item1)
+    assert_not_includes(scope_for_grandchild, item2)
+    assert_includes(scope_for_grandchild, item3)
+    assert_not_includes(scope_for_grandchild, item4)
+  end
 end


### PR DESCRIPTION
# What it does
This PR fixes a bug where items in child categories weren't being shown on the inventory pages.

# Why it is important

This was a regression that popped up while doing some other work on filtering. We didn't notice it until now.

# Implementation notes

* I added a test for this case.

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
