### PR TITLE
Destroy associated user when a member is destroyed

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -20,7 +20,7 @@ class Member < ApplicationRecord
   has_one :pending_membership, -> { merge(Membership.pending) }, class_name: "Membership"
   has_one :last_membership, -> { order("ended_at DESC NULLS FIRST") }, class_name: "Membership"
 
-  belongs_to :user, optional: true
+  belongs_to :user, optional: true, dependent: :destroy
   has_many :notes, as: :notable
   has_many :for_later_list_items, -> { order(created_at: :desc) }, dependent: :destroy
   has_many :for_later_listed_items, through: :for_later_list_items, source: :item

--- a/test/controllers/admin/members_controller_test.rb
+++ b/test/controllers/admin/members_controller_test.rb
@@ -71,6 +71,16 @@ module Admin
       assert_redirected_to admin_member_url(@member)
     end
 
+    test "should destroy member and associated user" do
+      member = create(:member, :with_user)
+
+      assert_difference(["Member.count", "User.count"], -1) do
+        delete admin_member_url(member)
+      end
+
+      assert_redirected_to admin_members_url
+    end
+
     test "should resend member verification email to new unconfirmed user" do
       member = create(:member, user: create(:user, :unconfirmed))
       ActionMailer::Base.deliveries.clear


### PR DESCRIPTION
# What it does

- Adds `dependent: :destroy` to `Member`'s `belongs_to :user` association so the User record is cleaned up when a Member is destroyed
- Adds a test verifying both Member and User counts decrease together on destroy

# Why it is important

Fixes #2121. When an admin destroyed a member, the associated User (Devise) record was left behind as an orphan. This blocked the person from re-signing up because the email uniqueness constraint on User still claimed the address.

This completes the User-Member lifecycle invariant established in #2069 (which ensured Users are created alongside Members) by ensuring they are also destroyed together.