### PR TITLE
Remove Contact Us link from navigation

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -51,7 +51,6 @@
         <span class="link-group-label" id="nav-about-us-label">About Us</span>
         <ul aria-labelledby="nav-about-us-label">
           <%= navbar_link_to "Hours & Location", account_home_path %>
-          <%= navbar_link_to "Contact Us", "https://www.chicagotoollibrary.org/", new_tab: true %>
           <%= navbar_link_to "Visit Our Website", "https://www.chicagotoollibrary.org/", class: "extra-space", new_tab: true %>
         </ul>
       </li>


### PR DESCRIPTION
# What it does

Removes the "Contact Us" link from the "About Us" navigation section in the header.

# Why it is important

Closes #1993. The "Contact Us" link was redundant - it just linked to the main website (same as "Visit Our Website" below it), and the footer already provides an email contact option for users who need to reach out.

# UI Change Screenshot

N/A - Simple removal of a navigation link

# Implementation notes

Removed one line from `app/views/layouts/_header.html.erb`. No other changes needed as there were no tests referencing this link.