### PR TITLE
Sign out orphan Users hitting the account guard

### DIFF
--- a/app/controllers/account/base_controller.rb
+++ b/app/controllers/account/base_controller.rb
@@ -29,6 +29,7 @@ module Account
         )
       end
 
+      sign_out current_user
       redirect_to root_path, alert: "There's a problem with your account. Please contact the library for assistance."
     end
   end

--- a/test/controllers/account/home_controller_test.rb
+++ b/test/controllers/account/home_controller_test.rb
@@ -38,6 +38,17 @@ module Account
       assert_select "a.btn-default", "Renew Membership"
     end
 
+    test "signs out and redirects when a user has no member record" do
+      orphan = create(:member_user)
+      sign_in orphan
+
+      get account_home_url
+
+      assert_redirected_to root_path
+      assert_match(/problem with your account/i, flash[:alert])
+      assert_nil controller.current_user, "expected the orphan user to be signed out"
+    end
+
     test "shows updates on the home page" do
       create(:library_update, published: true, body: "some good news")
       create(:library_update, published: false, body: "some old news")


### PR DESCRIPTION
# What it does

Sign the current user out inside `Account::BaseController#require_member` before the redirect to root. Adds a test for the orphan-User path.

# Why it is important

[AppSignal incident #3316](https://appsignal.com/chicago-tool-library/sites/60596f9214ad662e17191689/exceptions/incidents/3316) has been firing 234 times in the last two months: `RuntimeError: User without member record accessed account area`. The guard itself is intentional, but it left the session intact, so the broken state retriggered every time the user touched `/account` again. In a recent sample one user hit it 30 times in a single minute.

The underlying data problem is bounded: a poke at production turned up 15 orphan member-role Users, only one actively signing in. The creation-side fix (#2069) and the destruction-side fix (#2124) have both shipped, so no new orphans are being produced. Signing the orphans out breaks the loop. They see the same "there's a problem with your account" message, they just don't get stuck in a session that keeps tripping it. A separate cleanup of the historical rows will follow.

# Implementation notes

- Devise's `sign_out` resets the session, but the subsequent `redirect_to ..., alert: ...` writes a fresh flash, so the user still sees the explanatory message.
- AppSignal still gets the `report_error` call with `user_id`/`email`/`role`, so if a new orphan ever appears we'll see it — we just won't see it 30 times per minute from the same person.