### PR TITLE
Stop expired holds from masquerading as checkouts on appointments

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -6,9 +6,16 @@ class Appointment < ApplicationRecord
 
   belongs_to :member
 
+  # Backstop window for holds whose items have been pulled but not yet checked
+  # out. Matches the default hold duration so a pulled item is held for the
+  # member roughly as long as a fresh hold would be.
+  HOLD_PULL_EXPIRY_BACKSTOP = Hold::DEFAULT_HOLD_DURATION.days
+
   validate :ends_at_later_than_starts_at, :date_present
   validate :starts_before_holds_expire, if: :member_updating
   validate :item_present, unless: :staff_updating
+
+  after_update :protect_pulled_holds_from_expiring, if: :saved_change_to_pulled_at?
 
   scope :upcoming, -> { where("starts_at > ?", Time.zone.now).order(:starts_at) }
   scope :today_or_later, -> { where("starts_at > ?", Time.zone.now.beginning_of_day).order(:starts_at) }
@@ -55,6 +62,25 @@ class Appointment < ApplicationRecord
   end
 
   private
+
+  # When staff pull the items for an appointment, the member's holds should not
+  # keep ticking down on their own clock while the items sit off the shelf
+  # waiting to be checked out (issue #2181). Otherwise a missed "Check-out"
+  # click can silently expire a hold mid-appointment, flipping the item back to
+  # "available" and bouncing the member out of line. We push expiry out to a
+  # backstop, only ever extending (never shortening), and leave un-pulled
+  # appointments alone.
+  def protect_pulled_holds_from_expiring
+    return if pulled_at.nil?
+
+    backstop = (pulled_at + HOLD_PULL_EXPIRY_BACKSTOP).end_of_day
+    holds.each do |hold|
+      next unless hold.started? && !hold.ended?
+      next if hold.expires_at && hold.expires_at >= backstop
+
+      hold.update_column(:expires_at, backstop)
+    end
+  end
 
   def no_items?
     holds.empty? && loans.empty?

--- a/app/views/admin/appointments/_checkouts.html.erb
+++ b/app/views/admin/appointments/_checkouts.html.erb
@@ -7,12 +7,12 @@
       <%#= button_to "Check-out All", admin_appointment_checkouts_path(@appointment, hold_ids: appointment_pickup_items.active.pluck(:id)), class: "btn btn-primary", data: { disable_with: "Checking-out...", turbo_confirm: "Are you sure you want to check-out all items?" }, disabled: !appointment_pickup_items.active.exists? || !member.borrow? %>
     </div>
   </div>
-  <% appointment_pickup_items.each do |loan| %>
+  <% appointment_pickup_items.each do |hold| %>
     <div class="columns mt-2 mb-2">
       <div class="column col-sm-6 col-4">
         <%= tag.div class: "item-image" do %>
-          <% if loan.item.image.attached? %>
-            <%= image_tag item_image_url(loan.item.image, resize_to_limit: [160, 112]) %>
+          <% if hold.item.image.attached? %>
+            <%= image_tag item_image_url(hold.item.image, resize_to_limit: [160, 112]) %>
           <% else %>
             <div class="image-placeholder"></div>
           <% end %>
@@ -20,13 +20,13 @@
         <div class="divider"></div>
       </div>
       <div class="column col-sm-6 col-4">
-        <p><%= loan.item.name %></p>
-        <p><%= link_to full_item_number(loan.item), admin_item_path(loan.item) %></p>
+        <p><%= hold.item.name %></p>
+        <p><%= link_to full_item_number(hold.item), admin_item_path(hold.item) %></p>
       </div>
       <div class="column col-sm-12 col-4 text-right checkout-button-column" data-controller="confirm-item-accessories">
-        <% if loan.item.accessories? && loan.active? %>
+        <% if hold.item.accessories? && hold.active? %>
           <ul class="simple-list of-accessories">
-            <% loan.item.accessories.each do |accessory| %>
+            <% hold.item.accessories.each do |accessory| %>
               <li>
                 <%= label_tag accessory, accessory %>
                 <%= checkbox_tag accessory, data: {:action => "confirm-item-accessories#handleCheck", "confirm-item-accessories-target" => "accessory"} %>
@@ -34,15 +34,15 @@
             <% end %>
           </ul>
         <% end %>
-        <%= button_to "Check-out", admin_appointment_checkouts_path(@appointment, hold_ids: [loan.id]),
-              id: "checkout-#{loan.id}",
+        <%= button_to "Check-out", admin_appointment_checkouts_path(@appointment, hold_ids: [hold.id]),
+              id: "checkout-#{hold.id}",
               class: "btn btn-primary btn-sm",
               data: {:disable_with => "Checking-out...", "confirm-item-accessories-target" => "button"},
-              disabled: !loan.active? || !member.borrow? || loan.item.accessories? %>
+              disabled: !hold.active? || !member.borrow? || hold.item.accessories? %>
         <div class="checkout-button-group">
-          <% if loan.active? %>
+          <% if hold.active? %>
             <%= button_to "Cancel Hold",
-                  admin_appointment_hold_path(@appointment, loan), {
+                  admin_appointment_hold_path(@appointment, hold), {
                     params: {cancel_hold: true},
                       method: :delete,
                       class: "btn btn-sm mt-2 float-right",
@@ -52,7 +52,7 @@
                       }
                   } %>
             <%= button_to "Remove Item",
-                  admin_appointment_hold_path(@appointment, loan), {
+                  admin_appointment_hold_path(@appointment, hold), {
                     params: {cancel_hold: false},
                       method: :delete,
                       class: "btn btn-sm mt-2 float-right",
@@ -61,19 +61,24 @@
                         turbo_confirm: "Are you sure you want to remove this item from the appointment?"
                       }
                   } %>
-          <% end %>
-          <% if !loan.active? %>
-            <em>Item checked-out</em>
+          <% else %>
+            <% if hold.loan.present? %>
+              <em>Item checked-out</em>
+            <% elsif hold.expired? %>
+              <em>Hold expired without pickup</em>
+            <% else %>
+              <em>Hold ended without checkout</em>
+            <% end %>
           <% end %>
         </div>
       </div>
     </div>
-    <% if loan.item.checkout_notice? %>
+    <% if hold.item.checkout_notice? %>
       <div>
         <div class="info-box">
           <p>
             <strong>Checkout Notice:</strong><br>
-            <%= loan.item.checkout_notice %>
+            <%= hold.item.checkout_notice %>
           </p>
         </div>
       </div>

--- a/test/controllers/admin/appointments_controller_test.rb
+++ b/test/controllers/admin/appointments_controller_test.rb
@@ -46,5 +46,27 @@ module Admin
         get admin_appointment_path(@appointment)
       end
     end
+
+    test "labels a hold that timed out as expired, not checked-out" do
+      appointment = build(:appointment, member: @member)
+      appointment.holds << create(:hold, :expired, member: @member)
+      appointment.save!
+
+      get admin_appointment_path(appointment)
+
+      assert_select "em", text: "Hold expired without pickup"
+      assert_select "em", text: "Item checked-out", count: 0
+    end
+
+    test "labels a hold that was actually picked up as checked-out" do
+      appointment = build(:appointment, member: @member)
+      loan = create(:loan, member: @member)
+      appointment.holds << create(:hold, :ended, member: @member, loan: loan)
+      appointment.save!
+
+      get admin_appointment_path(appointment)
+
+      assert_select "em", text: "Item checked-out"
+    end
   end
 end

--- a/test/models/appointment_test.rb
+++ b/test/models/appointment_test.rb
@@ -140,4 +140,38 @@ class AppointmentTest < ActiveSupport::TestCase
 
     refute appointment.dropoff_only?
   end
+
+  test "pulling an appointment protects attached holds from expiring on their own clock" do
+    member = create(:member, :with_user)
+    hold = create(:hold, member: member, creator: member.user, started_at: Time.current, expires_at: 1.day.from_now)
+    appointment = create(:appointment, member: member, holds: [hold])
+
+    appointment.update!(pulled_at: Time.current, staff_updating: true)
+
+    expected = (appointment.pulled_at + Appointment::HOLD_PULL_EXPIRY_BACKSTOP).end_of_day
+    assert_equal expected.to_i, hold.reload.expires_at.to_i
+  end
+
+  test "pulling never shortens a hold that already expires after the backstop" do
+    member = create(:member, :with_user)
+    far_future = 30.days.from_now
+    hold = create(:hold, member: member, creator: member.user, started_at: Time.current, expires_at: far_future)
+    appointment = create(:appointment, member: member, holds: [hold])
+
+    appointment.update!(pulled_at: Time.current, staff_updating: true)
+
+    assert_equal far_future.to_i, hold.reload.expires_at.to_i
+  end
+
+  test "un-pulling an appointment leaves the already-extended hold expiry untouched" do
+    member = create(:member, :with_user)
+    hold = create(:hold, member: member, creator: member.user, started_at: Time.current, expires_at: 1.day.from_now)
+    appointment = create(:appointment, member: member, holds: [hold])
+    appointment.update!(pulled_at: Time.current, staff_updating: true)
+    extended = hold.reload.expires_at
+
+    appointment.update!(pulled_at: nil, staff_updating: true)
+
+    assert_equal extended.to_i, hold.reload.expires_at.to_i
+  end
 end


### PR DESCRIPTION
# What it does

Two related fixes to how the appointment workflow handles holds.

The first untangles a misleading label on the admin appointment page. The checkout panel showed "Item checked-out" for any hold that wasn't active, but a hold goes inactive both when it's genuinely picked up and when it simply times out. So a hold that expired without anyone picking it up looked exactly like a completed checkout. The panel now tells the three states apart: picked up ("Item checked-out"), expired without pickup ("Hold expired without pickup"), and the rare ended-without-checkout case. The loop variable, confusingly named `loan` despite always being a Hold, is renamed to `hold`.

The second stops a hold from expiring out from under an in-progress appointment. A hold's expiry runs on its own clock, so if staff pull an item for an appointment and the "Check-out" click gets missed, the hold can expire that same night, the item quietly flips back to available, and the member loses their place in line. Pulling an appointment now pushes its attached holds' expiry out to a backstop so they can't die while the item is off the shelf waiting to be checked out.

# Why it is important

These two bugs compound into the "items wandering off member accounts" reports staff have been hitting. An item gets pulled for an appointment, the checkout never gets clicked, the hold expires that night, and when staff go back to investigate why the item isn't on the member's account, the appointment page cheerfully reports "Item checked-out" even though nothing ever was. The member looks like they're holding an item the system has no loan for, while the item is simultaneously back on the shelf for someone else to grab.

Fixes #2180 and #2181. (#2182 and #2183 are left as follow-ups.)

# UI Change Screenshot

Text-only change on the appointment checkout panel. For a hold that timed out, the label changes:

- Before: *Item checked-out*
- After: *Hold expired without pickup*

# Implementation notes

For #2181 I extended `expires_at` on the hold rather than teaching the `active`/`expired` SQL scopes about appointment state, so `start_waiting_holds` and item-availability queries keep working unchanged. Two decisions worth a look:

- The backstop is the default hold duration (7 days) measured from `pulled_at`, the candidate #2181 floated. We only ever extend, never shorten.
- Un-pulling an appointment does not restore the original pre-pull expiry. Restoring would need somewhere to stash the old value, which felt heavier than this fix warrants. It's documented in the code and pinned by a test, easy to revisit.

`start_waiting_holds` is untouched on purpose: it only acts on waiting holds (no `started_at`), and we only extend already-started ones. Currently-in-flight pulled appointments are not backfilled; that feels like #2182 territory.
