### PR TITLE
Even better category counts

### DIFF
--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -75,7 +75,7 @@ module ItemsHelper
 
     tag.nav(class: "tree-nav", data: {controller: "tree-nav"}) do
       concat(tag.ul do
-        root.children.values.sort_by { |node| node.value.name }.map do |node|
+        root.children.values.sort_by { |node| node.value.name.downcase }.map do |node|
           concat(render_tree_node(node, current_category))
         end
       end)

--- a/app/models/categorization.rb
+++ b/app/models/categorization.rb
@@ -3,13 +3,4 @@ class Categorization < ApplicationRecord
   belongs_to :category, counter_cache: true
   belongs_to :category_node, foreign_key: "category_id"
   validates :category_id, uniqueness: {scope: :item_id}
-
-  after_save :update_category_item_counts
-  after_destroy :update_category_item_counts
-
-  private
-
-  def update_category_item_counts
-    category.update_item_counts
-  end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -39,13 +39,6 @@ class Category < ApplicationRecord
     CategoryNode.refresh
   end
 
-  def update_item_counts
-    item_counts = Item.statuses.values.each_with_object({}) { |status, counts| counts[status] = 0 }
-    items.pluck(:status).each_with_object(item_counts) { |status, counts| counts[status] += 1 }
-
-    update(item_counts: item_counts)
-  end
-
   def self.recursive_all
     find_by_sql(<<~SQL)
       WITH RECURSIVE subcategories AS (

--- a/db/migrate/20220421204258_update_category_nodes_to_version_4.rb
+++ b/db/migrate/20220421204258_update_category_nodes_to_version_4.rb
@@ -1,0 +1,5 @@
+class UpdateCategoryNodesToVersion4 < ActiveRecord::Migration[6.1]
+  def change
+    update_view :category_nodes, version: 4, revert_to_version: 3, materialized: true
+  end
+end

--- a/db/migrate/20220422172531_remove_item_counts_from_categories.rb
+++ b/db/migrate/20220422172531_remove_item_counts_from_categories.rb
@@ -1,0 +1,5 @@
+class RemoveItemCountsFromCategories < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :categories, :item_counts, :jsonb, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_03_224122) do
+ActiveRecord::Schema.define(version: 2022_04_21_204258) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
 
   create_enum :adjustment_kind, [
@@ -664,30 +665,42 @@ ActiveRecord::Schema.define(version: 2022_04_03_224122) do
               categories.slug,
               categories.item_counts,
               categories.parent_id,
-              (search_tree_1.path_names || categories.name),
-              (search_tree_1.path_ids || categories.id)
-             FROM (search_tree search_tree_1
-               JOIN categories ON ((categories.parent_id = search_tree_1.id)))
-            WHERE (NOT (categories.id = ANY (search_tree_1.path_ids)))
+              (search_tree.path_names || categories.name),
+              (search_tree.path_ids || categories.id)
+             FROM (search_tree
+               JOIN categories ON ((categories.parent_id = search_tree.id)))
+            WHERE (NOT (categories.id = ANY (search_tree.path_ids)))
+          ), tree_nodes AS (
+           SELECT search_tree.id,
+              search_tree.library_id,
+              search_tree.name,
+              search_tree.slug,
+              search_tree.item_counts,
+              search_tree.parent_id,
+              search_tree.path_names,
+              search_tree.path_ids,
+              lower(array_to_string(search_tree.path_names, ' '::text)) AS sort_name,
+              ( SELECT array_agg(st.id) AS array_agg
+                     FROM search_tree st
+                    WHERE (search_tree.id = ANY (st.path_ids))) AS tree_ids
+             FROM search_tree
+            ORDER BY (lower(array_to_string(search_tree.path_names, ' '::text)))
           )
-   SELECT search_tree.id,
-      search_tree.library_id,
-      search_tree.name,
-      search_tree.slug,
-      search_tree.item_counts,
-      search_tree.parent_id,
-      search_tree.path_names,
-      search_tree.path_ids,
-      lower(array_to_string(search_tree.path_names, ' '::text)) AS sort_name,
-      ( SELECT json_build_object('active', COALESCE(sum(((st.item_counts -> 'active'::text))::integer), (0)::bigint), 'retired', COALESCE(sum(((st.item_counts -> 'retired'::text))::integer), (0)::bigint), 'maintenance', COALESCE(sum(((st.item_counts -> 'maintenance'::text))::integer), (0)::bigint), 'pending', COALESCE(sum(((st.item_counts -> 'pending'::text))::integer), (0)::bigint)) AS json_build_object
-             FROM search_tree st
-            WHERE (search_tree.id = ANY (st.path_ids))) AS tree_item_counts,
-      ( SELECT array_agg(st.id) AS array_agg
-             FROM search_tree st
-            WHERE (search_tree.id = ANY (st.path_ids))) AS tree_ids
-     FROM search_tree
-    ORDER BY (lower(array_to_string(search_tree.path_names, ' '::text)));
+   SELECT tree_nodes.id,
+      tree_nodes.library_id,
+      tree_nodes.name,
+      tree_nodes.slug,
+      tree_nodes.item_counts,
+      tree_nodes.parent_id,
+      tree_nodes.path_names,
+      tree_nodes.path_ids,
+      tree_nodes.sort_name,
+      tree_nodes.tree_ids,
+      ( SELECT json_build_object('active', count(DISTINCT categorizations.item_id) FILTER (WHERE (items.status = 'active'::item_status)), 'retired', count(DISTINCT categorizations.item_id) FILTER (WHERE (items.status = 'pending'::item_status)), 'maintenance', count(DISTINCT categorizations.item_id) FILTER (WHERE (items.status = 'maintenance'::item_status)), 'pending', count(DISTINCT categorizations.item_id) FILTER (WHERE (items.status = 'retired'::item_status))) AS json_build_object
+             FROM (categorizations
+               LEFT JOIN items ON ((categorizations.item_id = items.id)))
+            WHERE (categorizations.category_id = ANY (tree_nodes.tree_ids))) AS tree_item_counts
+     FROM tree_nodes;
   SQL
   add_index "category_nodes", ["id"], name: "index_category_nodes_on_id", unique: true
-
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_21_204258) do
+ActiveRecord::Schema.define(version: 2022_04_22_172531) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -220,7 +220,6 @@ ActiveRecord::Schema.define(version: 2022_04_21_204258) do
     t.integer "categorizations_count", default: 0, null: false
     t.bigint "parent_id"
     t.integer "library_id"
-    t.jsonb "item_counts", default: {}
     t.index ["library_id", "name"], name: "index_categories_on_library_id_and_name", unique: true
     t.index ["library_id", "slug"], name: "index_categories_on_library_id_and_slug", unique: true
     t.index ["parent_id"], name: "index_categories_on_parent_id"
@@ -647,12 +646,11 @@ ActiveRecord::Schema.define(version: 2022_04_21_204258) do
     ORDER BY months.month;
   SQL
   create_view "category_nodes", materialized: true, sql_definition: <<-SQL
-      WITH RECURSIVE search_tree(id, library_id, name, slug, item_counts, parent_id, path_names, path_ids) AS (
+      WITH RECURSIVE search_tree(id, library_id, name, slug, parent_id, path_names, path_ids) AS (
            SELECT categories.id,
               categories.library_id,
               categories.name,
               categories.slug,
-              categories.item_counts,
               categories.parent_id,
               ARRAY[categories.name] AS "array",
               ARRAY[categories.id] AS "array"
@@ -663,7 +661,6 @@ ActiveRecord::Schema.define(version: 2022_04_21_204258) do
               categories.library_id,
               categories.name,
               categories.slug,
-              categories.item_counts,
               categories.parent_id,
               (search_tree.path_names || categories.name),
               (search_tree.path_ids || categories.id)
@@ -675,7 +672,6 @@ ActiveRecord::Schema.define(version: 2022_04_21_204258) do
               search_tree.library_id,
               search_tree.name,
               search_tree.slug,
-              search_tree.item_counts,
               search_tree.parent_id,
               search_tree.path_names,
               search_tree.path_ids,
@@ -690,7 +686,6 @@ ActiveRecord::Schema.define(version: 2022_04_21_204258) do
       tree_nodes.library_id,
       tree_nodes.name,
       tree_nodes.slug,
-      tree_nodes.item_counts,
       tree_nodes.parent_id,
       tree_nodes.path_names,
       tree_nodes.path_ids,

--- a/db/views/category_nodes_v04.sql
+++ b/db/views/category_nodes_v04.sql
@@ -1,12 +1,12 @@
-WITH RECURSIVE search_tree(id, library_id, name, slug, item_counts, parent_id, path_names, path_ids) AS (
+WITH RECURSIVE search_tree(id, library_id, name, slug, parent_id, path_names, path_ids) AS (
 
-  SELECT id, library_id, name, slug, item_counts, parent_id, ARRAY[name], ARRAY[id]
+  SELECT id, library_id, name, slug, parent_id, ARRAY[name], ARRAY[id]
     FROM categories
   WHERE parent_id IS NULL
   
   UNION ALL
   
-    SELECT categories.id, categories.library_id, categories.name, categories.slug, categories.item_counts, 
+    SELECT categories.id, categories.library_id, categories.name, categories.slug, 
             categories.parent_id, path_names || categories.name, path_ids || categories.id
     FROM search_tree
     JOIN categories ON categories.parent_id = search_tree.id

--- a/db/views/category_nodes_v04.sql
+++ b/db/views/category_nodes_v04.sql
@@ -1,0 +1,34 @@
+WITH RECURSIVE search_tree(id, library_id, name, slug, item_counts, parent_id, path_names, path_ids) AS (
+
+  SELECT id, library_id, name, slug, item_counts, parent_id, ARRAY[name], ARRAY[id]
+    FROM categories
+  WHERE parent_id IS NULL
+  
+  UNION ALL
+  
+    SELECT categories.id, categories.library_id, categories.name, categories.slug, categories.item_counts, 
+            categories.parent_id, path_names || categories.name, path_ids || categories.id
+    FROM search_tree
+    JOIN categories ON categories.parent_id = search_tree.id
+    WHERE NOT categories.id = ANY(path_ids)
+  ),
+  
+  tree_nodes AS (
+	    SELECT *,
+	    lower(array_to_string(path_names, ' ')) as sort_name,
+	    (SELECT array_agg(st.id) FROM search_tree AS st WHERE search_tree.id = ANY(st.path_ids)) AS tree_ids
+	  FROM search_tree ORDER BY sort_name ASC
+  )
+  
+  SELECT *,
+    (SELECT json_build_object(
+	      'active', COUNT(DISTINCT categorizations.item_id) FILTER (WHERE items.status = 'active'),
+	      'retired', COUNT(DISTINCT categorizations.item_id) FILTER (WHERE items.status = 'pending'),
+	      'maintenance', COUNT(DISTINCT categorizations.item_id) FILTER (WHERE items.status = 'maintenance'),
+	      'pending', COUNT(DISTINCT categorizations.item_id) FILTER (WHERE items.status = 'retired')
+	    ) 
+  		FROM categorizations LEFT JOIN items ON categorizations.item_id = items.id
+  		WHERE categorizations.category_id = ANY(tree_ids)
+    ) AS tree_item_counts
+  
+  from tree_nodes;

--- a/lib/tasks/categories.rake
+++ b/lib/tasks/categories.rake
@@ -3,12 +3,4 @@ namespace :categories do
   task refresh_nodes: :environment do
     CategoryNode.refresh
   end
-
-  desc "Update the category counts for all categories"
-  task update_category_counts: :environment do
-    Category.find_each do |category|
-      category.update_item_counts
-    end
-    CategoryNode.refresh
-  end
 end

--- a/test/models/category_node_test.rb
+++ b/test/models/category_node_test.rb
@@ -2,27 +2,28 @@ require "test_helper"
 
 class CategoryNodeTest < ActiveSupport::TestCase
   test "loads entire tree" do
-    power_tools = Category.create(name: "Power Tools", item_counts: {active: 1})
-    saws = Category.create!(name: "Saws", parent: power_tools, item_counts: {active: 2})
-    mitre_saws = Category.create!(name: "Mitre Saws", parent: saws, item_counts: {active: 4})
+    power_tools = Category.create(name: "Power Tools")
+    saws = Category.create!(name: "Saws", parent: power_tools)
+    mitre_saws = Category.create!(name: "Mitre Saws", parent: saws)
+
+    create(:item, categories: [power_tools])
+    2.times { create(:item, categories: [saws]) }
+    4.times { create(:item, categories: [mitre_saws]) }
 
     CategoryNode.refresh
     tree = CategoryNode.all.order("id ASC")
 
     assert_equal power_tools.id, tree[0].id
-    assert_equal({"active" => 1}, tree[0].item_counts)
     assert_equal 7, tree[0].visible_items_count
     assert_equal [power_tools.id], tree[0].path_ids
     assert_equal [power_tools.name], tree[0].path_names
 
     assert_equal saws.id, tree[1].id
-    assert_equal({"active" => 2}, tree[1].item_counts)
     assert_equal 6, tree[1].visible_items_count
     assert_equal [power_tools.id, saws.id], tree[1].path_ids
     assert_equal [power_tools.name, saws.name], tree[1].path_names
 
     assert_equal mitre_saws.id, tree[2].id
-    assert_equal({"active" => 4}, tree[2].item_counts)
     assert_equal 4, tree[2].visible_items_count
     assert_equal [power_tools.id, saws.id, mitre_saws.id], tree[2].path_ids
     assert_equal [power_tools.name, saws.name, mitre_saws.name], tree[2].path_names

--- a/test/models/category_test.rb
+++ b/test/models/category_test.rb
@@ -14,14 +14,4 @@ class CategoryTest < ActiveSupport::TestCase
     refute power_tools.update(parent: saws)
     assert_equal ["can't be set to a child"], power_tools.errors[:parent_id]
   end
-
-  test "updates its item counts" do
-    power_tools = Category.create(name: "Power Tools")
-
-    create(:item, categories: [power_tools], status: "active")
-    create(:item, categories: [power_tools], status: "active")
-    create(:item, categories: [power_tools], status: "retired")
-
-    assert_equal({"active" => 2, "maintenance" => 0, "pending" => 0, "retired" => 1}, power_tools.item_counts)
-  end
 end

--- a/test/system/item_filtering_test.rb
+++ b/test/system/item_filtering_test.rb
@@ -6,11 +6,11 @@ class ItemFilteringTest < ApplicationSystemTestCase
     @category1_subcategory = create(:category, parent: @category1, name: "Pneumatic")
     @category2 = create(:category, name: "Drills")
 
-    CategoryNode.refresh
-
     @item1 = create(:item, categories: [@category1_subcategory], name: "Nine-Inch Nailgun")
     @item2 = create(:item, categories: [@category2], name: "Boring Borer")
     @item3 = create(:item, categories: [@category2], name: "Droll Drill")
+
+    CategoryNode.refresh
 
     login_as @user
   end

--- a/test/system/item_filtering_test.rb
+++ b/test/system/item_filtering_test.rb
@@ -6,6 +6,8 @@ class ItemFilteringTest < ApplicationSystemTestCase
     @category1_subcategory = create(:category, parent: @category1, name: "Pneumatic")
     @category2 = create(:category, name: "Drills")
 
+    CategoryNode.refresh
+
     @item1 = create(:item, categories: [@category1_subcategory], name: "Nine-Inch Nailgun")
     @item2 = create(:item, categories: [@category2], name: "Boring Borer")
     @item3 = create(:item, categories: [@category2], name: "Droll Drill")


### PR DESCRIPTION
# What it does

Changes the implementation of the category counts to handle items being counted more than once due to belonging to more than one category with a shared parent category.

# Why it is important

The item counts within categories were appearing to be wrong, which was confusing to users.

# UI Change Screenshot

_If this PR makes a change to the UI put a screenshot here. If you have before and after screenshots please add these._

# Implementation notes

* The previous implementation counted items assigned to each category, grouped by the item status. These counts were then rolled up by the `category_nodes` view. This was faster but made it impossible to prevent items from being counted more than once.
* This implementation does away with the category-level counts and does all the counting in the `category_nodes` view. This is slower (the view is take about 4x as long for me locally), but it's much more accurate. Since the previous work allowed `category_nodes` to be refreshed concurrently, I'm less worried that the process is a bit slower now.

# Your bandwidth for additional changes to this PR

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
