### PR TITLE
Auto-refresh camping gear dashboard every 5 minutes

### DIFF
--- a/app/views/admin/reports/myturn_reservations/index.html.erb
+++ b/app/views/admin/reports/myturn_reservations/index.html.erb
@@ -1,3 +1,7 @@
+<%= content_for :head do %>
+  <meta http-equiv="refresh" content="300">
+<% end %>
+
 <%= content_for :header do %>
   <%= index_header "Camping Gear" %>
 <% end %>


### PR DESCRIPTION
# What it does

Adds a meta refresh tag to the camping gear dashboard so it auto-reloads every 5 minutes.

# Why it is important

Librarians may leave this page open during a shift. Auto-refresh keeps it current without needing a manual reload.

Closes #2149