### PR TITLE
Avoid invalid DOM ids when rendering controls for item accessories.

### DIFF
--- a/app/views/admin/loans/_form.html.erb
+++ b/app/views/admin/loans/_form.html.erb
@@ -29,8 +29,8 @@
         <ul class="simple-list of-accessories">
           <% @item.accessories.each do |accessory| %>
             <li>
-              <%= label_tag accessory, accessory %>
-              <%= checkbox_tag accessory, data: {:action => "confirm-item-accessories#handleCheck", "confirm-item-accessories-target" => "accessory"} %>
+              <%= label_tag "check-#{accessory}", accessory %>
+              <%= checkbox_tag "check-#{accessory}", data: {:action => "confirm-item-accessories#handleCheck", "confirm-item-accessories-target" => "accessory"} %>
             </li>
           <% end %>
         </ul>

--- a/app/views/admin/members/show.html.erb
+++ b/app/views/admin/members/show.html.erb
@@ -91,8 +91,8 @@
                 <ul class="simple-list of-accessories">
                   <% summary.item.accessories.each do |accessory| %>
                     <li>
-                      <%= label_tag accessory, accessory %>
-                      <%= checkbox_tag accessory, data: {:action => "confirm-item-accessories#handleCheck", "confirm-item-accessories-target" => "accessory"} %>
+                      <%= label_tag "check-#{accessory}", accessory %>
+                      <%= checkbox_tag "check-#{accessory}", data: {:action => "confirm-item-accessories#handleCheck", "confirm-item-accessories-target" => "accessory"} %>
                     </li>
                   <% end %>
                 </ul>


### PR DESCRIPTION
# What it does

Fixes an edge case where having an item accessory that began with a number would result in an invalid DOM ID, breaking turbo when it attempted to replace content on the page. There is a JS error when this happens:

<img width="1840" height="98" alt="image" src="https://github.com/user-attachments/assets/ed149078-3d8d-47c8-a633-f481731f664e" />

# Implementation notes

* Adding a prefix of `check-` seemed like the simplest way to address this. I looked for a Rails helper that would escape things automatically but came up short.
