### PR TITLE
Added a small message letting users know they have been approved for C-Tools

### DIFF
--- a/app/controllers/account/home_controller.rb
+++ b/app/controllers/account/home_controller.rb
@@ -5,6 +5,7 @@ module Account
       @loans = current_member.loans.checked_out
       @ready_holds_count = current_member.holds.active.started.count
       @waiting_holds_count = current_member.holds.active.waiting.count
+      @recent_approvals = current_member.borrow_policy_approvals.approved.where(updated_at: 2.weeks.ago..)
     end
   end
 end

--- a/app/views/account/home/index.html.erb
+++ b/app/views/account/home/index.html.erb
@@ -12,6 +12,11 @@
         <div class="rule-list">
         <h2 class="h4">Account Summary</h2>
         <ul>
+            <% if @recent_approvals.any? %>
+              <% @recent_approvals.each do |approval| %>
+                <li>You have been approved to borrow <strong><%= approval.borrow_policy.code %>-Tools</strong> 🎉</li>
+              <% end %>
+            <% end %>
             <% if @loans.any? %>
                 <li>You have <%= link_to account_loans_path do %><span class="text-bold"><%= pluralize @loans.count, "item" %></span> checked out<% end %>.</li>
                 <li> The next day items are due is <span class="text-bold"><%= next_due_date(@loans) %></span>.</li>

--- a/test/controllers/account/home_controller_test.rb
+++ b/test/controllers/account/home_controller_test.rb
@@ -47,5 +47,25 @@ module Account
       assert_match "some good news", response.body
       refute_match "some old news", response.body
     end
+
+    test "shows a message when the member has recently been approved to borrow C-Tools" do
+      approval = create(:borrow_policy_approval, :approved, member: @member, updated_at: 13.days.ago)
+
+      get account_home_url
+
+      assert_match "You have been approved to borrow", response.body
+      assert_match "#{approval.borrow_policy.code}-Tools", response.body
+    end
+
+    test "does not show a message when the member has not been recently approved" do
+      approved = create(:borrow_policy_approval, :approved, member: @member, updated_at: 15.days.ago)
+      requested = create(:borrow_policy_approval, :requested, member: @member, updated_at: 13.days.ago)
+
+      get account_home_url
+
+      refute_match "You have been approved to borrow", response.body
+      refute_match "#{approved.borrow_policy.code}-Tools", response.body
+      refute_match "#{requested.borrow_policy.code}-Tools", response.body
+    end
   end
 end


### PR DESCRIPTION
# What it does

Puts a small message about being approved for C-Tools on the homepage if they were approved in the last two weeks.

# Why it is important

#1979

# UI Change Screenshot

<img width="1001" height="279" alt="Screenshot 2025-08-19 at 3 15 36 PM" src="https://github.com/user-attachments/assets/b76f8efc-7784-4a2f-a61e-d7f175a57f28" />


# Implementation notes

Once #1983 lands it might make sense to make the message link to the filtered list of tools.
