### PR TITLE
Use bookmark icons for the save for later functionality

### DIFF
--- a/app/assets/stylesheets/application_styles.scss
+++ b/app/assets/stylesheets/application_styles.scss
@@ -17,6 +17,7 @@
 @use 'volunteer';
 @use 'header';
 @use 'reservations';
+@use 'for_later_list';
 @use 'spectre-css/variables';
 
 body {

--- a/app/assets/stylesheets/application_styles.scss
+++ b/app/assets/stylesheets/application_styles.scss
@@ -145,6 +145,7 @@ $photo-width: 187px;
   .item-container {
     display: flex;
     border-bottom: 1px solid #dadee4;
+    position: relative;
   }
 
   .item-container .item-name {

--- a/app/assets/stylesheets/for_later_list.scss
+++ b/app/assets/stylesheets/for_later_list.scss
@@ -1,0 +1,12 @@
+.save-for-later-button svg {
+}
+
+.remove-from-save-for-later-button {
+  svg {
+    fill: lighten(#605045, 40%);
+  }
+
+  &:hover svg {
+    fill: white;
+  }
+}

--- a/app/assets/stylesheets/for_later_list.scss
+++ b/app/assets/stylesheets/for_later_list.scss
@@ -1,12 +1,25 @@
-.save-for-later-button svg {
-}
+@use 'sass:color';
 
 .remove-from-save-for-later-button {
   svg {
-    fill: lighten(#605045, 40%);
+    fill: color.adjust(#605045, $lightness: 40%, $space: hsl);
   }
 
   &:hover svg {
     fill: white;
   }
+
+  &:active svg {
+    fill: color.adjust(#605045, $lightness: 40%, $space: hsl);
+  }
+}
+
+.for-later-list-button-container {
+  position: absolute;
+  top: 0;
+  right: 0;
+}
+
+.saved-for-later-list {
+  padding-block-start: 22px;
 }

--- a/app/controllers/account/for_later_list_items_controller.rb
+++ b/app/controllers/account/for_later_list_items_controller.rb
@@ -20,7 +20,8 @@ module Account
         format.turbo_stream do
           render turbo_stream: [
             turbo_stream.replace("for_later_list_item_show", partial: "items/for_later_list_item_show", locals: {item:, for_later_list_item:}),
-            turbo_stream.replace("#{helpers.dom_id(item)}_for_later_list_items_index", partial: "items/for_later_list_items_index", locals: {item:, for_later_list_item:})
+            turbo_stream.replace("#{helpers.dom_id(item)}_for_later_list_items_index", partial: "items/for_later_list_items_index", locals: {item:, for_later_list_item:}),
+            turbo_stream.update("flash-message-container", view_context.flash_message_html("Successfully saved for later", :success))
           ]
         end
       end
@@ -39,7 +40,8 @@ module Account
           render turbo_stream: [
             turbo_stream.remove(helpers.dom_id(for_later_list_item)),
             turbo_stream.replace("for_later_list_item_show", partial: "items/for_later_list_item_show", locals: {item:, for_later_list_item: nil}),
-            turbo_stream.replace("#{helpers.dom_id(item)}_for_later_list_items_index", partial: "items/for_later_list_items_index", locals: {item:, for_later_list_item: nil})
+            turbo_stream.replace("#{helpers.dom_id(item)}_for_later_list_items_index", partial: "items/for_later_list_items_index", locals: {item:, for_later_list_item: nil}),
+            turbo_stream.update("flash-message-container", view_context.flash_message_html("Successfully removed from saved for later list", :success))
           ]
         end
       end

--- a/app/controllers/account/for_later_list_items_controller.rb
+++ b/app/controllers/account/for_later_list_items_controller.rb
@@ -15,13 +15,15 @@ module Account
 
       item = for_later_list_item.item
 
+      success_message = "Successfully saved for later"
+
       respond_to do |format|
-        format.html { redirect_to item_path(for_later_list_item.item) }
+        format.html { redirect_to item_path(for_later_list_item.item), success: success_message }
         format.turbo_stream do
           render turbo_stream: [
             turbo_stream.replace("for_later_list_item_show", partial: "items/for_later_list_item_show", locals: {item:, for_later_list_item:}),
             turbo_stream.replace("#{helpers.dom_id(item)}_for_later_list_items_index", partial: "items/for_later_list_items_index", locals: {item:, for_later_list_item:}),
-            turbo_stream.update("flash-message-container", view_context.flash_message_html("Successfully saved for later", :success))
+            turbo_stream.update("flash-message-container", view_context.flash_message_html(success_message, :success))
           ]
         end
       end
@@ -34,14 +36,16 @@ module Account
 
       item = for_later_list_item.item
 
+      success_message = "Successfully removed from saved for later list"
+
       respond_to do |format|
-        format.html { redirect_to account_for_later_list_items_path }
+        format.html { redirect_to account_for_later_list_items_path, success: success_message }
         format.turbo_stream do
           render turbo_stream: [
             turbo_stream.remove(helpers.dom_id(for_later_list_item)),
             turbo_stream.replace("for_later_list_item_show", partial: "items/for_later_list_item_show", locals: {item:, for_later_list_item: nil}),
             turbo_stream.replace("#{helpers.dom_id(item)}_for_later_list_items_index", partial: "items/for_later_list_items_index", locals: {item:, for_later_list_item: nil}),
-            turbo_stream.update("flash-message-container", view_context.flash_message_html("Successfully removed from saved for later list", :success))
+            turbo_stream.update("flash-message-container", view_context.flash_message_html(success_message, :success))
           ]
         end
       end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -15,11 +15,15 @@ module AdminHelper
     end
   end
 
-  def flash_message(key, classname = key)
+  def flash_message(key, type_override = key)
     if flash.key?(key)
-      tag.div(class: "toast toast-#{classname}", data: {controller: "alert"}) do
-        tag.button(class: "btn btn-clear float-right", data: {action: "alert#remove"}) + flash[key].html_safe
-      end
+      flash_message_html(flash[key].html_safe, type_override)
+    end
+  end
+
+  def flash_message_html(message, type)
+    tag.div(class: "toast toast-#{type}", data: {controller: "alert"}) do
+      tag.button(class: "btn btn-clear float-right", data: {action: "alert#remove"}) + message
     end
   end
 

--- a/app/views/account/for_later_list_items/index.html.erb
+++ b/app/views/account/for_later_list_items/index.html.erb
@@ -34,7 +34,7 @@
             <br>
 
             <%= tag.div [item.brand, item.model].select(&:present?).join(", ") %>
-            <%= button_to "Don't need it", account_for_later_list_item_path(for_later_list_item),
+            <%= button_to "Remove from saved for later", account_for_later_list_item_path(for_later_list_item),
                   method: :delete, class: "btn" %>
           <% end %>
 

--- a/app/views/account/for_later_list_items/index.html.erb
+++ b/app/views/account/for_later_list_items/index.html.erb
@@ -42,7 +42,7 @@
             <% end %>
           <% end %>
           <%= button_to "Remove", account_for_later_list_item_path(for_later_list_item),
-                method: :delete, class: "btn" %>
+                method: :delete, class: "btn", data: {turbo_confirm: "Are you sure?"} %>
         </div>
       </li>
     <% end %>

--- a/app/views/account/for_later_list_items/index.html.erb
+++ b/app/views/account/for_later_list_items/index.html.erb
@@ -1,7 +1,7 @@
 <h1 class="title">Saved for later</h1>
 
 <% if @for_later_list_items.any? %>
-  <ul class="items-list">
+  <ul class="items-list saved-for-later-list">
     <% @for_later_list_items.each do |for_later_list_item| %>
       <% item = for_later_list_item.item %>
       <li id="<%= dom_id(for_later_list_item) %>" class="item-container">
@@ -34,8 +34,6 @@
             <br>
 
             <%= tag.div [item.brand, item.model].select(&:present?).join(", ") %>
-            <%= button_to "Remove from saved for later", account_for_later_list_item_path(for_later_list_item),
-                  method: :delete, class: "btn" %>
           <% end %>
 
           <%= tag.div class: "item-categories" do %>
@@ -43,6 +41,8 @@
               <%= link_to category.name, {category: category.id} %>
             <% end %>
           <% end %>
+          <%= button_to "Remove", account_for_later_list_item_path(for_later_list_item),
+                method: :delete, class: "btn" %>
         </div>
       </li>
     <% end %>

--- a/app/views/items/_for_later_list_item_show.html.erb
+++ b/app/views/items/_for_later_list_item_show.html.erb
@@ -1,7 +1,7 @@
 <% if FeatureFlags.for_later_lists_enabled? %>
   <span id="for_later_list_item_show">
     <% if for_later_list_item.present? %>
-      <%= button_to "Don't need it", account_for_later_list_item_path(for_later_list_item),
+      <%= button_to "Remove from saved for later", account_for_later_list_item_path(for_later_list_item),
             method: :delete, class: "btn" %>
     <% else %>
       <%= button_to "Save for later", account_for_later_list_items_path,

--- a/app/views/items/_for_later_list_item_show.html.erb
+++ b/app/views/items/_for_later_list_item_show.html.erb
@@ -1,11 +1,17 @@
 <% if FeatureFlags.for_later_lists_enabled? %>
   <span id="for_later_list_item_show">
     <% if for_later_list_item.present? %>
-      <%= button_to "Remove from saved for later", account_for_later_list_item_path(for_later_list_item),
-            method: :delete, class: "btn" %>
+      <%= button_to account_for_later_list_item_path(for_later_list_item),
+            method: :delete, class: "btn remove-from-save-for-later-button", title: "Remove from save for later list" do %>
+          <%= render partial: "shared/icons/bookmark" %>
+          <span class="visually-hidden">Remove from saved for later</span>
+      <% end %>
     <% else %>
-      <%= button_to "Save for later", account_for_later_list_items_path,
-            method: :post, class: "btn", params: {for_later_list_item: {item_id: item.id}} %>
+      <%= button_to account_for_later_list_items_path,
+            method: :post, class: "btn save-for-later-button", title: "Save for later list", params: {for_later_list_item: {item_id: item.id}} do %>
+          <%= render partial: "shared/icons/bookmark" %>
+          <span class="visually-hidden">Save for later</span>
+      <% end %>
     <% end %>
   </span>
 <% end %>

--- a/app/views/items/_for_later_list_item_show.html.erb
+++ b/app/views/items/_for_later_list_item_show.html.erb
@@ -3,14 +3,14 @@
     <% if for_later_list_item.present? %>
       <%= button_to account_for_later_list_item_path(for_later_list_item),
             method: :delete, class: "btn remove-from-save-for-later-button", title: "Remove from save for later list" do %>
-          <%= render partial: "shared/icons/bookmark" %>
-          <span class="visually-hidden">Remove from saved for later</span>
+        <%= render partial: "shared/icons/bookmark" %>
+        <span class="visually-hidden">Remove from saved for later</span>
       <% end %>
     <% else %>
       <%= button_to account_for_later_list_items_path,
-            method: :post, class: "btn save-for-later-button", title: "Save for later list", params: {for_later_list_item: {item_id: item.id}} do %>
-          <%= render partial: "shared/icons/bookmark" %>
-          <span class="visually-hidden">Save for later</span>
+            method: :post, class: "btn save-for-later-button", title: "Save for later", params: {for_later_list_item: {item_id: item.id}} do %>
+        <%= render partial: "shared/icons/bookmark" %>
+        <span class="visually-hidden">Save for later</span>
       <% end %>
     <% end %>
   </span>

--- a/app/views/items/_for_later_list_item_show.html.erb
+++ b/app/views/items/_for_later_list_item_show.html.erb
@@ -4,7 +4,7 @@
       <%= button_to account_for_later_list_item_path(for_later_list_item),
             method: :delete, class: "btn remove-from-save-for-later-button", title: "Remove from save for later list" do %>
         <%= render partial: "shared/icons/bookmark" %>
-        <span class="visually-hidden">Remove from saved for later</span>
+        <span class="visually-hidden">Remove from saved for later list</span>
       <% end %>
     <% else %>
       <%= button_to account_for_later_list_items_path,

--- a/app/views/items/_for_later_list_items_index.html.erb
+++ b/app/views/items/_for_later_list_items_index.html.erb
@@ -1,11 +1,17 @@
 <% if FeatureFlags.for_later_lists_enabled? %>
   <div id="<%= "#{dom_id(item)}_for_later_list_items_index" %>" class="for-later-list-button-container">
     <% if for_later_list_item.present? %>
-      <%= button_to "Remove from saved for later", account_for_later_list_item_path(for_later_list_item),
-            method: :delete, class: "btn btn-sm" %>
+      <%= button_to account_for_later_list_item_path(for_later_list_item),
+            method: :delete, class: "btn btn-sm remove-from-save-for-later-button", title: "Remove from save for later list" do %>
+        <%= render partial: "shared/icons/bookmark" %>
+        <span class="visually-hidden">Remove from saved for later</span>
+      <% end %>
     <% else %>
-      <%= button_to "Save for later", account_for_later_list_items_path,
-            method: :post, class: "btn btn-sm", params: {for_later_list_item: {item_id: item.id}} %>
+      <%= button_to account_for_later_list_items_path,
+            method: :post, class: "btn btn-sm save-for-later-button", title: "Save for later", params: {for_later_list_item: {item_id: item.id}} do %>
+        <%= render partial: "shared/icons/bookmark" %>
+        <span class="visually-hidden">Save for later</span>
+      <% end %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/items/_for_later_list_items_index.html.erb
+++ b/app/views/items/_for_later_list_items_index.html.erb
@@ -4,7 +4,7 @@
       <%= button_to account_for_later_list_item_path(for_later_list_item),
             method: :delete, class: "btn btn-sm remove-from-save-for-later-button", title: "Remove from save for later list" do %>
         <%= render partial: "shared/icons/bookmark" %>
-        <span class="visually-hidden">Remove from saved for later</span>
+        <span class="visually-hidden">Remove from saved for later list</span>
       <% end %>
     <% else %>
       <%= button_to account_for_later_list_items_path,

--- a/app/views/items/_for_later_list_items_index.html.erb
+++ b/app/views/items/_for_later_list_items_index.html.erb
@@ -1,7 +1,7 @@
 <% if FeatureFlags.for_later_lists_enabled? %>
   <div id="<%= "#{dom_id(item)}_for_later_list_items_index" %>" class="for-later-list-button-container">
     <% if for_later_list_item.present? %>
-      <%= button_to "Don't need it", account_for_later_list_item_path(for_later_list_item),
+      <%= button_to "Remove from saved for later", account_for_later_list_item_path(for_later_list_item),
             method: :delete, class: "btn btn-sm" %>
     <% else %>
       <%= button_to "Save for later", account_for_later_list_items_path,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,11 +36,13 @@
         <% end %>
 
         <div class="app-body">
-          <%= flash_message :notice %>
-          <%= flash_message :success %>
-          <%= flash_message :warning %>
-          <%= flash_message :error %>
-          <%= flash_message :alert, "error" %>
+          <div id="flash-message-container">
+            <%= flash_message :notice %>
+            <%= flash_message :success %>
+            <%= flash_message :warning %>
+            <%= flash_message :error %>
+            <%= flash_message :alert, "error" %>
+          </div>
 
           <%= render(partial: "account/membership_renewal_message") if user_signed_in? %>
 

--- a/app/views/shared/icons/_bookmark.html.erb
+++ b/app/views/shared/icons/_bookmark.html.erb
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  class="feather feather-bookmark"
+  aria-hidden="true">
+  <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"></path>
+</svg>

--- a/test/controllers/account/for_later_list_items_controller_test.rb
+++ b/test/controllers/account/for_later_list_items_controller_test.rb
@@ -35,12 +35,12 @@ module Account
 
       assert_turbo_stream(action: "replace", target: "for_later_list_item_show") do |elements|
         assert_includes elements.to_s, "for_later_list_item_show"
-        assert_includes elements.to_s, "Don't need it"
+        assert_includes elements.to_s, "Remove from saved for later"
       end
 
       assert_turbo_stream(action: "replace", target: "#{dom_id(item)}_for_later_list_items_index") do |elements|
         assert_includes elements.to_s, "#{dom_id(item)}_for_later_list_items_index"
-        assert_includes elements.to_s, "Don't need it"
+        assert_includes elements.to_s, "Remove from saved for later"
       end
     end
 

--- a/test/controllers/account/for_later_list_items_controller_test.rb
+++ b/test/controllers/account/for_later_list_items_controller_test.rb
@@ -42,6 +42,11 @@ module Account
         assert_includes elements.to_s, "#{dom_id(item)}_for_later_list_items_index"
         assert_includes elements.to_s, "Remove from saved for later"
       end
+
+      assert_turbo_stream(action: "update", target: "flash-message-container") do |elements|
+        assert_includes elements.to_s, "toast-success"
+        assert_includes elements.to_s, "Successfully saved for later"
+      end
     end
 
     test_with_for_later_list_items_enabled "member can unsave an item for later" do
@@ -72,6 +77,11 @@ module Account
       assert_turbo_stream(action: "replace", target: "#{dom_id(item)}_for_later_list_items_index") do |elements|
         assert_includes elements.to_s, "#{dom_id(item)}_for_later_list_items_index"
         assert_includes elements.to_s, "Save for later"
+      end
+
+      assert_turbo_stream(action: "update", target: "flash-message-container") do |elements|
+        assert_includes elements.to_s, "toast-success"
+        assert_includes elements.to_s, "Successfully removed from saved for later list"
       end
     end
   end

--- a/test/helpers/admin_helper_test.rb
+++ b/test/helpers/admin_helper_test.rb
@@ -1,0 +1,55 @@
+require "test_helper"
+
+class AdminHelperTest < ActionView::TestCase
+  setup do
+  end
+
+  test "flash_message returns nothing when there is no matching flash for the given key" do
+    flash.now[:notice] = "This is a notice."
+
+    result = flash_message(:success)
+
+    assert_nil result
+  end
+
+  test "flash_message returns a closable toast message for the given key" do
+    message = "This is a notice."
+    flash.now[:notice] = message
+
+    result = flash_message(:notice)
+
+    refute_nil result
+    assert_includes result, message
+    assert_includes result, "toast-notice"
+    assert_includes result, "btn-clear"
+  end
+
+  test "flash_message returns a closable toast message for the given key with an overridable type" do
+    message = "This is a notice."
+    flash.now[:notice] = message
+
+    result = flash_message(:notice, :alert)
+
+    refute_nil result
+    assert_includes result, message
+    assert_includes result, "toast-alert"
+    assert_includes result, "btn-clear"
+  end
+
+  test "flash_message_html returns a closable toast message for the given message and flash type" do
+    message = "This is another message."
+    result = flash_message_html(message, :notice)
+
+    refute_nil result
+    assert_includes result, message
+    assert_includes result, "toast-notice"
+    assert_includes result, "btn-clear"
+
+    result = flash_message_html(message, :success)
+
+    refute_nil result
+    assert_includes result, message
+    assert_includes result, "toast-success"
+    assert_includes result, "btn-clear"
+  end
+end

--- a/test/helpers/admin_helper_test.rb
+++ b/test/helpers/admin_helper_test.rb
@@ -1,9 +1,6 @@
 require "test_helper"
 
 class AdminHelperTest < ActionView::TestCase
-  setup do
-  end
-
   test "flash_message returns nothing when there is no matching flash for the given key" do
     flash.now[:notice] = "This is a notice."
 

--- a/test/system/account/for_later_list_items_test.rb
+++ b/test/system/account/for_later_list_items_test.rb
@@ -102,7 +102,7 @@ module Account
       assert_text ignored_for_later_list_item.item.name
 
       within("##{dom_id(for_later_list_item)}") do
-        click_button "Remove from saved for later"
+        click_button "Remove"
       end
 
       refute_text for_later_list_item.item.name

--- a/test/system/account/for_later_list_items_test.rb
+++ b/test/system/account/for_later_list_items_test.rb
@@ -102,7 +102,7 @@ module Account
       assert_text ignored_for_later_list_item.item.name
 
       within("##{dom_id(for_later_list_item)}") do
-        click_button "Remove"
+        accept_confirm { click_button "Remove" }
       end
 
       refute_text for_later_list_item.item.name

--- a/test/system/account/for_later_list_items_test.rb
+++ b/test/system/account/for_later_list_items_test.rb
@@ -35,7 +35,7 @@ module Account
       visit item_path(create(:item))
 
       refute_text "Save for later"
-      refute_text "Don't need it"
+      refute_text "Remove from saved for later"
     end
 
     test_with_for_later_list_items_enabled "members that are not signed in cannot add anything to their for later list on the items index page" do
@@ -44,7 +44,7 @@ module Account
       visit items_path
 
       refute_text "Save for later"
-      refute_text "Don't need it"
+      refute_text "Remove from saved for later"
     end
 
     test_with_for_later_list_items_enabled "members can see that they've previously for later listed an item on the item details page" do
@@ -52,7 +52,7 @@ module Account
 
       visit item_path(for_later_list_item.item)
 
-      assert_text "Don't need it"
+      assert_text "Remove from saved for later"
     end
 
     test_with_for_later_list_items_enabled "members can see that they've previously for later listed an item on the items index page" do
@@ -60,7 +60,7 @@ module Account
 
       visit items_path
 
-      assert_text "Don't need it"
+      assert_text "Remove from saved for later"
     end
 
     test_with_for_later_list_items_enabled "members can add an item to their for later list from the item details page" do
@@ -70,7 +70,7 @@ module Account
 
       assert_difference("@member.for_later_list_items.count", 1) do
         click_button "Save for later"
-        assert_text "Don't need it"
+        assert_text "Remove from saved for later"
       end
 
       for_later_list_item = @member.for_later_list_items.first!
@@ -85,7 +85,7 @@ module Account
 
       assert_difference("@member.for_later_list_items.count", 1) do
         click_button "Save for later"
-        assert_text "Don't need it"
+        assert_text "Remove from saved for later"
       end
 
       for_later_list_item = @member.for_later_list_items.first!
@@ -102,7 +102,7 @@ module Account
       assert_text ignored_for_later_list_item.item.name
 
       within("##{dom_id(for_later_list_item)}") do
-        click_button "Don't need it"
+        click_button "Remove from saved for later"
       end
 
       refute_text for_later_list_item.item.name
@@ -115,7 +115,7 @@ module Account
       visit item_path(for_later_list_item.item)
 
       assert_difference("@member.for_later_list_items.count", -1) do
-        click_button "Don't need it"
+        click_button "Remove from saved for later"
         assert_text "Save for later"
       end
     end
@@ -126,7 +126,7 @@ module Account
       visit items_path
 
       assert_difference("@member.for_later_list_items.count", -1) do
-        click_button "Don't need it"
+        click_button "Remove from saved for later"
         assert_text "Save for later"
       end
     end


### PR DESCRIPTION
# What it does

Replaces the old save for later buttons' text with styled bookmark icons and html `title` attributes for information on hover.

# Why it is important

Makes things a little easier on the eyes and more compact.

# UI Change Screenshot

Items index with saved and not saved items:
<img width="789" height="513" alt="Screenshot 2026-05-17 at 3 58 17 PM" src="https://github.com/user-attachments/assets/8739e474-951f-4892-b175-6c721db54a67" />

Saved for items index:
<img width="1036" height="601" alt="Screenshot 2026-05-17 at 3 58 29 PM" src="https://github.com/user-attachments/assets/dfe73495-a133-485c-8487-884b719c50d5" />

Saved for later item show:
<img width="998" height="488" alt="Screenshot 2026-05-17 at 3 58 04 PM" src="https://github.com/user-attachments/assets/79f4fddc-7851-4992-86fd-688d49192c1e" />

Not saved for later item show:
<img width="1011" height="424" alt="Screenshot 2026-05-17 at 3 57 58 PM" src="https://github.com/user-attachments/assets/426edad1-741d-4d52-aa77-6d13715bd928" />

## New flash messages

Unsaving an item on the index page:
<img width="1014" height="633" alt="Screenshot 2026-05-30 at 3 35 12 PM" src="https://github.com/user-attachments/assets/88de6867-05a8-48c1-b127-378e30840f33" />

Saving an item on the index page:
<img width="1045" height="649" alt="Screenshot 2026-05-30 at 3 35 26 PM" src="https://github.com/user-attachments/assets/fce49c39-e753-402d-9a52-69b32710eb47" />

Removing an item from the saved for later page:
<img width="997" height="406" alt="Screenshot 2026-05-30 at 3 35 51 PM" src="https://github.com/user-attachments/assets/a3cd73f8-5b9d-4225-82ae-244b15aeb10b" />

# Implementation notes

I added an svg as a partial which is possibly a little weird, but it made it much easier to style. Also, I had to add the svg in the first place because the feather icon for bookmark as Circulate is set up now is some tricky css with borders.
