### PR TITLE
Fix: Pressing cancel in the item lookup box doesn't always work

### DIFF
--- a/app/views/admin/members/lookups/show.html.erb
+++ b/app/views/admin/members/lookups/show.html.erb
@@ -40,7 +40,7 @@
         <div class="image-placeholder"></div>
       <% end %>
 
-      <%= link_to "Cancel", admin_member_path(@member, anchor: "checkout"), class: "btn", data: {turbo_frame: "_top"} %>
+      <%= link_to "Cancel", admin_member_path(@member), class: "btn", data: {turbo_frame: "_top"} %>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
# What it does

#1561 Removes the anchor from the link that clears (refreshes, really) the page. 

# Why it is important

This makes it so the cancel button does something rather than nothing.

# UI Change Screenshot
Nothing is visually different but just here's a picture of the button for reference:
<img width="1012" height="739" alt="Screenshot 2026-01-18 at 3 05 57 PM" src="https://github.com/user-attachments/assets/22d42923-824d-4147-8a53-85931cac3f53" />

# Implementation notes

There's some turbo stuff on the link I've left alone because it doesn't seem to hurt anything. My guess is this link broke because of a change in turbo at some point but I'm not 100% sure.
