### PR TITLE
Item status category counts

### DIFF
--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -5,7 +5,7 @@ module Admin
     before_action :set_category, only: [:show, :edit, :update, :destroy]
 
     def index
-      @categories = CategoryNode.all
+      @categories = CategoryNode.all.sorted
     end
 
     def new

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -97,7 +97,7 @@ module ItemsHelper
       end
 
       # NOTE: This does not reflect current query / category selection
-      count = node.value.tree_categorizations_count
+      count = node.value.visible_items_count
 
       concat(link_to((node.value.name + "&nbsp;(#{count})").html_safe, add_filter_param(:category, node.value.id)))
       if has_children

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -68,14 +68,14 @@ module ItemsHelper
 
   def category_tree_nav(categories, current_category = nil)
     root = TreeNode.new(nil)
-    categories.each do |category|
+    categories.sort_by { |c| c.path_ids.size }.each do |category|
       parent = category.path_ids[0..-2].reduce(root) { |node, id| node[id] }
       parent[category.id] = TreeNode.new(category)
     end
 
     tag.nav(class: "tree-nav", data: {controller: "tree-nav"}) do
       concat(tag.ul do
-        root.children.values.map do |node|
+        root.children.values.sort_by { |node| node.value.name }.map do |node|
           concat(render_tree_node(node, current_category))
         end
       end)
@@ -102,7 +102,7 @@ module ItemsHelper
       concat(link_to((node.value.name + "&nbsp;(#{count})").html_safe, add_filter_param(:category, node.value.id)))
       if has_children
         concat(tag.ul(class: "tree-node-children") do
-          node.children.values.map do |child|
+          node.children.values.sort_by { |node| node.value.name }.map do |child|
             concat(render_tree_node(child, current_value))
           end
         end)

--- a/app/models/categorization.rb
+++ b/app/models/categorization.rb
@@ -4,18 +4,10 @@ class Categorization < ApplicationRecord
   belongs_to :category_node, foreign_key: "category_id"
   validates :category_id, uniqueness: {scope: :item_id}
 
-  after_commit :refresh_category_nodes
-
   after_save :update_category_item_counts
   after_destroy :update_category_item_counts
 
   private
-
-  # update categorization_counts
-  # TODO remove this once the we're using the new status-based counts
-  def refresh_category_nodes
-    CategoryNode.refresh
-  end
 
   def update_category_item_counts
     category.update_item_counts

--- a/app/models/categorization.rb
+++ b/app/models/categorization.rb
@@ -6,8 +6,18 @@ class Categorization < ApplicationRecord
 
   after_commit :refresh_category_nodes
 
+  after_save :update_category_item_counts
+  after_destroy :update_category_item_counts
+
+  private
+
   # update categorization_counts
+  # TODO remove this once the we're using the new status-based counts
   def refresh_category_nodes
     CategoryNode.refresh
+  end
+
+  def update_category_item_counts
+    category.update_item_counts
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -39,6 +39,13 @@ class Category < ApplicationRecord
     CategoryNode.refresh
   end
 
+  def update_item_counts
+    item_counts = Item.statuses.values.each_with_object({}) { |status, counts| counts[status] = 0 }
+    items.pluck(:status).each_with_object(item_counts) { |status, counts| counts[status] += 1 }
+
+    update(item_counts: item_counts)
+  end
+
   def self.recursive_all
     find_by_sql(<<~SQL)
       WITH RECURSIVE subcategories AS (

--- a/app/models/category_node.rb
+++ b/app/models/category_node.rb
@@ -8,6 +8,7 @@ class CategoryNode < ApplicationRecord
   acts_as_tenant :library
 
   scope :with_items, -> { where("(tree_item_counts->>'active')::int > 0") }
+  scope :sorted, -> { order("sort_name ASC") }
 
   def full_name
     path_names.join("  ")

--- a/app/models/category_node.rb
+++ b/app/models/category_node.rb
@@ -7,10 +7,14 @@ class CategoryNode < ApplicationRecord
 
   acts_as_tenant :library
 
-  scope :with_items, -> { where("tree_categorizations_count > 0") }
+  scope :with_items, -> { where("(tree_item_counts->>'active')::int > 0") }
 
   def full_name
     path_names.join("  ")
+  end
+
+  def visible_items_count
+    tree_item_counts.values_at("active", "maintenance").sum
   end
 
   # used for dom_class and other view-level helpers
@@ -19,6 +23,6 @@ class CategoryNode < ApplicationRecord
   end
 
   def self.refresh
-    Scenic.database.refresh_materialized_view(table_name, concurrently: false, cascade: false)
+    Scenic.database.refresh_materialized_view(table_name, concurrently: true, cascade: false)
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -96,7 +96,6 @@ class Item < ApplicationRecord
   before_validation :strip_whitespace
 
   before_save :cache_description_as_plain_text
-
   after_update :clear_holds_if_inactive, :pause_next_hold_if_maintenance
 
   def self.next_number(limit = nil)

--- a/app/views/admin/categories/index.html.erb
+++ b/app/views/admin/categories/index.html.erb
@@ -16,7 +16,7 @@
       <% end %>
 
       <%= tag.div class: "categories-table-count" do %>
-        <%= category.tree_categorizations_count %>
+        <%= category.visible_items_count %>
       <% end %>
 
       <%= tag.div class: "categories-table-actions" do %>

--- a/db/migrate/20220330165641_add_item_counts_to_category.rb
+++ b/db/migrate/20220330165641_add_item_counts_to_category.rb
@@ -1,0 +1,5 @@
+class AddItemCountsToCategory < ActiveRecord::Migration[6.1]
+  def change
+    add_column :categories, :item_counts, :jsonb, default: {}
+  end
+end

--- a/db/migrate/20220330175925_update_category_nodes_to_version_3.rb
+++ b/db/migrate/20220330175925_update_category_nodes_to_version_3.rb
@@ -1,0 +1,8 @@
+class UpdateCategoryNodesToVersion3 < ActiveRecord::Migration[6.1]
+  def change
+    update_view :category_nodes,
+      version: 3,
+      revert_to_version: 2,
+      materialized: true
+  end
+end

--- a/db/migrate/20220403224122_add_unique_index_to_category_nodes.rb
+++ b/db/migrate/20220403224122_add_unique_index_to_category_nodes.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToCategoryNodes < ActiveRecord::Migration[6.1]
+  def change
+    add_index :category_nodes, :id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -678,6 +678,7 @@ ActiveRecord::Schema.define(version: 2022_04_03_224122) do
       search_tree.parent_id,
       search_tree.path_names,
       search_tree.path_ids,
+      lower(array_to_string(search_tree.path_names, ' '::text)) AS sort_name,
       ( SELECT json_build_object('active', COALESCE(sum(((st.item_counts -> 'active'::text))::integer), (0)::bigint), 'retired', COALESCE(sum(((st.item_counts -> 'retired'::text))::integer), (0)::bigint), 'maintenance', COALESCE(sum(((st.item_counts -> 'maintenance'::text))::integer), (0)::bigint), 'pending', COALESCE(sum(((st.item_counts -> 'pending'::text))::integer), (0)::bigint)) AS json_build_object
              FROM search_tree st
             WHERE (search_tree.id = ANY (st.path_ids))) AS tree_item_counts,
@@ -685,7 +686,8 @@ ActiveRecord::Schema.define(version: 2022_04_03_224122) do
              FROM search_tree st
             WHERE (search_tree.id = ANY (st.path_ids))) AS tree_ids
      FROM search_tree
-    ORDER BY search_tree.path_names;
+    ORDER BY (lower(array_to_string(search_tree.path_names, ' '::text)));
   SQL
   add_index "category_nodes", ["id"], name: "index_category_nodes_on_id", unique: true
+
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_30_165641) do
+ActiveRecord::Schema.define(version: 2022_04_03_224122) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -556,48 +556,6 @@ ActiveRecord::Schema.define(version: 2022_03_30_165641) do
   add_foreign_key "tickets", "users", column: "creator_id"
   add_foreign_key "users", "members"
 
-  create_view "category_nodes", materialized: true, sql_definition: <<-SQL
-      WITH RECURSIVE search_tree(id, library_id, name, slug, categorizations_count, parent_id, path_names, path_ids) AS (
-           SELECT categories.id,
-              categories.library_id,
-              categories.name,
-              categories.slug,
-              categories.categorizations_count,
-              categories.parent_id,
-              ARRAY[categories.name] AS "array",
-              ARRAY[categories.id] AS "array"
-             FROM categories
-            WHERE (categories.parent_id IS NULL)
-          UNION ALL
-           SELECT categories.id,
-              categories.library_id,
-              categories.name,
-              categories.slug,
-              categories.categorizations_count,
-              categories.parent_id,
-              (search_tree_1.path_names || categories.name),
-              (search_tree_1.path_ids || categories.id)
-             FROM (search_tree search_tree_1
-               JOIN categories ON ((categories.parent_id = search_tree_1.id)))
-            WHERE (NOT (categories.id = ANY (search_tree_1.path_ids)))
-          )
-   SELECT search_tree.id,
-      search_tree.library_id,
-      search_tree.name,
-      search_tree.slug,
-      search_tree.categorizations_count,
-      search_tree.parent_id,
-      search_tree.path_names,
-      search_tree.path_ids,
-      ( SELECT sum(st.categorizations_count) AS sum
-             FROM search_tree st
-            WHERE (search_tree.id = ANY (st.path_ids))) AS tree_categorizations_count,
-      ( SELECT array_agg(st.id) AS array_agg
-             FROM search_tree st
-            WHERE (search_tree.id = ANY (st.path_ids))) AS tree_ids
-     FROM search_tree
-    ORDER BY search_tree.path_names;
-  SQL
   create_view "loan_summaries", sql_definition: <<-SQL
       SELECT loans.library_id,
       loans.item_id,
@@ -687,4 +645,47 @@ ActiveRecord::Schema.define(version: 2022_03_30_165641) do
     GROUP BY months.month
     ORDER BY months.month;
   SQL
+  create_view "category_nodes", materialized: true, sql_definition: <<-SQL
+      WITH RECURSIVE search_tree(id, library_id, name, slug, item_counts, parent_id, path_names, path_ids) AS (
+           SELECT categories.id,
+              categories.library_id,
+              categories.name,
+              categories.slug,
+              categories.item_counts,
+              categories.parent_id,
+              ARRAY[categories.name] AS "array",
+              ARRAY[categories.id] AS "array"
+             FROM categories
+            WHERE (categories.parent_id IS NULL)
+          UNION ALL
+           SELECT categories.id,
+              categories.library_id,
+              categories.name,
+              categories.slug,
+              categories.item_counts,
+              categories.parent_id,
+              (search_tree_1.path_names || categories.name),
+              (search_tree_1.path_ids || categories.id)
+             FROM (search_tree search_tree_1
+               JOIN categories ON ((categories.parent_id = search_tree_1.id)))
+            WHERE (NOT (categories.id = ANY (search_tree_1.path_ids)))
+          )
+   SELECT search_tree.id,
+      search_tree.library_id,
+      search_tree.name,
+      search_tree.slug,
+      search_tree.item_counts,
+      search_tree.parent_id,
+      search_tree.path_names,
+      search_tree.path_ids,
+      ( SELECT json_build_object('active', COALESCE(sum(((st.item_counts -> 'active'::text))::integer), (0)::bigint), 'retired', COALESCE(sum(((st.item_counts -> 'retired'::text))::integer), (0)::bigint), 'maintenance', COALESCE(sum(((st.item_counts -> 'maintenance'::text))::integer), (0)::bigint), 'pending', COALESCE(sum(((st.item_counts -> 'pending'::text))::integer), (0)::bigint)) AS json_build_object
+             FROM search_tree st
+            WHERE (search_tree.id = ANY (st.path_ids))) AS tree_item_counts,
+      ( SELECT array_agg(st.id) AS array_agg
+             FROM search_tree st
+            WHERE (search_tree.id = ANY (st.path_ids))) AS tree_ids
+     FROM search_tree
+    ORDER BY search_tree.path_names;
+  SQL
+  add_index "category_nodes", ["id"], name: "index_category_nodes_on_id", unique: true
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_27_010549) do
+ActiveRecord::Schema.define(version: 2022_03_30_165641) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -219,6 +219,7 @@ ActiveRecord::Schema.define(version: 2022_03_27_010549) do
     t.integer "categorizations_count", default: 0, null: false
     t.bigint "parent_id"
     t.integer "library_id"
+    t.jsonb "item_counts", default: {}
     t.index ["library_id", "name"], name: "index_categories_on_library_id_and_name", unique: true
     t.index ["library_id", "slug"], name: "index_categories_on_library_id_and_slug", unique: true
     t.index ["parent_id"], name: "index_categories_on_parent_id"

--- a/db/views/category_nodes_v03.sql
+++ b/db/views/category_nodes_v03.sql
@@ -14,6 +14,7 @@ WITH RECURSIVE search_tree(id, library_id, name, slug, item_counts, parent_id, p
   )
   
   SELECT *,
+    lower(array_to_string(path_names, ' ')) as sort_name,
     (SELECT json_build_object(
       'active', COALESCE(SUM((st.item_counts->'active')::int), 0),
       'retired', COALESCE(SUM((st.item_counts->'retired')::int), 0),
@@ -21,4 +22,4 @@ WITH RECURSIVE search_tree(id, library_id, name, slug, item_counts, parent_id, p
       'pending', COALESCE(SUM((st.item_counts->'pending')::int), 0)
     ) FROM search_tree AS st WHERE search_tree.id = ANY(st.path_ids)) AS tree_item_counts,
     (SELECT array_agg(st.id) FROM search_tree AS st WHERE search_tree.id = ANY(st.path_ids)) AS tree_ids
-  FROM search_tree ORDER BY path_names;
+  FROM search_tree ORDER BY sort_name ASC;

--- a/db/views/category_nodes_v03.sql
+++ b/db/views/category_nodes_v03.sql
@@ -1,0 +1,24 @@
+WITH RECURSIVE search_tree(id, library_id, name, slug, item_counts, parent_id, path_names, path_ids) AS (
+
+  SELECT id, library_id, name, slug, item_counts, parent_id, ARRAY[name], ARRAY[id]
+    FROM categories
+  WHERE parent_id IS NULL
+  
+  UNION ALL
+  
+    SELECT categories.id, categories.library_id, categories.name, categories.slug, categories.item_counts, 
+            categories.parent_id, path_names || categories.name, path_ids || categories.id
+    FROM search_tree
+    JOIN categories ON categories.parent_id = search_tree.id
+    WHERE NOT categories.id = ANY(path_ids)
+  )
+  
+  SELECT *,
+    (SELECT json_build_object(
+      'active', COALESCE(SUM((st.item_counts->'active')::int), 0),
+      'retired', COALESCE(SUM((st.item_counts->'retired')::int), 0),
+      'maintenance', COALESCE(SUM((st.item_counts->'maintenance')::int), 0),
+      'pending', COALESCE(SUM((st.item_counts->'pending')::int), 0)
+    ) FROM search_tree AS st WHERE search_tree.id = ANY(st.path_ids)) AS tree_item_counts,
+    (SELECT array_agg(st.id) FROM search_tree AS st WHERE search_tree.id = ANY(st.path_ids)) AS tree_ids
+  FROM search_tree ORDER BY path_names;

--- a/lib/tasks/categories.rake
+++ b/lib/tasks/categories.rake
@@ -3,4 +3,12 @@ namespace :categories do
   task refresh_nodes: :environment do
     CategoryNode.refresh
   end
+
+  desc "Update the category counts for all categories"
+  task update_category_counts: :environment do
+    Category.find_each do |category|
+      category.update_item_counts
+    end
+    CategoryNode.refresh
+  end
 end

--- a/lib/tasks/categories.rake
+++ b/lib/tasks/categories.rake
@@ -1,0 +1,6 @@
+namespace :categories do
+  desc "Updates the category_nodes materialized view"
+  task refresh_nodes: :environment do
+    CategoryNode.refresh
+  end
+end

--- a/test/models/categorization_test.rb
+++ b/test/models/categorization_test.rb
@@ -1,7 +1,0 @@
-require "test_helper"
-
-class CategorizationTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
-end

--- a/test/models/category_node_test.rb
+++ b/test/models/category_node_test.rb
@@ -2,27 +2,28 @@ require "test_helper"
 
 class CategoryNodeTest < ActiveSupport::TestCase
   test "loads entire tree" do
-    power_tools = Category.create(name: "Power Tools", categorizations_count: 1)
-    saws = Category.create!(name: "Saws", parent: power_tools, categorizations_count: 2)
-    mitre_saws = Category.create!(name: "Mitre Saws", parent: saws, categorizations_count: 4)
+    power_tools = Category.create(name: "Power Tools", item_counts: {active: 1})
+    saws = Category.create!(name: "Saws", parent: power_tools, item_counts: {active: 2})
+    mitre_saws = Category.create!(name: "Mitre Saws", parent: saws, item_counts: {active: 4})
 
-    tree = CategoryNode.all
+    CategoryNode.refresh
+    tree = CategoryNode.all.order("id ASC")
 
     assert_equal power_tools.id, tree[0].id
-    assert_equal 1, tree[0].categorizations_count
-    assert_equal 7, tree[0].tree_categorizations_count
+    assert_equal({"active" => 1}, tree[0].item_counts)
+    assert_equal 7, tree[0].visible_items_count
     assert_equal [power_tools.id], tree[0].path_ids
     assert_equal [power_tools.name], tree[0].path_names
 
     assert_equal saws.id, tree[1].id
-    assert_equal 2, tree[1].categorizations_count
-    assert_equal 6, tree[1].tree_categorizations_count
+    assert_equal({"active" => 2}, tree[1].item_counts)
+    assert_equal 6, tree[1].visible_items_count
     assert_equal [power_tools.id, saws.id], tree[1].path_ids
     assert_equal [power_tools.name, saws.name], tree[1].path_names
 
     assert_equal mitre_saws.id, tree[2].id
-    assert_equal 4, tree[2].categorizations_count
-    assert_equal 4, tree[2].tree_categorizations_count
+    assert_equal({"active" => 4}, tree[2].item_counts)
+    assert_equal 4, tree[2].visible_items_count
     assert_equal [power_tools.id, saws.id, mitre_saws.id], tree[2].path_ids
     assert_equal [power_tools.name, saws.name, mitre_saws.name], tree[2].path_names
   end

--- a/test/models/category_test.rb
+++ b/test/models/category_test.rb
@@ -14,4 +14,14 @@ class CategoryTest < ActiveSupport::TestCase
     refute power_tools.update(parent: saws)
     assert_equal ["can't be set to a child"], power_tools.errors[:parent_id]
   end
+
+  test "updates its item counts" do
+    power_tools = Category.create(name: "Power Tools")
+
+    create(:item, categories: [power_tools], status: "active")
+    create(:item, categories: [power_tools], status: "active")
+    create(:item, categories: [power_tools], status: "retired")
+
+    assert_equal({"active" => 2, "maintenance" => 0, "pending" => 0, "retired" => 1}, power_tools.item_counts)
+  end
 end


### PR DESCRIPTION
# What it does

This PR updates the category counts to consider item statuses. The category cound only include items that have an `active` or `maintenance` status.

# Still to do

- [x] Add a rake task to update the all the category counts. This is a one-time thing as they will be kept up to date as items are editing going forward.

# Why it is important

This fixes the issue where CTL have 500 seeds shown in the category listing but only about half that number when browsing since so many are actually retired.

It's also an issue for smaller categories, where the numbers are confusing and make it look like the site is broken or there are items just missing.

# Implementation notes

We now store item counts as a Hash that's stored in a JSONB column in the database. This persists the number of items with each status in the category, and we can use that information to then calculate how many items are in categories themselves or in their children.

We'll need to run `rails categories:update_category_counts` in production when this is rolled out.

# Your bandwidth for additional changes to this PR

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
