### PR TITLE
Add simpler status reason option for borrow policy approvals

### DIFF
--- a/app/views/admin/borrow_policy_approvals/edit.html.erb
+++ b/app/views/admin/borrow_policy_approvals/edit.html.erb
@@ -16,6 +16,7 @@
           "Unreliable borrowing: overdue tools.",
           "Unreliable borrowing: damaged or dirty tools.",
           "Unreliable borrowing: not respecting policies.",
+          "You need to complete more successful loans to earn access.",
           "You are a new member. You need to complete more successful loans to earn access."
         ],
         hint: "This will be sent in an email notification to the member, prefaced with 'This is because:'" %>


### PR DESCRIPTION
# What it does

Adds a plain "You need to complete more successful loans to earn access." option to the borrow policy approval status reasons dropdown.

# Why it is important

Allows staff to provide this reason without implying the member is new—useful when someone isn't new but still needs more successful loans.