### PR TITLE
Fix NoMethodError and param dropping on items index when category lookup fails

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,12 +5,11 @@ class ItemsController < ApplicationController
     item_scope = Item.listed_publicly.includes(:borrow_policy, :active_holds, :checked_out_exclusive_loan, :categories)
 
     item_scope = filter_by_category(item_scope) if filter_params[:category].present?
+    return if performed?
+
     item_scope = filter_by_query(item_scope) if filter_params[:query].present?
     item_scope = filter_by_available(item_scope) if filter_params[:available].present?
     item_scope = filter_by_staff_approval_required(item_scope) if filter_params[:staff_approval_required].present?
-
-    # One of the filtering methods above may have already redirected
-    return if performed?
 
     item_scope = apply_order(item_scope.with_attached_image)
 
@@ -102,14 +101,7 @@ class ItemsController < ApplicationController
   end
 
   def filter_failed(failed_param, error_message)
-    filter_params = %i[sort category query].each_with_object({}) do |filter_param, accepted_params|
-      next if filter_param == failed_param
-      next if params[:filter_param].blank?
-
-      accepted_params[filter_param] = params[filter_param]
-    end
-
-    redirect_to items_path(filter_params), error: error_message, status: :see_other
+    redirect_to items_path(filter_params.except(failed_param)), error: error_message, status: :see_other
   end
 
   def apply_order(query)

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -27,6 +27,16 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     get items_url(category: 999999)
 
     assert_response :redirect
+    assert_redirected_to items_path
+  end
+
+  test "attempting to view a category that doesn't exist with other filters preserves them on redirect" do
+    get items_url(category: 999999, query: "hammer", staff_approval_required: "true", sort: "name")
+
+    assert_response :redirect
+    assert_redirected_to items_path(query: "hammer", staff_approval_required: "true", sort: "name")
+    follow_redirect!
+    assert_response :success
   end
 
   test "only shows one of a given item regardless of how many categories it is in" do


### PR DESCRIPTION
# What it does

Two fixes in `ItemsController` that together address [AppSignal incident #209](https://appsignal.com/chicago-tool-library/sites/60596f9214ad662e17191689/exceptions/incidents/209) (`NoMethodError ... for an instance of Integer`), which has been open since January 2022 and is still firing.

1. Move the `return if performed?` guard so it runs immediately after the only filter that can redirect (`filter_by_category`) instead of after the whole filter chain.
2. Rewrite `filter_failed` to use `filter_params.except(failed_param)` for the redirect URL.

# Why it is important

The 500s are 100% bot traffic. I sampled 29 distinct error traces and every single one targets the same dead `category=42` URL (`?category=42&query=Paper cutter` and a couple of close variants). Probably an old sitemap or someone's archived URL pool. So no real users are affected, but the code is genuinely broken in two ways:

- `filter_by_category` redirects when the category isn't found. In Rails 8, `redirect_to ..., status: :see_other` returns the status integer (303). That integer was being assigned to `item_scope`, and the next filter would call `.search_and_order_by_availability` (or `.where`) on `303` and explode. The pre-existing `return if performed?` guard sat below all four filter calls, so it never got a chance to fire.
- While in there I noticed `filter_failed` had a typo. `next if params[:filter_param].blank?` used the literal symbol `:filter_param` instead of the loop variable, so the conditional always fired and **every** filter got dropped from the redirect URL, not just the failing one. The hand-rolled allowlist was also stale (`%i[sort category query]` predates `available` and `staff_approval_required`). Switching to `filter_params.except(failed_param)` reuses the controller's existing source of truth.

# UI Change Screenshot

N/A, no UI change.

# Implementation notes

The first new test reproduces the original NoMethodError on `main`; the second asserts that valid filter params survive the redirect, which catches the `filter_failed` typo and the stale allowlist together.

A couple of choices worth flagging:

- I considered adding `return if performed?` after every filter call rather than just after `filter_by_category`. Decided against it: only `filter_by_category` can redirect today, and parallel guards would be easy to drift out of sync.
- I considered leaving the `filter_failed` typo for a follow-up. Decided to fold it in: same code path, the two bugs were hiding each other (you don't notice the dropped params if the request 500s first), and the refactored version is shorter than the buggy original.
