### PR TITLE
Remove checkout notices appearing for members #1047

### DIFF
--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -30,12 +30,6 @@
         </div>
       <% end %>
 
-      <% if @item.checkout_notice.present? %>
-        <div class="toast">
-          <p><%= @item.checkout_notice %></p>
-        </div>
-      <% end %>
-
       <% if @item.borrow_policy.rules.present? %>
         <blockquote>
           <%= @item.borrow_policy.rules %>


### PR DESCRIPTION
# What it does

Checkout notices will not be shown on the member side of an item view no matter what.

# Why it is important

Fixes #1047

Checkout notices generally have librarian information not relevant to borrowers.

# UI Change Screenshot

Before: 
<img width="1080" alt="Screen Shot 2022-06-15 at 12 32 01 PM" src="https://user-images.githubusercontent.com/50007657/173891400-4c1df2ac-4198-4e7a-aea6-32cb6a7bc087.png">

After:
<img width="1086" alt="Screen Shot 2022-06-15 at 12 38 31 PM" src="https://user-images.githubusercontent.com/50007657/173891446-84989c44-51e0-4c7d-b512-ec83a9872dd5.png">

Librarian View remains the same:

<img width="1088" alt="Screen Shot 2022-06-15 at 12 40 13 PM" src="https://user-images.githubusercontent.com/50007657/173891488-a2a28ec8-a4ff-43bf-8fec-9cbd34d34234.png">

# Implementation notes



# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
