### PR TITLE
Handle Pagy underflow errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,6 +17,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery store: NonSessionCookieStore.new(:csrf_token), with: :exception
 
   rescue_from ActionController::InvalidAuthenticityToken, with: :handle_invalid_authenticity_token
+  rescue_from Pagy::VariableError, with: :redirect_to_first_page
 
   set_current_tenant_through_filter
   before_action :set_tenant
@@ -107,5 +108,9 @@ class ApplicationController < ActionController::Base
     redirect_back(fallback_location: root_path, flash: {
       error: "There was an issue with your submission, please try again."
     })
+  end
+
+  def redirect_to_first_page
+    redirect_to url_for(page: 1)
   end
 end

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -42,6 +42,12 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
       get new_user_session_path, headers: {referer: "not a valid referer"}
     end
   end
+
+  test "handles requests for nonexistent page 0 by redirecting to first page" do
+    get items_path(page: 0)
+
+    assert_redirected_to items_path(page: 1)
+  end
 end
 
 # This is a lot of code to work around that I couldn't find a nice way to


### PR DESCRIPTION
# What it does

Fixes #1921

# Why it is important

Fewer exceptions!

# Implementation notes

We already use [Pagy's overflow handling](https://github.com/chicago-tool-library/circulate/blob/3920f33bdce84fcb2b3bedc3e287ff117500100c/config/initializers/pagy.rb#L5), so this handled the other side.