### PR TITLE
Handle users without member records gracefully in account area

### DIFF
--- a/app/controllers/account/base_controller.rb
+++ b/app/controllers/account/base_controller.rb
@@ -1,6 +1,7 @@
 module Account
   class BaseController < ApplicationController
     before_action :authenticate_user!
+    before_action :require_member
 
     def are_appointments_enabled?
       if !@current_library.allow_appointments?
@@ -14,5 +15,21 @@ module Account
       )
     end
     helper_method :current_reservation
+
+    private
+
+    def require_member
+      return if current_member.present?
+
+      Appsignal.report_error(RuntimeError.new("User without member record accessed account area")) do |transaction|
+        transaction.set_custom_data(
+          user_id: current_user.id,
+          user_email: current_user.email,
+          user_role: current_user.role
+        )
+      end
+
+      redirect_to root_path, alert: "There's a problem with your account. Please contact the library for assistance."
+    end
   end
 end


### PR DESCRIPTION
# What it does

Adds a `require_member` check in `Account::BaseController` that catches users without a Member record before they hit any controller actions. Reports to Appsignal with user details and redirects with a friendly message instead of crashing.

# Why it is important

We have 14 users with `role: "member"` but no associated Member record. When they hit any `/account/*` page, `current_member` returns nil and we get crashes like `undefined method 'loans' for nil`. This lets them see a helpful message while we figure out how to clean up the orphaned accounts.