### PR TITLE
Skip volunteer shifts calendar test

### DIFF
--- a/test/system/volunteer/shifts_test.rb
+++ b/test/system/volunteer/shifts_test.rb
@@ -5,6 +5,7 @@ module Volunteer
     roles = ["Librarian (Senior)", "Librarian"]
 
     test "views shift calendar" do
+      skip "Redirecting to teamup for volunteer signups instead"
       visit test_google_auth_url(email: "volunteer@example.com")
 
       Time.use_zone("America/Chicago") do


### PR DESCRIPTION
# What it does

Skips a system test for viewing the volunteer shift calendar.

# Why it is important

I looked into why CI is [failing on main](https://github.com/rubyforgood/circulate/runs/7552874488?check_suite_focus=true) and the failing test seems related to this commit https://github.com/rubyforgood/circulate/commit/bc4583d700bc1c8137bc9fd8b0969aa6af081682, redirecting users to a Teamup link to handle volunteer shifts.

I don't know the plan for the volunteer calendar in the future, so I figured skipping the test for now would at least get the test suite to green and unblock any upcoming work :)

# Your bandwidth for additional changes to this PR

_Please choose one of the following to help the project maintainers provide the appropriate level of support:_

- [x] I have the time and interest to make additional changes to this PR based on feedback.
- [x] I am interested in feedback but don't need to make the changes myself.
- [ ] I don't have time or interest in making additional changes to this work.
- [ ] Other or not sure (please describe):
