### PR TITLE
Update links to camping site

### DIFF
--- a/.env
+++ b/.env
@@ -62,3 +62,5 @@ TWILIO_AUTH_TOKEN=
 # service be specified.
 # TWILIO_PHONE_NUMBER=
 # TWILIO_MESSAGING_SERVICE_SID=
+
+CAMPING_HOMEPAGE_URL=https://www.chicagotoollibrary.org/camping

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -30,4 +30,8 @@ module ApplicationHelper
       "#{current_library.name} Inventory"
     end
   end
+
+  def camping_homepage_url
+    ENV.fetch("CAMPING_HOMEPAGE_URL", "https://www.chicagotoollibrary.org/camping")
+  end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -55,7 +55,7 @@
             <% if current_library.allow_members? %>
               <%= navbar_link_to "Sign Up", signup_path %>
             <% end %>
-            <%= navbar_link_to "Camping Membership", "https://chicagotoollibrary.myturn.com/library/inventory/browse?location=3838", new_tab: true %>
+            <%= navbar_link_to "Rent Camping Gear", camping_homepage_url, new_tab: true %>
           <% end %>
         </ul>
       </li>

--- a/app/views/signup/home/index.html.erb
+++ b/app/views/signup/home/index.html.erb
@@ -22,10 +22,10 @@
     <div class="callout-box gift-membership">
       <h5>Need to borrow camping equipment?</h5>
       <p>
-        We offer a special memberships for camping gear and equipment!
+        We have a dedicated camping gear collection that is separate from our tool collection. No membership is required to borrow camping gear!
       </p>
       <p class="mr-2">
-        <%= link_to "Sign up for a Camping Membership", "https://chicagotoollibrary.myturn.com/library/inventory/browse?location=3838", class: "btn btn-secondary btn-block btn-lg" %>
+        <%= link_to "Rent Camping Gear", camping_homepage_url, class: "btn btn-secondary btn-block btn-lg", target: "_blank", rel: "noopener noreferrer" %>
       </p>
     </div>
   </div>


### PR DESCRIPTION
# What it does

Updates the links and language related to the camping program. Fixes #2116.

# UI Change Screenshot

<img width="1238" height="348" alt="image" src="https://github.com/user-attachments/assets/be7746d1-faba-4fa1-a8c2-d23f1c2e10bb" />

# Implementation notes

I set things up so in the future we can tweak the URL using an env variable without making a code change.