### PR TITLE
Cancel appointments for holds that are ended when an item is unavailable

### DIFF
--- a/app/models/hold.rb
+++ b/app/models/hold.rb
@@ -53,7 +53,7 @@ class Hold < ApplicationRecord
     ended? || expired?(now)
   end
 
-  # A hold that was picked up
+  # A hold that was picked up or a hold on an item that was retired
   def ended?
     ended_at.present?
   end
@@ -66,12 +66,16 @@ class Hold < ApplicationRecord
   end
 
   def cancel!
-    if appointment.present?
-      appointment_hold.destroy!
-      appointment.cancel_if_no_items!
-    end
-
+    remove_from_appointment!
     destroy!
+  end
+
+  def remove_from_appointment!
+    return if appointment.blank?
+
+    appointment_hold.destroy!
+
+    appointment.cancel_if_no_items!
   end
 
   # A hold that timed out

--- a/test/models/hold_test.rb
+++ b/test/models/hold_test.rb
@@ -96,6 +96,22 @@ class HoldTest < ActiveSupport::TestCase
     end
   end
 
+  test "remove hold from appointment" do
+    hold1 = create(:hold)
+    hold2 = create(:hold)
+    member = create(:member)
+    create(:appointment, holds: [hold1, hold2], member: member)
+
+    hold1.remove_from_appointment!
+    assert hold1.appointment_hold.destroyed?
+    assert member.appointments.count, 1
+
+    # calls Appointment#cancel_if_no_items! if it's the only hold
+    hold2.remove_from_appointment!
+    assert hold2.appointment_hold.destroyed?
+    assert_equal member.appointments.count, 0
+  end
+
   test "when the item's borrow policy requires approval, the member must be approved" do
     member = create(:verified_member)
     borrow_policy = create(:borrow_policy, :requires_approval)

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -159,18 +159,22 @@ class ItemTest < ActiveSupport::TestCase
     refute item.next_hold
   end
 
-  test "clears holds when changing to an inactive status" do
+  test "clears holds and appointments when changing to an inactive status" do
     item = create(:item)
-    create(:started_hold, item: item)
+    hold = create(:started_hold, item: item)
+    member = create(:member)
+    create(:appointment, member: member, starts_at: 1.day.from_now, ends_at: 1.day.from_now + 2.hours, holds: [hold])
 
     item.update!(status: Item.statuses[:pending])
     assert_equal item.active_holds.count, 1
 
     item.update!(status: Item.statuses[:maintenance])
     assert_equal item.active_holds.count, 1
+    assert_equal member.appointments.count, 0
 
     item.update!(status: Item.statuses[:retired])
     assert_equal item.active_holds.count, 0
+    assert_equal member.appointments.count, 0
   end
 
   test "clears next hold when changed to maintenance" do

--- a/test/system/admin/consumables_test.rb
+++ b/test/system/admin/consumables_test.rb
@@ -75,7 +75,10 @@ class ConsumablesTest < ApplicationSystemTestCase
     @item = create(:consumable_item, quantity: 1)
     @member = create(:verified_member_with_membership)
     hold = create(:hold, item: @item, member: @member)
-    appointment = create(:appointment, holds: [hold], member: hold.member)
+    # make this into a loan instead
+
+    loan = create(:loan, member: @member)
+    appointment = create(:appointment, holds: [hold], loans: [loan], member: hold.member)
 
     visit admin_appointment_path(appointment)
 


### PR DESCRIPTION
# What it does

<!-- Describe the changes that you've made to the application in this PR. -->
- In the Hold model, adds a method to remove a hold from an appointment, cancelling the appointment if there are no other items
- In the Item model, updates `clear_holds_if_inactive` to trigger holds on the item to be removed from an appointment if it exists. 

# Why it is important
Addresses #1934 
# UI Change Screenshot

<!-- If this PR makes a change to the UI put a screenshot here. If you have before and after screenshots please add these. -->

# Implementation notes

- Thinking about this, it might make sense to add a notification here, but wasn't sure if we wanted to avoid notifications for some reason!
- The way I implemented this ended up interacting badly with consumable items, so that if you were the librarian checking out the last of a consumable item, you'd see an error screen once the item was "loaned", retiring the item once it was consumed (the scenario in the consumable_concern_test I edited). I just fudged the test a little by adding another item to avoid this situation in the test, since looking at the description for the consumable borrow policy, we haven't had consumable items since the seed share a few years ago. If we're still using consumable items, I'm happy to look more into how to reconcile these issues!

<!-- Anything notable about the technical approach you took. -->

<!-- Any open questions you have about the PR or areas where you'd like specific feedback. -->
