### PR TITLE
Skip "pulled items" step for dropoff-only appointments

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -36,6 +36,10 @@ class Appointment < ApplicationRecord
     completed_at.present?
   end
 
+  def dropoff_only?
+    holds.empty? && !loans.empty?
+  end
+
   def merge!(other_appointment)
     transaction do
       holds << other_appointment.holds

--- a/app/views/admin/appointments/_appointment.html.erb
+++ b/app/views/admin/appointments/_appointment.html.erb
@@ -32,8 +32,13 @@
       <%= button_to "complete", admin_appointment_completion_path(appointment, params: {new: true}),
             method: :post, class: "btn btn-sm", data: {disable_with: "saving"} %>
     <% else %>
-      <%= button_to "pull items", admin_appointment_pull_path(appointment, params: {new: true}),
-            method: :post, class: "btn btn-sm", data: {disable_with: "saving"} %>
+      <% if appointment.dropoff_only? %>
+        <%= button_to "complete", admin_appointment_completion_path(appointment, params: {new: true}),
+              method: :post, class: "btn btn-sm", data: {disable_with: "saving"} %>
+      <% else %>
+        <%= button_to "pull items", admin_appointment_pull_path(appointment, params: {new: true}),
+              method: :post, class: "btn btn-sm", data: {disable_with: "saving"} %>
+      <% end %>
     <% end %>
   </td>
 <% end %>

--- a/app/views/admin/appointments/_appointment_mobile.html.erb
+++ b/app/views/admin/appointments/_appointment_mobile.html.erb
@@ -64,8 +64,13 @@
       <%= button_to "Complete", admin_appointment_completion_path(appointment, new: true),
             method: :post, class: "btn btn-primary", data: {disable_with: "saving"} %>
     <% else %>
-      <%= button_to "Pull Items", admin_appointment_pull_path(appointment, params: {new: true}),
-            method: :post, class: "btn btn-primary", data: {disable_with: "saving"} %>
+      <% if appointment.dropoff_only? %>
+        <%= button_to "Complete", admin_appointment_completion_path(appointment, new: true),
+              method: :post, class: "btn btn-primary", data: {disable_with: "saving"} %>
+      <% else %>
+        <%= button_to "Pull Items", admin_appointment_pull_path(appointment, params: {new: true}),
+              method: :post, class: "btn btn-primary", data: {disable_with: "saving"} %>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/appointments/_appointment_orig.html.erb
+++ b/app/views/admin/appointments/_appointment_orig.html.erb
@@ -39,8 +39,13 @@
       <%= button_to "Complete", admin_appointment_completion_path(appointment), params: {new: false},
             method: :post, class: "btn btn-sm", data: {disable_with: "saving"} %>
     <% else %>
-      <%= button_to "Pull Items", admin_appointment_pull_path(appointment, params: {new: false}),
-            method: :post, class: "btn btn-sm", data: {disable_with: "saving"} %>
+      <% if appointment.dropoff_only? %>
+        <%= button_to "Complete", admin_appointment_completion_path(appointment), params: {new: false},
+              method: :post, class: "btn btn-sm", data: {disable_with: "saving"} %>
+      <% else %>
+        <%= button_to "Pull Items", admin_appointment_pull_path(appointment, params: {new: false}),
+              method: :post, class: "btn btn-sm", data: {disable_with: "saving"} %>
+      <% end %>
     <% end %>
   </td>
 <% end %>

--- a/test/models/appointment_test.rb
+++ b/test/models/appointment_test.rb
@@ -105,4 +105,39 @@ class AppointmentTest < ActiveSupport::TestCase
 
     assert appointment.destroyed?
   end
+
+  test "#dropoff_only? returns true when appointment has only loans (no holds)" do
+    member = create(:member)
+    loan = create(:loan, member: member)
+    appointment = create(:appointment, loans: [loan], member: member)
+
+    assert appointment.dropoff_only?
+  end
+
+  test "#dropoff_only? returns false when appointment has both holds and loans" do
+    member = create(:member)
+    hold = create(:hold, member: member)
+    loan = create(:loan, member: member)
+    appointment = create(:appointment, holds: [hold], loans: [loan], member: member)
+
+    refute appointment.dropoff_only?
+  end
+
+  test "#dropoff_only? returns false when appointment has only holds (no loans)" do
+    member = create(:member)
+    hold = create(:hold, member: member)
+    appointment = create(:appointment, holds: [hold], member: member)
+
+    refute appointment.dropoff_only?
+  end
+
+  test "#dropoff_only? returns false when appointment has no holds or loans" do
+    # This is a temporary state that should be caught by validation
+    member = create(:member)
+    appointment = build(:appointment, member: member)
+    appointment.staff_updating = true
+    appointment.save!(validate: false)
+
+    refute appointment.dropoff_only?
+  end
 end


### PR DESCRIPTION
# What it does

Adds logic to skip the "pulled items" step for appointments that only involve returns. These appointments can now go directly from pending to completed with a single "Complete" button click.

# Why it is important

Closes #1898

Librarians currently have to click through a "pulled items" step even when there's nothing to pull (dropoff-only appointments). This removes that unnecessary friction.

# UI Change Screenshot

(UI change is button text/logic only: "Pull Items" button becomes "Complete" button for dropoff-only appointments)

# Implementation notes

Added a `dropoff_only?` method to the Appointment model and updated the view partials to conditionally show the appropriate button. The completion controller already supports going directly from pending to completed, so no state machine changes were needed.