### PR TITLE
Reuse stale approval rows on re-request

### DIFF
--- a/app/controllers/account/borrow_policy_approvals_controller.rb
+++ b/app/controllers/account/borrow_policy_approvals_controller.rb
@@ -5,7 +5,9 @@ module Account
       result = BorrowPolicyAuthorizer.check(borrow_policy:, member: current_member)
 
       if result.can_request?
-        BorrowPolicyApproval.create!(borrow_policy:, member: current_user.member)
+        approval = result.borrow_policy_approval || BorrowPolicyApproval.new(borrow_policy:, member: current_member)
+        approval.status = "requested"
+        approval.save!
 
         redirect_to request.referrer.presence || root_path, status: :see_other, success: "Approval requested."
       else

--- a/test/controllers/account/borrow_policy_approvals_controller_test.rb
+++ b/test/controllers/account/borrow_policy_approvals_controller_test.rb
@@ -36,6 +36,18 @@ module Account
       assert flash[:error].present?
     end
 
+    test "reuses an old rejected approval when re-requesting after the cooldown" do
+      approval = create(:borrow_policy_approval, :rejected, borrow_policy: @borrow_policy, member: @member, updated_at: 3.months.ago)
+
+      assert_difference("BorrowPolicyApproval.count", 0) do
+        post account_borrow_policy_approvals_url, params: {item_id: @item.id, borrow_policy_id: @borrow_policy.id}
+      end
+
+      assert_equal "requested", approval.reload.status
+      assert flash[:success].present?
+      assert flash[:error].blank?
+    end
+
     test "does not create borrow policy approval when the member is new" do
       @member.update!(created_at: 1.day.ago)
 


### PR DESCRIPTION
# What it does

Fixes [AppSignal incident #3300](https://appsignal.com/chicago-tool-library/sites/60596f9214ad662e17191689/exceptions/incidents/3300) (`ActiveRecord::RecordInvalid: Validation failed: Borrow policy has already been taken`), 64 occurrences over the last few months. When a member re-requests approval after their previous request was rejected or revoked, reuse the existing `BorrowPolicyApproval` row instead of trying to create a duplicate.

# Why it is important

Unlike a lot of our AppSignal noise, this one's hitting real members. `BorrowPolicyAuthorizer` is explicit that a member can re-request approval if their prior request was rejected or revoked more than two months ago (the `approval_recently_updated?` gate at `app/lib/borrow_policy_authorizer.rb:15-16`). But the controller was calling `BorrowPolicyApproval.create!`, which trips the uniqueness validation on `(borrow_policy_id, member_id)`. So the authorizer says "yes, your cooldown is up, request again," and Rails immediately turns around and 500s on the save. The member sees an error page instead of a fresh request.

# UI Change Screenshot

N/A, no UI change.

# Implementation notes

The authorizer's `Result` struct already carries the existing approval (or nil), so the fix reuses that record rather than doing a second `find_by`:

```ruby
approval = result.borrow_policy_approval || BorrowPolicyApproval.new(borrow_policy:, member: current_member)
approval.status = "requested"
approval.save!
```

A few choices worth flagging:

- Considered `find_or_create_by` / `create_or_find_by`, but neither lets you update the existing row's status, which is the whole point in the re-request case.
- The new test sets `updated_at: 3.months.ago` on the seed record so it falls outside the two-month cooldown window. The other two existing tests (first-time creation, blocked-because-already-pending) still pass unmodified, so the green-field path is still covered.
- Also switched `current_user.member` to `current_member` on the create line, just to match the helper used elsewhere in the controller. `Account::BaseController` already guarantees it's non-nil via `require_member`.