### PR TITLE
Stop chasing CSRF noise on Devise login and signup

### DIFF
--- a/app/controllers/signup/members_controller.rb
+++ b/app/controllers/signup/members_controller.rb
@@ -1,6 +1,11 @@
 module Signup
   class MembersController < BaseController
     before_action :is_membership_enabled?
+    # Skip CSRF to stop InvalidAuthenticityToken errors that hurt real users
+    # (long signup form, lost data on retry). Signup is public and #create
+    # doesn't read current_user, so spam prevention belongs in rate-limiting,
+    # not CSRF. See application_controller.rb for prior chapters.
+    skip_before_action :verify_authenticity_token, only: :create
 
     def new
       if session[:member_id]

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,5 +1,11 @@
 module Users
   class SessionsController < Devise::SessionsController
+    # Skip CSRF to stop InvalidAuthenticityToken errors that hurt real users
+    # (mostly mobile Safari after ITP evicts the csrf_token cookie). Login is
+    # public, login-CSRF is low-impact, and Devise rotates the session on
+    # successful sign-in. See application_controller.rb for prior chapters.
+    skip_before_action :verify_authenticity_token, only: :create
+
     def new
       if request.referer.present?
         referer = URI.parse(request.referer)
@@ -10,6 +16,10 @@ module Users
     rescue URI::InvalidURIError
       # bad URI, ignore
     ensure
+      super
+    end
+
+    def create
       super
     end
   end

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -57,10 +57,13 @@ end
 # possible to simply change the config value and have it take affect.
 #
 # In this case we're using a specific subclass to verify the desired behavior.
+# Users::ConfirmationsController is a convenient target because it's public,
+# uses POST, and still has CSRF protection enabled (sessions and signup
+# creates now skip it intentionally).
 class ApplicationControllerCSRFTest < ActionDispatch::IntegrationTest
   setup do
     @user = create(:user)
-    class Users::SessionsController # standard:disable Lint/ConstantDefinitionInBlock
+    class Users::ConfirmationsController # standard:disable Lint/ConstantDefinitionInBlock
       alias_method :original_protect_against_forgery?, :protect_against_forgery?
       def protect_against_forgery?
         true
@@ -69,17 +72,17 @@ class ApplicationControllerCSRFTest < ActionDispatch::IntegrationTest
   end
 
   teardown do
-    class Users::SessionsController # standard:disable Lint/ConstantDefinitionInBlock
+    class Users::ConfirmationsController # standard:disable Lint/ConstantDefinitionInBlock
       alias_method :protect_against_forgery?, :original_protect_against_forgery?
       remove_method :original_protect_against_forgery?
     end
   end
 
   test "handles an invalid_authenticity_token" do
-    post user_session_path, params: {user: {email: @user.email, password: "password"}}, headers: {referer: "http://example.com/users/sessions/new"}
+    post user_confirmation_path, params: {user: {email: @user.email}}, headers: {referer: "http://example.com/users/confirmation/new"}
 
     assert_response :redirect
-    assert_equal "http://example.com/users/sessions/new", response.location
+    assert_equal "http://example.com/users/confirmation/new", response.location
     assert_equal "There was an issue with your submission, please try again.", flash[:error]
   end
 end


### PR DESCRIPTION
# What it does

Skips CSRF on `Users::SessionsController#create` and `Signup::MembersController#create`. The application_controller rescue and AppSignal reporting stay in place for every other form.

# Why it is important

These two endpoints have been generating most of our `InvalidAuthenticityToken` noise for a long time: about 1,300 on the sessions controller and 30 on signup. The `NonSessionCookieStore` round helped a lot but didn't fully stop the bleed.

I sampled the still-failing requests today, and the leftover noise is almost entirely things CSRF can't defend against. Bots POSTing scraped login forms, Safari users whose csrf_token cookie got pruned by ITP, and a few folks who left a tab open too long. Not a single real CSRF attack in the bunch.

Login is public, login-CSRF is low-impact for a library app, and Devise rotates the session on sign-in. Signup is public too and `#create` doesn't read `current_user`, so spam prevention belongs in rate-limiting, not CSRF.

# UI Change Screenshot

No UI changes. Failed attempts now show the usual Devise/form validation errors instead of the "There was an issue with your submission, please try again." retry flash.

# Implementation notes

The `Users::SessionsController#create` override is a `super` passthrough so `Rails/LexicallyScopedActionFilter` doesn't complain about a `skip_before_action` targeting an inherited action.

The CSRF rescue test moves off the sessions controller (since the rescue can't fire there anymore) and exercises the rescue via `Users::ConfirmationsController` instead.