### PR TITLE
Convert no-holds items to 1-day holds

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -138,6 +138,7 @@ class Item < ApplicationRecord
   before_validation :strip_whitespace
 
   before_save :cache_description_as_plain_text
+  before_save :clear_hold_duration_when_holds_disabled
   after_update :clear_holds_if_inactive, :pause_next_hold_if_maintenance
 
   def self.ransackable_attributes(auth_object = nil)
@@ -230,6 +231,10 @@ class Item < ApplicationRecord
       next if value.blank?
       self[attr_name] = value.strip
     end
+  end
+
+  def clear_hold_duration_when_holds_disabled
+    self.hold_duration = nil unless holds_enabled
   end
 
   def clear_holds_if_inactive

--- a/db/migrate/20260424150504_convert_no_holds_items_to_one_day_holds.rb
+++ b/db/migrate/20260424150504_convert_no_holds_items_to_one_day_holds.rb
@@ -1,0 +1,15 @@
+class ConvertNoHoldsItemsToOneDayHolds < ActiveRecord::Migration[8.0]
+  def up
+    Item.where(status: "active", holds_enabled: false).find_each do |item|
+      item.update!(
+        holds_enabled: true,
+        hold_duration: 1,
+        audit_comment: "Converted from no-holds to 1-day hold (issue #2157)"
+      )
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_11_221407) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_24_150504) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -143,6 +143,12 @@ class ItemTest < ActiveSupport::TestCase
     refute item.holdable?
   end
 
+  test "clears hold_duration when holds are disabled" do
+    item = create(:item, holds_enabled: true, hold_duration: 1)
+    item.update!(holds_enabled: false)
+    assert_nil item.reload.hold_duration
+  end
+
   test "has a next_hold" do
     item = create(:item)
     hold = create(:hold, item: item, created_at: 2.days.ago)


### PR DESCRIPTION
# What it does

Runs a data migration that flips the 57 active `holds_enabled=false` items to `holds_enabled=true, hold_duration=1`, turning the old "no holds" set into one-day-hold items. Also adds a `before_save` on `Item` that nulls `hold_duration` whenever `holds_enabled` gets unchecked, so the two fields can't drift apart.

# Why it is important

When one-day holds went out in #2118, Tessa flagged that items which used to be no-holds were showing up as regular 7-day holds. Digging through the audit trail, the actual story was that staff had been flipping the checkbox back on manually over the past few months, sometimes without setting the new hold duration dropdown. The original intent was always for one-day holds to replace no-holds for high-demand seasonal items (power washers, carpet cleaners, weed whackers, reel mowers), so rather than ask staff to re-touch 57 items by hand, we do it here.

The `holds_enabled=false` state still works the way it always has, in case we want to bring it back — it's just no longer the default path for short-hold items.

Closes #2157

# UI Change Screenshot

No UI changes.

# Implementation notes

The migration uses `update!` with an `audit_comment` rather than `update_all`, so each converted item gets a readable entry in its audit history ("Converted from no-holds to 1-day hold (issue #2157)"). At 57 rows the perf cost of iterating is a rounding error.

There are also 13 stragglers — items that staff previously flipped from no-holds back to enabled without setting a duration, so they currently act as 7-day holds. A couple are clearly intentional (named "Metal wheelbarrow - 7 day hold") and a few are ambiguous. I'll post the list on #2157 once this lands so Tessa can triage.