### PR TITLE
Allow admins to view previous holds

### DIFF
--- a/app/controllers/admin/item_holds_controller.rb
+++ b/app/controllers/admin/item_holds_controller.rb
@@ -2,13 +2,25 @@ module Admin
   class ItemHoldsController < BaseController
     def index
       @item = Item.find(params[:item_id])
-      @holds = @item.holds.order(created_at: :asc)
+      holds_scope = @item.holds.order(created_at: :asc)
       @holds =
         if params[:inactive]
-          @holds.inactive
+          holds_scope.inactive
         else
-          @holds.active
+          holds_scope.active
         end
     end
+
+    def wait_time(hold)
+      if hold.active?
+        helpers.time_ago_in_words(hold.created_at)
+      elsif hold.ended_at.present?
+        helpers.distance_of_time_in_words(hold.created_at, hold.ended_at)
+      else
+        helpers.distance_of_time_in_words(hold.created_at, hold.expires_at)
+      end
+    end
+
+    helper_method :wait_time
   end
 end

--- a/app/controllers/admin/item_holds_controller.rb
+++ b/app/controllers/admin/item_holds_controller.rb
@@ -2,7 +2,13 @@ module Admin
   class ItemHoldsController < BaseController
     def index
       @item = Item.find(params[:item_id])
-      @holds = @item.active_holds.order(created_at: :asc)
+      @holds = @item.holds.order(created_at: :asc)
+      @holds =
+        if params[:inactive]
+          @holds.inactive
+        else
+          @holds.active
+        end
     end
   end
 end

--- a/app/views/admin/item_holds/index.html.erb
+++ b/app/views/admin/item_holds/index.html.erb
@@ -1,10 +1,10 @@
 <%= render "admin/items/profile" do %>
 <div class="btn-group mt-2">
-  <%= link_to_unless params[:inactive].blank?, "Active", url_for, method: :get, class: "btn btn-sm" do %>
-    <button class="btn btn-sm active">Active</button>
+  <%= link_to_unless params[:inactive].blank?, "Current", url_for, method: :get, class: "btn btn-sm" do %>
+    <button class="btn btn-sm active">Current</button>
   <% end %>
-  <%= link_to_unless_current "Inactive", url_for(inactive: true), method: :get, class: "btn btn-sm" do %>
-    <button class="btn btn-sm active">Inactive</button>
+  <%= link_to_unless_current "Ended", url_for(inactive: true), method: :get, class: "btn btn-sm" do %>
+    <button class="btn btn-sm active">Ended</button>
   <% end %>
 </div>
   <table class="table">
@@ -13,7 +13,11 @@
       <th>Member</th>
       <th>Reserved</th>
       <th>Wait time</th>
-      <th>Expires on</th>
+      <% if params[:inactive].blank? %>
+        <th>Expires on</th>
+      <% else %>
+        <th>Picked up on</th>
+      <% end %>
     </thead>
     <tbody>
       <% @holds.each_with_index do |hold, index| %>
@@ -24,8 +28,12 @@
                   admin_member_holds_path(hold.member) %>
           </td>
           <td><%= date_with_time_title hold.created_at %></td>
-          <td><%= time_ago_in_words(hold.created_at) %></td>
-          <td><%= date_with_time_title(hold.expires_at) if hold.expires_at %></td>
+          <td><%= wait_time(hold) %></td>
+          <% if params[:inactive].blank? %>
+            <td><%= date_with_time_title(hold.expires_at) if hold.expires_at %></td>
+          <% else %>
+            <td><%= date_with_time_title(hold.loan.created_at) if hold.loan %></td>
+          <% end %>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/admin/item_holds/index.html.erb
+++ b/app/views/admin/item_holds/index.html.erb
@@ -1,4 +1,12 @@
 <%= render "admin/items/profile" do %>
+<div class="btn-group mt-2">
+  <%= link_to_unless params[:inactive].blank?, "Active", url_for, method: :get, class: "btn btn-sm" do %>
+    <button class="btn btn-sm active">Active</button>
+  <% end %>
+  <%= link_to_unless_current "Inactive", url_for(inactive: true), method: :get, class: "btn btn-sm" do %>
+    <button class="btn btn-sm active">Inactive</button>
+  <% end %>
+</div>
   <table class="table">
     <thead>
       <th>#</th>
@@ -9,7 +17,7 @@
     </thead>
     <tbody>
       <% @holds.each_with_index do |hold, index| %>
-        <tr>
+        <tr data-hold-id="<%= hold.id %>">
           <td><%= index + 1 %></td>
           <td>
             <%= link_to preferred_or_default_name(hold.member),

--- a/test/system/admin/items_test.rb
+++ b/test/system/admin/items_test.rb
@@ -170,7 +170,7 @@ class ItemsTest < ApplicationSystemTestCase
     visit admin_item_item_holds_path(@item)
     find("[data-hold-id='#{@active_hold.id}']")
 
-    click_on "Inactive"
+    click_on "Ended"
     find("[data-hold-id='#{@inactive_hold.id}']")
   end
 end

--- a/test/system/admin/items_test.rb
+++ b/test/system/admin/items_test.rb
@@ -161,4 +161,16 @@ class ItemsTest < ApplicationSystemTestCase
     assert_text "Item was successfully created"
     assert_equal 1, Item.all.map(&:name).count(@item.name)
   end
+
+  test "viewing an item's holds" do
+    @item = create(:item)
+    @active_hold = create(:hold, item: @item)
+    @inactive_hold = create(:ended_hold, item: @item)
+
+    visit admin_item_item_holds_path(@item)
+    find("[data-hold-id='#{@active_hold.id}']")
+
+    click_on "Inactive"
+    find("[data-hold-id='#{@inactive_hold.id}']")
+  end
 end


### PR DESCRIPTION
Thanks to @jutonz for pairing with me on this 🙂 

# What it does

Admins can toggle to see an item's active or inactive holds.

# Why it is important

Resolves issue https://github.com/rubyforgood/circulate/issues/980

# UI Change Screenshot

<img width="1054" alt="image" src="https://user-images.githubusercontent.com/12875392/157986064-9f1e1a3a-7776-4ad1-9166-a6deae645b1a.png">


# Implementation notes

A few open questions:

1. We assumed "previous/historic" holds (as written in the [issue](https://github.com/rubyforgood/circulate/issues/980)) meant inactive, but it looks like there are more granular states. Was this the correct assumption or should the list filter on something else?
2. Related, we labeled the buttons "Active" and "Inactive" based on what I saw in the code. Will that work or there more user-friendly terms to use here? 
3. Inactive holds shows the same data in the table as active holds, but it looks like some of the columns might not be relevant, or that some additional information for inactive holds could be helpful! Let me know if there's a change I can make here.

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [x] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
