### PR TITLE
Allow empty issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,1 @@
-blank_issues_enabled: false
+blank_issues_enabled: true


### PR DESCRIPTION
We mostly create issues internally to track work, and forcing folks to use one of the templates we've setup isn't useful in those cases.