### PR TITLE
Fix NoMethodError in signup home controller

### DIFF
--- a/app/controllers/signup/home_controller.rb
+++ b/app/controllers/signup/home_controller.rb
@@ -7,7 +7,7 @@ module Signup
       @org_signup_url = if FeatureFlags.group_lending_enabled?
         signup_organizations_policies_url
       else
-        ENV.get("ORGANIZATION_SIGNUP_URL")
+        ENV.fetch("ORGANIZATION_SIGNUP_URL")
       end
     end
   end

--- a/test/controllers/signup/home_controller_test.rb
+++ b/test/controllers/signup/home_controller_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+module Signup
+  class HomeControllerTest < ActionDispatch::IntegrationTest
+    include Devise::Test::IntegrationHelpers
+
+    setup do
+      create(:agreement_document)
+    end
+
+    test "renders the index page when group lending is disabled" do
+      FeatureFlags.stub :group_lending_enabled?, false do
+        get signup_url
+        assert_response :success
+      end
+    end
+
+    test "renders the index page when group lending is enabled" do
+      FeatureFlags.stub :group_lending_enabled?, true do
+        get signup_url
+        assert_response :success
+      end
+    end
+  end
+end

--- a/test/fixtures/libraries.yml
+++ b/test/fixtures/libraries.yml
@@ -3,6 +3,7 @@ chicago_tool_library:
   hostname: "example.com"
   city: Chicago
   email: team@chicagotoollibrary.org
+  allow_members: true
   address: |-
     The Chicago Tool Library
     1048 W 37th Street Suite 102


### PR DESCRIPTION
# What it does

Uses correct method name to look up environment variable.

# Why it is important

Fixes error preventing member signup from working

# Implementation notes

ENV doesn't have a `get` method. Changed to use `fetch` instead to raise a clear error if ORGANIZATION_SIGNUP_URL is missing.

Also adds test coverage for the signup home controller index action and enables member signups in the test library fixture.
