### PR TITLE
Handle authorization error when renewing a stale loan

### DIFF
--- a/app/controllers/account/renewals_controller.rb
+++ b/app/controllers/account/renewals_controller.rb
@@ -8,6 +8,8 @@ module Account
 
       renew_loan(@loan)
       redirect_to account_loans_path, success: "#{@loan.item.name} was renewed.", status: :see_other
+    rescue Pundit::NotAuthorizedError
+      redirect_to account_loans_path, warning: "This loan can no longer be renewed.", status: :see_other
     end
   end
 end

--- a/test/controllers/account/renewals_controller_test.rb
+++ b/test/controllers/account/renewals_controller_test.rb
@@ -23,15 +23,15 @@ module Account
     end
 
     test "member cannot renew a non-renewable loan" do
-      assert_raises Pundit::NotAuthorizedError do
-        post account_renewals_url(loan_id: @loan1)
-      end
+      post account_renewals_url(loan_id: @loan1)
+      assert_redirected_to account_loans_url
+      assert_equal "This loan can no longer be renewed.", flash[:warning]
     end
 
     test "member cannot renew another member's loan" do
-      assert_raises Pundit::NotAuthorizedError do
-        post account_renewals_url(loan_id: @loan2)
-      end
+      post account_renewals_url(loan_id: @loan2)
+      assert_redirected_to account_loans_url
+      assert_equal "This loan can no longer be renewed.", flash[:warning]
     end
   end
 end


### PR DESCRIPTION
# What it does

Rescues `Pundit::NotAuthorizedError` in the account renewals controller and redirects the member back to their loans page with a warning message instead of showing a 500 error.

# Why it is important

A member hit a 500 when they clicked "Renew Loan" on a loan that staff had checked in seconds earlier. This is a natural race condition — the page showed the Renew button, but by the time they clicked it the loan was already ended. This change handles that gracefully.

# Implementation notes

The race window is small but real — in the observed case it was ~12 seconds between check-in and the renewal attempt. Rather than adding broader Pundit error handling across all account controllers, this rescue is scoped to just the renewals action where the stale-page scenario is expected.