### PR TITLE
Add rake task to import item locations from CSV

### DIFF
--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -53,6 +53,88 @@ namespace :import do
     end
   end
 
+  # Updates item locations from a CSV with headers including:
+  #   complete_number, name, location_area, location_shelf
+  # Other columns are ignored. Joins on complete_number rather than `id`.
+  # The CSV's id column is not a reliable join key (the May 2026 spreadsheet
+  # had 118 duplicate ids); complete_number maps cleanly via
+  # Item.find_by_complete_number.
+  #
+  # To run without redeploying (the May 2026 recipe), tar the script + CSV
+  # together and pipe to a one-off dyno:
+  #
+  #   tar -c -C /tmp import_locations.rb tool_locations.csv | \
+  #     heroku run --no-tty --app chicagotoollibrary -- bash -c '
+  #       set -e
+  #       cd /tmp && tar x
+  #       AUTHOR=you@chicagotoollibrary.org LIBRARY_ID=1 DRY_RUN=1 \
+  #         CSV_FILE=/tmp/tool_locations.csv \
+  #         rails runner /tmp/import_locations.rb
+  #     '
+  #
+  # Or after deploying the rake task:
+  #
+  #   heroku run rake import:item_locations \
+  #     CSV_FILE=/tmp/locations.csv AUTHOR=email LIBRARY_ID=1 DRY_RUN=1
+  desc "Updates item locations (location_area, location_shelf) from a CSV"
+  task item_locations: :environment do
+    path = ENV["CSV_FILE"]
+    user = User.find_by(email: ENV["AUTHOR"])
+    raise "author not found!" unless user
+
+    library = Library.find(ENV["LIBRARY_ID"])
+    dry_run = ENV["DRY_RUN"] == "1"
+
+    puts "DRY RUN: no changes will be saved" if dry_run
+
+    stats = Hash.new(0)
+
+    CSV.foreach(path, headers: true) do |row|
+      Audited.audit_model.as_user(user) do
+        ActsAsTenant.with_tenant(library) do
+          complete_number = row["complete_number"]
+          item = Item.find_by_complete_number(complete_number)
+
+          unless item
+            puts "SKIP #{complete_number}: item not found (csv name=#{row["name"].inspect})"
+            stats[:skipped_not_found] += 1
+            next
+          end
+
+          if row["location_area"].to_s.strip.empty?
+            puts "SKIP #{complete_number} (#{item.name.inspect}): blank location_area in CSV"
+            stats[:skipped_missing_area] += 1
+            next
+          end
+
+          if row["name"].to_s.strip.present? && row["name"].strip != item.name.to_s.strip
+            puts "NAME MISMATCH #{complete_number}: db=#{item.name.inspect} csv=#{row["name"].inspect} (updating location anyway)"
+            stats[:name_mismatch] += 1
+          end
+
+          new_area = row["location_area"].strip
+          new_shelf = row["location_shelf"].to_s.strip.presence
+
+          if item.location_area == new_area && item.location_shelf == new_shelf
+            stats[:unchanged] += 1
+            next
+          end
+
+          puts "UPDATE #{complete_number} id=#{item.id}: area #{item.location_area.inspect} -> #{new_area.inspect}, shelf #{item.location_shelf.inspect} -> #{new_shelf.inspect}"
+
+          unless dry_run
+            item.update!(location_area: new_area, location_shelf: new_shelf)
+          end
+          stats[:updated] += 1
+        end
+      end
+    end
+
+    puts ""
+    puts "Summary:"
+    stats.sort.each { |k, v| puts "  #{k}: #{v}" }
+  end
+
   def find_or_create_categories_from_names(item_id, names)
     path_names = names.split(";").map(&:strip).reject(&:empty?).uniq
     category_ids = CategoryNode.where("ARRAY_TO_STRING(path_names, '//') IN (?)", path_names).pluck(:id)


### PR DESCRIPTION
# What it does

Adds `import:item_locations`, a rake task that reads a CSV with `complete_number`, `name`, `location_area`, and `location_shelf` columns and updates the matching `Item` records. Supports `DRY_RUN=1` to preview changes, logs name mismatches and skips for blank areas, and wraps updates in `Audited.audit_model.as_user` + `ActsAsTenant.with_tenant` so the audit trail and tenant scoping match the existing import tasks.

# Why it is important

We just ran this against prod to import Tessa's May 2026 spreadsheet of tool locations (~3,700 items now have their physical location captured in the system). The actual import was run inline via `rails runner` rather than a deploy, but committing the same logic as a rake task gives the next person something discoverable via `rake -T` and a header comment that captures the gotcha that bit us: the CSV's `id` column is not a reliable join key, so the task joins on `complete_number` via `Item.find_by_complete_number`.

# Implementation notes

The header comment includes both invocation recipes: the conventional `heroku run rake` path, and the `tar` + `heroku run --no-tty` recipe we actually used to run it without redeploying. That recipe is the load-bearing piece for anyone repeating this kind of import.

No tests since this is a one-off operational task following the pattern of the existing `import:item_csv` and `import:category_csv` siblings.