### PR TITLE
Replace datalist with server-backed autocomplete for checkout

### DIFF
--- a/app/assets/stylesheets/overrides.scss
+++ b/app/assets/stylesheets/overrides.scss
@@ -123,6 +123,11 @@ trix-toolbar {
   z-index: 10;
 }
 
+// Panel body styling without overflow constraint for autocomplete dropdowns
+.panel-body-no-overflow {
+  padding: 0 variables.$layout-spacing-lg;
+}
+
 .off-canvas {
   height: auto;
   .off-canvas-content {

--- a/app/assets/stylesheets/spectre-css/_panels.scss
+++ b/app/assets/stylesheets/spectre-css/_panels.scss
@@ -22,4 +22,9 @@
     overflow-y: auto;
     padding: 0 variables.$layout-spacing-lg;
   }
+
+  .panel-body-no-overflow {
+    flex: 1 1 auto;
+    padding: 0 variables.$layout-spacing-lg;
+  }
 }

--- a/app/controllers/admin/appointments_controller.rb
+++ b/app/controllers/admin/appointments_controller.rb
@@ -76,10 +76,6 @@ module Admin
       end
     end
 
-    helper_method def items_available_to_add_to_pickup
-      Item.available.includes(:borrow_policy)
-    end
-
     helper_method def items_available_to_add_to_dropoff
       (@appointment.member.loans.checked_out.includes(item: :borrow_policy) - appointment_return_items).map(&:item)
     end

--- a/app/controllers/admin/ui_controller.rb
+++ b/app/controllers/admin/ui_controller.rb
@@ -44,5 +44,17 @@ module Admin
 
       render json: strengths
     end
+
+    def available_items
+      items = Item
+        .available
+        .includes(:borrow_policy)
+        .search_by_anything(params[:q])
+        .by_name
+        .limit(20)
+        .map(&:complete_number_and_name)
+
+      render json: items
+    end
   end
 end

--- a/app/views/admin/appointments/_checkouts.html.erb
+++ b/app/views/admin/appointments/_checkouts.html.erb
@@ -80,15 +80,12 @@
     <% end %>
   <% end %>
   <div class="divider"></div>
+</div>
+<div class="panel-body-no-overflow">
   <div class="columns">
     <h5>Add an item to the appointment for check-out</h5>
     <%= form_with(model: [:admin, AppointmentHold.new], url: admin_appointment_holds_path(@appointment), method: :post, builder: SpectreFormBuilder) do |form| %>
-      <%= form.text_field :item_id, list: "items", autocomplete: :off, label: false %>
-      <datalist id="items">
-        <%= items_available_to_add_to_pickup.find_each do |item| %>
-          <%= tag(:option, value: item.complete_number_and_name) %>
-        <% end %>
-      </datalist>
+      <%= form.autocomplete_text_field :item_id, path: admin_ui_available_items_path(format: :json), label: false, placeholder: "Search for an item..." %>
       <%= form.submit do %>
         <%= feather_icon "plus" %>Add item to appointment
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -206,6 +206,7 @@ Rails.application.routes.draw do
     get "/ui/brands", to: "ui#brands"
     get "/ui/sizes", to: "ui#sizes"
     get "/ui/strengths", to: "ui#strengths"
+    get "/ui/available_items", to: "ui#available_items"
 
     if FeatureFlags.group_lending_enabled?
       # Group Lending


### PR DESCRIPTION
# What it does

Replaces the HTML5 datalist on the appointment checkout page with a server-backed autocomplete.

The "Add an item to the appointment for check-out" form now fetches matching items on-demand via AJAX as the user types, instead of rendering all ~5800 items into the DOM on page load.

# Why it is important

The datalist approach was loading thousands of `<option>` elements on every appointment page load, causing performance issues. The new autocomplete only loads ~20 items per search query.

# UI Change Screenshot

N/A - reproduces existing behavior with better performance

# Implementation notes

- Follows the existing autocomplete pattern used elsewhere (item names, brands, sizes)
- New endpoint: `GET /admin/ui/available_items?q=search_term`
- Uses `Item.search_by_anything()` to match user input
- Returns up to 20 results, properly scoped to current library tenant
- Uses existing `SpectreFormBuilder#autocomplete_text_field` helper
- Stimulus autocomplete controller + Awesomplete library handle the UI
- Moved the "Add an item" form outside the `.panel-body` container to prevent the Awesomplete dropdown from being clipped by the `overflow-y: auto` CSS property. The form is now wrapped in a `.panel-body-no-overflow` div that maintains consistent padding without the overflow constraint.