### PR TITLE
Set staff_updating to avoid empty appointment validation issue

### DIFF
--- a/app/controllers/admin/appointment_completions_controller.rb
+++ b/app/controllers/admin/appointment_completions_controller.rb
@@ -6,13 +6,13 @@ module Admin
 
     def create
       @appointment = Appointment.find(params[:appointment_id])
-      @appointment.update!(completed_at: Time.current)
+      @appointment.update!(completed_at: Time.current, staff_updating: true)
       render_to_portal("admin/appointments/appointment", table_row: true, locals: {appointment: @appointment})
     end
 
     def destroy
       @appointment = Appointment.find(params[:appointment_id])
-      @appointment.update!(completed_at: nil)
+      @appointment.update!(completed_at: nil, staff_updating: true)
       render_to_portal("admin/appointments/appointment", table_row: true, locals: {appointment: @appointment})
     end
   end

--- a/test/controllers/admin/appointment_completions_controller_test.rb
+++ b/test/controllers/admin/appointment_completions_controller_test.rb
@@ -1,0 +1,43 @@
+require "application_system_test_case"
+
+module Admin
+  class AppointmentCompletionsControllerTest < ActionDispatch::IntegrationTest
+    include Devise::Test::IntegrationHelpers
+
+    setup do
+      @member = create(:member)
+      @loan = create(:loan, member: @member)
+      @appointment = build(:appointment, member: @member)
+      @appointment.loans << @loan
+      @appointment.save!
+
+      @user = create(:admin_user)
+      sign_in @user
+    end
+
+    test "completes an appointment" do
+      post admin_appointment_completion_path(@appointment)
+      assert_response :success
+
+      assert @appointment.reload.completed_at
+    end
+
+    test "completes an empty appointment" do
+      @appointment.appointment_loans.delete_all
+
+      post admin_appointment_completion_path(@appointment)
+      assert_response :success
+
+      assert @appointment.reload.completed_at
+    end
+
+    test "un-completes an appointment" do
+      @appointment.update!(completed_at: Time.current)
+
+      delete admin_appointment_completion_path(@appointment)
+      assert_response :success
+
+      assert_nil @appointment.reload.completed_at
+    end
+  end
+end


### PR DESCRIPTION
# What it does

This fixes a bug where appointment without items couldn't be marked as complete.