### PR TITLE
Replace organization signup links. Fixes #2043.

### DIFF
--- a/app/controllers/signup/home_controller.rb
+++ b/app/controllers/signup/home_controller.rb
@@ -4,11 +4,6 @@ module Signup
 
     def index
       @hide_steps = true
-      @org_signup_url = if FeatureFlags.group_lending_enabled?
-        signup_organizations_policies_url
-      else
-        ENV.fetch("ORGANIZATION_SIGNUP_URL")
-      end
     end
   end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -46,7 +46,7 @@
             <% if current_library.allow_members? %>
               <%= navbar_link_to "Sign Up", signup_path %>
             <% end %>
-            <%= navbar_link_to "Tools for Organizations", "https://chicagotoollibrary.myturn.com/library/", new_tab: true %>
+            <%= navbar_link_to "Camping Membership", "https://chicagotoollibrary.myturn.com/library/inventory/browse?location=3838", new_tab: true %>
           <% end %>
         </ul>
       </li>

--- a/app/views/signup/home/index.html.erb
+++ b/app/views/signup/home/index.html.erb
@@ -20,12 +20,12 @@
     </p>
 
     <div class="callout-box gift-membership">
-      <h5>Need to borrow tools for your organization?</h5>
+      <h5>Need to borrow camping equipment?</h5>
       <p>
-        We offer memberships for groups like nonprofits, block clubs, schools, and more!
+        We offer a special memberships for camping gear and equipment!
       </p>
       <p class="mr-2">
-        <%= link_to "Sign Up as an Organization", @org_signup_url, class: "btn btn-secondary btn-block btn-lg" %>
+        <%= link_to "Sign up for a Camping Membership", "https://chicagotoollibrary.myturn.com/library/inventory/browse?location=3838", class: "btn btn-secondary btn-block btn-lg" %>
       </p>
     </div>
   </div>


### PR DESCRIPTION
# What it does

Replaces the organization signup links with those to the camping inventory.

# UI Change Screenshot

<img width="307" height="150" alt="Screenshot 2025-11-18 at 7 38 11 PM" src="https://github.com/user-attachments/assets/f9ab6606-b8d4-4479-9d8c-d8a4ffbeb76c" />
<img width="716" height="589" alt="Screenshot 2025-11-18 at 7 38 26 PM" src="https://github.com/user-attachments/assets/22e24d0f-7a36-49ee-8f54-2b21e47d7655" />