### PR TITLE
#575 Display item checkout notices on member's appointment and loan pages

### DIFF
--- a/app/views/account/appointments/index.html.erb
+++ b/app/views/account/appointments/index.html.erb
@@ -70,7 +70,7 @@
                         <div class="details">
                           <span class="item">
                             <%= link_to hold.item.name, item_path(hold.item) %> (<%= hold.item.complete_number %>)
-                            <div class="text-tiny"><strong>Checkout notice:</strong> <em><%= hold.item.checkout_notice %></em></div>
+                            <div class="text-tiny"><strong>Checkout notice:</strong> <em><%= hold.item.checkout_notice || "None" %></em></div>
                           </span>
                         </div>
                       </li>

--- a/app/views/account/appointments/index.html.erb
+++ b/app/views/account/appointments/index.html.erb
@@ -70,6 +70,7 @@
                         <div class="details">
                           <span class="item">
                             <%= link_to hold.item.name, item_path(hold.item) %> (<%= hold.item.complete_number %>)
+                            <div class="text-tiny"><strong>Checkout notice:</strong> <em><%= hold.item.checkout_notice %></em></div>
                           </span>
                         </div>
                       </li>

--- a/app/views/account/appointments/index.html.erb
+++ b/app/views/account/appointments/index.html.erb
@@ -70,7 +70,7 @@
                         <div class="details">
                           <span class="item">
                             <%= link_to hold.item.name, item_path(hold.item) %> (<%= hold.item.complete_number %>)
-                            <div class="text-tiny"><strong>Checkout notice:</strong> <em><%= hold.item.checkout_notice || "None" %></em></div>
+                            <div class="checkout-notice text-tiny"><strong>Checkout notice:</strong> <em><%= hold.item.checkout_notice || "None" %></em></div>
                           </span>
                         </div>
                       </li>

--- a/app/views/account/loans/index.html.erb
+++ b/app/views/account/loans/index.html.erb
@@ -32,6 +32,7 @@
                 <span class="status">
                   <%= tag.span "Due #{humanize_due_date(loan)}",
                         class: ("warning text-bold" if loan.due_at - Time.now < 3.days) %>
+                  <div class="checkout-notice"><strong>Checkout notice:</strong> <%= loan.item.checkout_notice || "None" %></div>
                   <% if loan.renewal? %>(renewed <%= pluralize(loan.renewal_count, "time") %>)<% end %>
                   <% if @current_library.allow_appointments? %>
                     <span class="pickup"><%= loan_pickup_status(loan) %></span>


### PR DESCRIPTION
# What it does

Adds items' checkout notices on the appointment and loan pages in the member portal.

# Why it is important

Resolves https://github.com/rubyforgood/circulate/issues/575

# UI Change Screenshot

**Loans:**
![Screenshot from 2022-06-16 19-03-42](https://user-images.githubusercontent.com/50384514/174129602-9c796c5e-a14d-4b3b-9ea3-e4c872da9ddb.png)

**Appointments:**
![Screenshot from 2022-06-16 19-04-27](https://user-images.githubusercontent.com/50384514/174129672-6a9d1455-0384-4ef3-9e09-54f5b9dc893d.png)

# Implementation notes

The change is only concerning UI, therefore no tests were added. If you would like to see a test for this, please let me know, I'll be happy to add it.

Also... my first PR :)

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [X] I have the time and interest to make additional changes to this PR based on feedback.
- [ ] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
