### PR TITLE
Added includes to appointment check ins/outs to speed things up a bit

### DIFF
--- a/app/controllers/admin/appointments_controller.rb
+++ b/app/controllers/admin/appointments_controller.rb
@@ -77,19 +77,19 @@ module Admin
     end
 
     helper_method def items_available_to_add_to_pickup
-      Item.available.eager_load(:borrow_policy)
+      Item.available.includes(:borrow_policy)
     end
 
     helper_method def items_available_to_add_to_dropoff
-      (@appointment.member.loans.checked_out - appointment_return_items).map(&:item)
+      (@appointment.member.loans.checked_out.includes(item: :borrow_policy) - appointment_return_items).map(&:item)
     end
 
     helper_method def appointment_pickup_items
-      @appointment.holds
+      @appointment.holds.includes(hold_includes)
     end
 
     helper_method def appointment_return_items
-      @appointment.loans
+      @appointment.loans.includes(loan_includes)
     end
 
     helper_method def checkout_items_quantity_for_appointment
@@ -98,6 +98,18 @@ module Admin
 
     helper_method def checkin_items_quantity_for_appointment
       appointment_return_items.length
+    end
+
+    def item_includes
+      [:borrow_policy, :image_attachment]
+    end
+
+    def hold_includes
+      {item: item_includes}
+    end
+
+    def loan_includes
+      {item: item_includes}
     end
 
     def appointment_params

--- a/app/views/admin/appointments/_checkins.html.erb
+++ b/app/views/admin/appointments/_checkins.html.erb
@@ -5,29 +5,29 @@
       <%#= button_to "Check-in All", admin_appointment_checkins_path(@appointment, loan_ids: appointment_return_items.checked_out.pluck(:id)), class: "btn btn-primary", data: { disable_with: "Checking-in...", turbo_confirm: "Are you sure you want to check-in all items?" }, disabled: !appointment_return_items.checked_out.exists? %>
     </div>
   </div>
-  <% appointment_return_items.each do |return_item| %>
+  <% appointment_return_items.each do |loan| %>
     <div class="columns mt-2 mb-2">
       <div class="column col-sm-6 col-4">
         <%= tag.div class: "item-image" do %>
-          <% if return_item.item.image.attached? %>
-            <%= image_tag item_image_url(return_item.item.image, resize_to_limit: [160, 112]) %>
+          <% if loan.item.image.attached? %>
+            <%= image_tag item_image_url(loan.item.image, resize_to_limit: [160, 112]) %>
           <% else %>
             <div class="image-placeholder"></div>
           <% end %>
         <% end %>
 
-        <% if return_item.checked_out? %>
-          <%= button_to "remove item", admin_appointment_loan_path(@appointment, return_item), method: :delete, data: {disable_with: "Removing...", turbo_confirm: "Are you sure you want to remove this item from the appointment?"} %>
+        <% if loan.checked_out? %>
+          <%= button_to "remove item", admin_appointment_loan_path(@appointment, loan), method: :delete, data: {disable_with: "Removing...", turbo_confirm: "Are you sure you want to remove this item from the appointment?"} %>
         <% end %>
         </div>
         <div class="column col-sm-6 col-4">
-          <p><%= return_item.item.name %></p>
-          <p><%= link_to full_item_number(return_item.item), admin_item_path(return_item.item) %></p>
+          <p><%= loan.item.name %></p>
+          <p><%= link_to full_item_number(loan.item), admin_item_path(loan.item) %></p>
         </div>
         <div class="column col-sm-12 col-4 text-right" data-controller="confirm-item-accessories">
-          <% if return_item.item.accessories? && return_item.checked_out? %>
+          <% if loan.item.accessories? && loan.checked_out? %>
             <ul class="simple-list of-accessories">
-              <% return_item.item.accessories.each do |accessory| %>
+              <% loan.item.accessories.each do |accessory| %>
                 <li>
                   <%= label_tag accessory, accessory %>
                   <%= checkbox_tag accessory, data: {:action => "confirm-item-accessories#handleCheck", "confirm-item-accessories-target" => "accessory"} %>
@@ -35,21 +35,21 @@
               <% end %>
             </ul>
           <% end %>
-          <%= button_to "Check-in", admin_appointment_checkins_path(@appointment, loan_ids: [return_item.id]),
-                id: "checkin-#{return_item.id}",
+          <%= button_to "Check-in", admin_appointment_checkins_path(@appointment, loan_ids: [loan.id]),
+                id: "checkin-#{loan.id}",
                 class: "btn btn-primary",
                 data: {:disable_with => "Checking-in...", "confirm-item-accessories-target" => "button"},
-                disabled: !return_item.checked_out? || return_item.item.accessories? %>
-          <% if !return_item.checked_out? %>
+                disabled: !loan.checked_out? || loan.item.accessories? %>
+          <% if !loan.checked_out? %>
             <em>Item checked-in</em>
         <% end %>
         </div>
       </div>
-      <% if return_item.item.checkout_notice? %>
+      <% if loan.item.checkout_notice? %>
         <div class="info-box">
           <p>
             <strong>Checkout Notice:</strong><br>
-            <%= return_item.item.checkout_notice %>
+            <%= loan.item.checkout_notice %>
           </p>
         </div>
     <% end %>

--- a/app/views/admin/appointments/_checkouts.html.erb
+++ b/app/views/admin/appointments/_checkouts.html.erb
@@ -7,12 +7,12 @@
       <%#= button_to "Check-out All", admin_appointment_checkouts_path(@appointment, hold_ids: appointment_pickup_items.active.pluck(:id)), class: "btn btn-primary", data: { disable_with: "Checking-out...", turbo_confirm: "Are you sure you want to check-out all items?" }, disabled: !appointment_pickup_items.active.exists? || !member.borrow? %>
     </div>
   </div>
-  <% appointment_pickup_items.each do |pickup_item| %>
+  <% appointment_pickup_items.each do |loan| %>
     <div class="columns mt-2 mb-2">
       <div class="column col-sm-6 col-4">
         <%= tag.div class: "item-image" do %>
-          <% if pickup_item.item.image.attached? %>
-            <%= image_tag item_image_url(pickup_item.item.image, resize_to_limit: [160, 112]) %>
+          <% if loan.item.image.attached? %>
+            <%= image_tag item_image_url(loan.item.image, resize_to_limit: [160, 112]) %>
           <% else %>
             <div class="image-placeholder"></div>
           <% end %>
@@ -20,13 +20,13 @@
         <div class="divider"></div>
       </div>
       <div class="column col-sm-6 col-4">
-        <p><%= pickup_item.item.name %></p>
-        <p><%= link_to full_item_number(pickup_item.item), admin_item_path(pickup_item.item) %></p>
+        <p><%= loan.item.name %></p>
+        <p><%= link_to full_item_number(loan.item), admin_item_path(loan.item) %></p>
       </div>
       <div class="column col-sm-12 col-4 text-right checkout-button-column" data-controller="confirm-item-accessories">
-        <% if pickup_item.item.accessories? && pickup_item.active? %>
+        <% if loan.item.accessories? && loan.active? %>
           <ul class="simple-list of-accessories">
-            <% pickup_item.item.accessories.each do |accessory| %>
+            <% loan.item.accessories.each do |accessory| %>
               <li>
                 <%= label_tag accessory, accessory %>
                 <%= checkbox_tag accessory, data: {:action => "confirm-item-accessories#handleCheck", "confirm-item-accessories-target" => "accessory"} %>
@@ -34,15 +34,15 @@
             <% end %>
           </ul>
         <% end %>
-        <%= button_to "Check-out", admin_appointment_checkouts_path(@appointment, hold_ids: [pickup_item.id]),
-              id: "checkout-#{pickup_item.id}",
+        <%= button_to "Check-out", admin_appointment_checkouts_path(@appointment, hold_ids: [loan.id]),
+              id: "checkout-#{loan.id}",
               class: "btn btn-primary btn-sm",
               data: {:disable_with => "Checking-out...", "confirm-item-accessories-target" => "button"},
-              disabled: !pickup_item.active? || !member.borrow? || pickup_item.item.accessories? %>
+              disabled: !loan.active? || !member.borrow? || loan.item.accessories? %>
         <div class="checkout-button-group">
-          <% if pickup_item.active? %>
+          <% if loan.active? %>
             <%= button_to "Cancel Hold",
-                  admin_appointment_hold_path(@appointment, pickup_item), {
+                  admin_appointment_hold_path(@appointment, loan), {
                     params: {cancel_hold: true},
                       method: :delete,
                       class: "btn btn-sm mt-2 float-right",
@@ -52,7 +52,7 @@
                       }
                   } %>
             <%= button_to "Remove Item",
-                  admin_appointment_hold_path(@appointment, pickup_item), {
+                  admin_appointment_hold_path(@appointment, loan), {
                     params: {cancel_hold: false},
                       method: :delete,
                       class: "btn btn-sm mt-2 float-right",
@@ -62,18 +62,18 @@
                       }
                   } %>
           <% end %>
-          <% if !pickup_item.active? %>
+          <% if !loan.active? %>
             <em>Item checked-out</em>
           <% end %>
         </div>
       </div>
     </div>
-    <% if pickup_item.item.checkout_notice? %>
+    <% if loan.item.checkout_notice? %>
       <div>
         <div class="info-box">
           <p>
             <strong>Checkout Notice:</strong><br>
-            <%= pickup_item.item.checkout_notice %>
+            <%= loan.item.checkout_notice %>
           </p>
         </div>
       </div>


### PR DESCRIPTION
# What it does

Checking items out and returning them has felt a little sluggish lately so this adds some eager loading to help speed things up.

# Why it is important

I believe this was mentioned at the last stakeholders meeting

# Implementation notes

The real change is just the addition of some `includes` calls to eager load associations. I also changed the names of some block variables in the templates because the original names were throwing me off a little. 
