### PR TITLE
Item hold counts

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -14,7 +14,7 @@ module Admin
         item_scope = @category.items
       end
 
-      item_scope = item_scope.includes(:categories, :borrow_policy).with_attached_image.order(index_order)
+      item_scope = item_scope.includes(:categories, :borrow_policy, :active_holds).with_attached_image.order(index_order)
 
       @pagy, @items = pagy(item_scope)
       @categories = CategoryNode.with_items

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -896,12 +896,12 @@ table.monthly-adjustments {
 }
 
 .item-stats, .member-stats {
-  li.categories {
-    svg, .category-stats {
+  li.with-inner-stats {
+    svg, .inner-stats {
       float: left;
     }
   }
-  .category-stats {
+  .inner-stats {
     list-style: none outside;
     float: left;
     margin: 0;

--- a/app/views/admin/items/_item_panel.html.erb
+++ b/app/views/admin/items/_item_panel.html.erb
@@ -16,7 +16,16 @@
 
     <div class="panel-body">
         <ul class="item-stats">
-            <%= icon_stat "map-pin", item_location_span(item), title: "location", placeholder: "No location" %>
+            <%= icon_stat "map-pin", title: "location", css_class: "with-inner-stats" do %>
+                    <ul class="inner-stats">
+                        <% if item.location_area.present? %>
+                            <li><span class="text-italic">area</span> <%= item.location_area %></li>
+                        <% end %>
+                        <% if item.location_shelf.present? %>
+                            <li><span class="text-italic">shelf</span> <%= item.location_shelf %></li>
+                        <% end %>
+                    </ul>
+            <% end %>
             <% if item.tracks_quantity? %>
                 <%= icon_stat "layers", "#{item.quantity} in stock", title: "quantity", placeholder: "No quantity" %>
             <% end %>
@@ -31,9 +40,9 @@
                     <%= link_to "More info", item.url %>
                 <% end %>
             <% end %>
-            <%= icon_stat "tag", title: "categories", css_class: "categories", placeholder: "No categories" do %>
+            <%= icon_stat "tag", title: "categories", css_class: "with-inner-stats", placeholder: "No categories" do %>
                 <% if item.categories.size > 0 %>
-                    <ul class="category-stats">
+                    <ul class="inner-stats">
                         <% item.categories.sort_by(&:name).each do |category| %>
                             <li><%= link_to category.name, admin_items_path(category: category) %></li>
                         <% end %>

--- a/app/views/admin/items/_items.html.erb
+++ b/app/views/admin/items/_items.html.erb
@@ -13,7 +13,7 @@
     <%= tag.div class: "items-table-name" do %>
       <strong><%= full_item_number(item) %></strong>
       <%= item_status_label(item) %>
-      <span class="text-small"><%= pluralize item.active_holds.size, "hold"%></span>
+      <span class="text-small"><%= pluralize item.active_holds.size, "hold" %></span>
       <br>
       <%= link_to item.name, admin_item_path(item) %>
       <% if item.size.present? %>

--- a/app/views/admin/items/_items.html.erb
+++ b/app/views/admin/items/_items.html.erb
@@ -13,6 +13,7 @@
     <%= tag.div class: "items-table-name" do %>
       <strong><%= full_item_number(item) %></strong>
       <%= item_status_label(item) %>
+      <span class="text-small"><%= pluralize item.active_holds.size, "hold"%></span>
       <br>
       <%= link_to item.name, admin_item_path(item) %>
       <% if item.size.present? %>

--- a/app/views/admin/items/_profile.html.erb
+++ b/app/views/admin/items/_profile.html.erb
@@ -40,7 +40,7 @@
     <ul class="tab">
       <%= tab_link "Description", admin_item_path(@item) %>
       <%= tab_link "Files", admin_item_attachments_path(@item) %>
-      <%= tab_link "Holds", admin_item_item_holds_path(@item) %>
+      <%= tab_link "Holds", admin_item_item_holds_path(@item), badge: @item.active_holds.count %>
       <%= tab_link "Loan History", admin_item_loan_history_path(@item) %>
       <%= tab_link "Edit History", admin_item_item_history_path(@item) %>
       <% if ENV["FEATURE_MAINTENANCE_WORKFLOW"] %>

--- a/app/views/items/_item_panel.html.erb
+++ b/app/views/items/_item_panel.html.erb
@@ -1,7 +1,16 @@
 <div class="panel item-panel">
     <div class="panel-body">
         <ul class="item-stats">
-            <%= icon_stat "map-pin", item_location_span(item), title: "location" %>
+            <%= icon_stat "map-pin", title: "location", css_class: "with-inner-stats" do %>
+                    <ul class="inner-stats">
+                        <% if item.location_area.present? %>
+                            <li><span class="text-italic">area</span> <%= item.location_area %></li>
+                        <% end %>
+                        <% if item.location_shelf.present? %>
+                            <li><span class="text-italic">shelf</span> <%= item.location_shelf %></li>
+                        <% end %>
+                    </ul>
+            <% end %>
             <% if item.tracks_quantity? %>
                 <%= icon_stat "layers", "#{item.quantity} in stock", title: "quantity" %>
             <% end %>
@@ -16,9 +25,9 @@
                     <%= link_to "More info", item.url %>
                 <% end %>
             <% end %>
-            <%= icon_stat "tag", title: "categories", css_class: "categories", placeholder: "No categories" do %>
+            <%= icon_stat "tag", title: "categories", css_class: "with-inner-stats", placeholder: "No categories" do %>
                 <% if item.categories.size > 0 %>
-                    <ul class="category-stats">
+                    <ul class="inner-stats">
                         <% item.categories.sort_by(&:name).each do |category| %>
                             <li><%= link_to category.name, items_path(category: category) %></li>
                         <% end %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -80,7 +80,7 @@
             <strong><%= full_item_number(item) %></strong>
             <%= item_status_label(item) %>
             <% if item.active_holds.any? %>
-              <span class="text-small"><%= pluralize item.active_holds.size, "hold"%></span>
+              <span class="text-small"><%= pluralize item.active_holds.size, "hold" %></span>
             <% end %>
             <br>
             <%= link_to item.name, item_path(item) %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -79,6 +79,9 @@
           <%= tag.div class: "items-table-name" do %>
             <strong><%= full_item_number(item) %></strong>
             <%= item_status_label(item) %>
+            <% if item.active_holds.any? %>
+              <span class="text-small"><%= pluralize item.active_holds.size, "hold"%></span>
+            <% end %>
             <br>
             <%= link_to item.name, item_path(item) %>
             <%#= item.added %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,6 +4,9 @@
   <h2>
     <strong><%= @item.complete_number %></strong>
     <%= item_status_label(@item) %>
+    <% if @item.active_holds.any? %>
+      <span class="text-small"><%= pluralize @item.active_holds.count, "hold" %></span>
+    <% end %>
   </h2>
 
   <div class="columns">


### PR DESCRIPTION
# What it does

Displays the number of active holds in a few places:
* The items lists in both public inventory and admin side
* The inventory item page
* The admin item page

# Why it is important

See #984 

# Your bandwidth for additional changes to this PR

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
