### PR TITLE
Replace awesomplete with a simple datalist

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -614,6 +614,7 @@ PLATFORMS
   x86_64-darwin-19
   x86_64-darwin-22
   x86_64-darwin-23
+  x86_64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/app/assets/stylesheets/admin_application.scss
+++ b/app/assets/stylesheets/admin_application.scss
@@ -1,5 +1,4 @@
 @use 'styles.scss';
-@use 'awesomplete/awesomplete';
 @use '@selectize/selectize/dist/css/selectize.default';
 @use 'reports.scss';
 @use 'overrides.scss';

--- a/app/assets/stylesheets/overrides.scss
+++ b/app/assets/stylesheets/overrides.scss
@@ -118,11 +118,6 @@ trix-toolbar {
   background: variables.$bg-color;
 }
 
-// Fix issue where the tag input is being drawn above the name autocomplete
-.form-group .awesomplete > ul {
-  z-index: 10;
-}
-
 // Panel body styling without overflow constraint for autocomplete dropdowns
 .panel-body-no-overflow {
   padding: 0 variables.$layout-spacing-lg;

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -531,10 +531,6 @@ details .action-bar {
   margin-top: 1rem;
 }
 
-form .awesomplete {
-  display: block;
-}
-
 fieldset {
   margin-top: 1rem;
 }

--- a/app/lib/spectre_form_builder.rb
+++ b/app/lib/spectre_form_builder.rb
@@ -158,7 +158,7 @@ class SpectreFormBuilder < ActionView::Helpers::FormBuilder
   def autocomplete_text_field(method, options = {})
     text_field(method, options.merge(
       wrapper_options: {
-        data: {controller: "autocomplete", action: "input->autocomplete#input", autocomplete_path: options.delete(:path)}
+        data: {controller: "autocomplete", action: "keyup->autocomplete#input", autocomplete_path: options.delete(:path)}
       },
       data: {"autocomplete-target": "input"}
     ))

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@rails/activestorage": "^8.0.300",
     "@rails/ujs": "^7.1.502",
     "@selectize/selectize": "^0.15.2",
-    "awesomplete": "^1.1.7",
     "esbuild": "^0.27.2",
     "feather-icons": "^4.29.2",
     "jquery": "^3.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -371,11 +371,6 @@ autolinker@~0.28.0:
   dependencies:
     gulp-header "^1.7.1"
 
-awesomplete@^1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/awesomplete/-/awesomplete-1.1.7.tgz#480f7bb571e30c7a6d411c0139f07032943cd25a"
-  integrity sha512-hwClzFReIIfheoMWpoJ7juLp1o6Q7YjTtEdZIGfXvhRHA9ewKM03VS4ZoK+OEFIKM066PfQt9pzRIGV1TguRBw==
-
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"


### PR DESCRIPTION
# What it does

Replaces Awesomplete with a simple datalist managed by a stimulus controller.

# Why it is important

#1832 points out that Awesomplete isn't really maintained and there are some browser compatibility issues.

# UI Change Screenshot

How it looks with Awesomplete:

<img width="355" height="312" alt="Screenshot 2026-01-24 at 1 31 06 PM" src="https://github.com/user-attachments/assets/ad451830-7875-4754-bb6e-a6fd7a0f0ed7" />

How it looks with the datalist (it will appear above or below depending on scroll position):

<img width="338" height="467" alt="Screenshot 2026-01-24 at 1 31 17 PM" src="https://github.com/user-attachments/assets/7a0dc59a-feb7-4eef-83ae-299ff84b2e03" />

<img width="332" height="467" alt="Screenshot 2026-01-24 at 1 30 44 PM" src="https://github.com/user-attachments/assets/546893af-e818-49ad-88e7-1bc4712e87e3" />

# Implementation note
It's a little more JavaScript but I think it's easier than integrating any of the other autocomplete plugins I found. There are some [accessibility concerns](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/datalist#accessibility) with the datalist, but given the existing issues with Awesomplete this is probably a solid improvement.
