### PR TITLE
Surface unfinished appointments so dropped items get caught

### DIFF
--- a/app/controllers/admin/appointments_controller.rb
+++ b/app/controllers/admin/appointments_controller.rb
@@ -10,6 +10,8 @@ module Admin
         .chronologically
         .includes(:member, loans: {item: :borrow_policy}, holds: {item: :borrow_policy})
 
+      @unfinished_appointments_count = Appointment.unfinished.count
+
       @pending_appointments = []
       @pulled_appointments = []
       @completed_appointments = []

--- a/app/controllers/admin/reports/unfinished_appointments_controller.rb
+++ b/app/controllers/admin/reports/unfinished_appointments_controller.rb
@@ -1,0 +1,22 @@
+module Admin
+  module Reports
+    class UnfinishedAppointmentsController < BaseController
+      def index
+        @appointments = Appointment.unfinished
+          .chronologically
+          .includes(:member, holds: :item)
+      end
+
+      # Resolve a row straight from the worklist: mark the appointment complete
+      # so it drops off the list. Reversible from the appointment page if needed.
+      def complete
+        appointment = Appointment.find(params[:id])
+        appointment.update!(completed_at: Time.current, staff_updating: true)
+
+        redirect_to admin_reports_unfinished_appointments_path,
+          status: :see_other,
+          flash: {success: "Appointment marked complete."}
+      end
+    end
+  end
+end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -6,9 +6,16 @@ class Appointment < ApplicationRecord
 
   belongs_to :member
 
+  # Backstop window for holds whose items have been pulled but not yet checked
+  # out. Matches the default hold duration so a pulled item is held for the
+  # member roughly as long as a fresh hold would be.
+  HOLD_PULL_EXPIRY_BACKSTOP = Hold::DEFAULT_HOLD_DURATION.days
+
   validate :ends_at_later_than_starts_at, :date_present
   validate :starts_before_holds_expire, if: :member_updating
   validate :item_present, unless: :staff_updating
+
+  after_update :protect_pulled_holds_from_expiring, if: :saved_change_to_pulled_at?
 
   scope :upcoming, -> { where("starts_at > ?", Time.zone.now).order(:starts_at) }
   scope :today_or_later, -> { where("starts_at > ?", Time.zone.now.beginning_of_day).order(:starts_at) }
@@ -55,6 +62,25 @@ class Appointment < ApplicationRecord
   end
 
   private
+
+  # When staff pull the items for an appointment, the member's holds should not
+  # keep ticking down on their own clock while the items sit off the shelf
+  # waiting to be checked out (issue #2181). Otherwise a missed "Check-out"
+  # click can silently expire a hold mid-appointment, flipping the item back to
+  # "available" and bouncing the member out of line. We push expiry out to a
+  # backstop, only ever extending (never shortening), and leave un-pulled
+  # appointments alone.
+  def protect_pulled_holds_from_expiring
+    return if pulled_at.nil?
+
+    backstop = (pulled_at + HOLD_PULL_EXPIRY_BACKSTOP).end_of_day
+    holds.each do |hold|
+      next unless hold.started? && !hold.ended?
+      next if hold.expires_at && hold.expires_at >= backstop
+
+      hold.update_column(:expires_at, backstop)
+    end
+  end
 
   def no_items?
     holds.empty? && loans.empty?

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -23,6 +23,31 @@ class Appointment < ApplicationRecord
   scope :chronologically, -> { order("starts_at ASC") }
   scope :simultaneous, ->(appointment) { where(starts_at: appointment.starts_at, ends_at: appointment.ends_at).where.not(id: appointment.id) }
   scope :not_pulled, -> { where(pulled_at: nil) }
+  scope :pulled, -> { where.not(pulled_at: nil) }
+  scope :not_completed, -> { where(completed_at: nil) }
+
+  # How far back the "unfinished appointments" report looks. Anything older is
+  # almost always a stale record whose item has long since circulated to other
+  # borrowers (an expired hold is a fine terminal state on its own), so we don't
+  # nag staff about it.
+  UNFINISHED_WINDOW = 30.days
+
+  # Appointments from the last UNFINISHED_WINDOW that were pulled, never marked
+  # complete, and still have at least one held item that was neither checked out
+  # nor explicitly ended (cancelled / retired). These are where an item came off
+  # the shelf for a member and nobody closed the loop (#2182). What's unresolved
+  # is the appointment itself, which is why we key on completion rather than on
+  # the hold's own clock.
+  scope :unfinished, ->(now = Time.current) {
+    pulled
+      .not_completed
+      .where(starts_at: (now - UNFINISHED_WINDOW).beginning_of_day...now.beginning_of_day)
+      .where(id: AppointmentHold.where(hold: Hold.where(loan_id: nil, ended_at: nil)).select(:appointment_id))
+  }
+
+  def self.unfinished_window_days
+    (UNFINISHED_WINDOW / 1.day).to_i
+  end
 
   attr_accessor :member_updating, :staff_updating
 
@@ -42,6 +67,11 @@ class Appointment < ApplicationRecord
 
   def completed?
     completed_at.present?
+  end
+
+  # Held items on this appointment that never became a loan.
+  def holds_not_checked_out
+    holds.select { |hold| hold.loan_id.nil? }
   end
 
   def dropoff_only?

--- a/app/views/admin/appointments/_checkouts.html.erb
+++ b/app/views/admin/appointments/_checkouts.html.erb
@@ -7,12 +7,12 @@
       <%#= button_to "Check-out All", admin_appointment_checkouts_path(@appointment, hold_ids: appointment_pickup_items.active.pluck(:id)), class: "btn btn-primary", data: { disable_with: "Checking-out...", turbo_confirm: "Are you sure you want to check-out all items?" }, disabled: !appointment_pickup_items.active.exists? || !member.borrow? %>
     </div>
   </div>
-  <% appointment_pickup_items.each do |loan| %>
+  <% appointment_pickup_items.each do |hold| %>
     <div class="columns mt-2 mb-2">
       <div class="column col-sm-6 col-4">
         <%= tag.div class: "item-image" do %>
-          <% if loan.item.image.attached? %>
-            <%= image_tag item_image_url(loan.item.image, resize_to_limit: [160, 112]) %>
+          <% if hold.item.image.attached? %>
+            <%= image_tag item_image_url(hold.item.image, resize_to_limit: [160, 112]) %>
           <% else %>
             <div class="image-placeholder"></div>
           <% end %>
@@ -20,13 +20,13 @@
         <div class="divider"></div>
       </div>
       <div class="column col-sm-6 col-4">
-        <p><%= loan.item.name %></p>
-        <p><%= link_to full_item_number(loan.item), admin_item_path(loan.item) %></p>
+        <p><%= hold.item.name %></p>
+        <p><%= link_to full_item_number(hold.item), admin_item_path(hold.item) %></p>
       </div>
       <div class="column col-sm-12 col-4 text-right checkout-button-column" data-controller="confirm-item-accessories">
-        <% if loan.item.accessories? && loan.active? %>
+        <% if hold.item.accessories? && hold.active? %>
           <ul class="simple-list of-accessories">
-            <% loan.item.accessories.each do |accessory| %>
+            <% hold.item.accessories.each do |accessory| %>
               <li>
                 <%= label_tag accessory, accessory %>
                 <%= checkbox_tag accessory, data: {:action => "confirm-item-accessories#handleCheck", "confirm-item-accessories-target" => "accessory"} %>
@@ -34,15 +34,15 @@
             <% end %>
           </ul>
         <% end %>
-        <%= button_to "Check-out", admin_appointment_checkouts_path(@appointment, hold_ids: [loan.id]),
-              id: "checkout-#{loan.id}",
+        <%= button_to "Check-out", admin_appointment_checkouts_path(@appointment, hold_ids: [hold.id]),
+              id: "checkout-#{hold.id}",
               class: "btn btn-primary btn-sm",
               data: {:disable_with => "Checking-out...", "confirm-item-accessories-target" => "button"},
-              disabled: !loan.active? || !member.borrow? || loan.item.accessories? %>
+              disabled: !hold.active? || !member.borrow? || hold.item.accessories? %>
         <div class="checkout-button-group">
-          <% if loan.active? %>
+          <% if hold.active? %>
             <%= button_to "Cancel Hold",
-                  admin_appointment_hold_path(@appointment, loan), {
+                  admin_appointment_hold_path(@appointment, hold), {
                     params: {cancel_hold: true},
                       method: :delete,
                       class: "btn btn-sm mt-2 float-right",
@@ -52,7 +52,7 @@
                       }
                   } %>
             <%= button_to "Remove Item",
-                  admin_appointment_hold_path(@appointment, loan), {
+                  admin_appointment_hold_path(@appointment, hold), {
                     params: {cancel_hold: false},
                       method: :delete,
                       class: "btn btn-sm mt-2 float-right",
@@ -61,19 +61,24 @@
                         turbo_confirm: "Are you sure you want to remove this item from the appointment?"
                       }
                   } %>
-          <% end %>
-          <% if !loan.active? %>
-            <em>Item checked-out</em>
+          <% else %>
+            <% if hold.loan.present? %>
+              <em>Item checked-out</em>
+            <% elsif hold.expired? %>
+              <em>Hold expired without pickup</em>
+            <% else %>
+              <em>Hold ended without checkout</em>
+            <% end %>
           <% end %>
         </div>
       </div>
     </div>
-    <% if loan.item.checkout_notice? %>
+    <% if hold.item.checkout_notice? %>
       <div>
         <div class="info-box">
           <p>
             <strong>Checkout Notice:</strong><br>
-            <%= loan.item.checkout_notice %>
+            <%= hold.item.checkout_notice %>
           </p>
         </div>
       </div>

--- a/app/views/admin/appointments/_unfinished_banner.html.erb
+++ b/app/views/admin/appointments/_unfinished_banner.html.erb
@@ -1,0 +1,9 @@
+<% if @unfinished_appointments_count.to_i > 0 %>
+  <div class="toast toast-warning mb-2">
+    <%= link_to "Review", admin_reports_unfinished_appointments_path, class: "btn btn-sm float-right" %>
+    <%= pluralize(@unfinished_appointments_count, "appointment") %> from the last
+    <%= pluralize(Appointment.unfinished_window_days, "day") %>
+    <%= (@unfinished_appointments_count == 1) ? "was" : "were" %> pulled but never completed,
+    with items that were never checked out.
+  </div>
+<% end %>

--- a/app/views/admin/appointments/index.html.erb
+++ b/app/views/admin/appointments/index.html.erb
@@ -2,6 +2,8 @@
   <%= index_header "Scheduled Appointments" %>
 <% end %>
 
+<%= render "unfinished_banner" %>
+
 <div class="columns">
   <div class="col-12 admin-appointments">
     <ul class="pagination">

--- a/app/views/admin/appointments/index_orig.html.erb
+++ b/app/views/admin/appointments/index_orig.html.erb
@@ -2,6 +2,8 @@
   <%= index_header "Scheduled Appointments" %>
 <% end %>
 
+<%= render "unfinished_banner" %>
+
 <div class="columns">
   <div class="col-12 admin-appointments-orig">
     <ul class="pagination">

--- a/app/views/admin/reports/unfinished_appointments/index.html.erb
+++ b/app/views/admin/reports/unfinished_appointments/index.html.erb
@@ -1,0 +1,56 @@
+<%= content_for :header do %>
+  <%= index_header "Unfinished Appointments" %>
+<% end %>
+
+<div class="columns">
+  <div class="column col-12">
+    <p class="text-gray">
+      Appointments from the last <%= pluralize(Appointment.unfinished_window_days, "day") %>
+      that were pulled but never marked complete, where at least one held item was
+      never checked out. Older appointments aren't shown here, since their items have
+      almost always circulated on to other borrowers by now.
+    </p>
+    <p class="text-gray">
+      Use the appointment or member links to figure out what happened to an item, then
+      <strong>Mark complete</strong> to clear the row. (You can undo that from the
+      appointment page if you need to.)
+    </p>
+
+    <% if @appointments.empty? %>
+      <%= empty_state "No unfinished appointments. Nice and tidy." %>
+    <% else %>
+      <table class="table">
+        <tr>
+          <th>Appointment</th>
+          <th>Member</th>
+          <th>Items not checked out</th>
+          <th></th>
+        </tr>
+        <% @appointments.each do |appointment| %>
+          <tr>
+            <td>
+              <%= link_to l(appointment.starts_at, format: :date), admin_appointment_path(appointment) %>
+            </td>
+            <td>
+              <%= link_to preferred_or_default_name(appointment.member), admin_member_path(appointment.member) %>
+            </td>
+            <td>
+              <ul class="simple-list">
+                <% appointment.holds_not_checked_out.each do |hold| %>
+                  <li>
+                    <%= link_to "#{hold.item.name} (#{full_item_number(hold.item)})", admin_item_path(hold.item) %>
+                  </li>
+                <% end %>
+              </ul>
+            </td>
+            <td class="text-right">
+              <%= button_to "Mark complete", complete_admin_reports_unfinished_appointment_path(appointment),
+                    method: :post, class: "btn btn-sm",
+                    data: {turbo_submits_with: "Marking complete..."} %>
+            </td>
+          </tr>
+        <% end %>
+      </table>
+    <% end %>
+  </div>
+</div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -59,6 +59,7 @@
               <li class="nav-item"><%= link_to "Activity", admin_reports_monthly_activities_path %></li>
               <li class="nav-item"><%= link_to "Member Requests", admin_reports_member_requests_path %></li>
               <li class="nav-item"><%= link_to "Members with Overdue Loans", admin_reports_members_with_overdue_loans_path %></li>
+              <li class="nav-item"><%= link_to "Unfinished Appointments", admin_reports_unfinished_appointments_path %></li>
               <li class="nav-item"><%= link_to "Memberships", admin_reports_memberships_path %></li>
               <li class="nav-item"><%= link_to "Money", admin_reports_money_path %></li>
               <li class="nav-item"><%= link_to "Notifications", admin_reports_notifications_path %></li>
@@ -166,6 +167,7 @@
                 <li class="menu-item"><%= link_to "Activity", admin_reports_monthly_activities_path %></li>
                 <li class="menu-item"><%= link_to "Member Requests", admin_reports_member_requests_path %></li>
                 <li class="menu-item"><%= link_to "Members with Overdue Loans", admin_reports_members_with_overdue_loans_path %></li>
+                <li class="menu-item"><%= link_to "Unfinished Appointments", admin_reports_unfinished_appointments_path %></li>
                 <li class="menu-item"><%= link_to "Memberships", admin_reports_memberships_path %></li>
                 <li class="menu-item"><%= link_to "Money", admin_reports_money_path %></li>
                 <li class="menu-item"><%= link_to "Notifications", admin_reports_notifications_path %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -171,6 +171,11 @@ Rails.application.routes.draw do
       resources :shifts, only: :index
       resources :items_without_image, only: :index
       resources :items_with_holds, only: :index
+      resources :unfinished_appointments, only: :index do
+        member do
+          post :complete
+        end
+      end
       resources :zipcodes, only: :index
       get "money", to: "money#index"
       get "members-with-overdue-loans", to: "members_with_overdue_loans#index"

--- a/test/controllers/admin/appointments_controller_test.rb
+++ b/test/controllers/admin/appointments_controller_test.rb
@@ -46,5 +46,27 @@ module Admin
         get admin_appointment_path(@appointment)
       end
     end
+
+    test "labels a hold that timed out as expired, not checked-out" do
+      appointment = build(:appointment, member: @member)
+      appointment.holds << create(:hold, :expired, member: @member)
+      appointment.save!
+
+      get admin_appointment_path(appointment)
+
+      assert_select "em", text: "Hold expired without pickup"
+      assert_select "em", text: "Item checked-out", count: 0
+    end
+
+    test "labels a hold that was actually picked up as checked-out" do
+      appointment = build(:appointment, member: @member)
+      loan = create(:loan, member: @member)
+      appointment.holds << create(:hold, :ended, member: @member, loan: loan)
+      appointment.save!
+
+      get admin_appointment_path(appointment)
+
+      assert_select "em", text: "Item checked-out"
+    end
   end
 end

--- a/test/controllers/admin/appointments_controller_test.rb
+++ b/test/controllers/admin/appointments_controller_test.rb
@@ -68,5 +68,14 @@ module Admin
 
       assert_select "em", text: "Item checked-out"
     end
+
+    test "banners unfinished appointments on the index when any exist" do
+      create(:appointment, holds: [create(:hold)], pulled_at: 2.days.ago,
+        starts_at: 2.days.ago, ends_at: 2.days.ago + 1.hour)
+
+      get admin_appointments_path(day: Date.current.strftime("%F"))
+
+      assert_select "a[href=?]", admin_reports_unfinished_appointments_path
+    end
   end
 end

--- a/test/controllers/admin/reports/unfinished_appointments_controller_test.rb
+++ b/test/controllers/admin/reports/unfinished_appointments_controller_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+
+module Admin
+  module Reports
+    class UnfinishedAppointmentsControllerTest < ActionDispatch::IntegrationTest
+      include Devise::Test::IntegrationHelpers
+
+      setup do
+        @user = create(:admin_user)
+        sign_in @user
+      end
+
+      test "lists pulled-but-never-completed appointments with items not checked out" do
+        unfinished = create(:appointment, holds: [create(:hold)], pulled_at: 2.days.ago,
+          starts_at: 2.days.ago, ends_at: 2.days.ago + 1.hour)
+        completed = create(:appointment, holds: [create(:hold)], pulled_at: 2.days.ago,
+          completed_at: 1.day.ago, starts_at: 2.days.ago, ends_at: 2.days.ago + 1.hour)
+
+        get admin_reports_unfinished_appointments_url
+        assert_response :success
+
+        assert_select "a[href=?]", admin_appointment_path(unfinished)
+        assert_select "a[href=?]", admin_appointment_path(completed), false,
+          "completed appointments should not appear"
+      end
+
+      test "shows an empty state when nothing is unfinished" do
+        get admin_reports_unfinished_appointments_url
+        assert_response :success
+
+        assert_select "table", false
+      end
+
+      test "marking an appointment complete resolves it and drops it from the list" do
+        appointment = create(:appointment, holds: [create(:hold)], pulled_at: 2.days.ago,
+          starts_at: 2.days.ago, ends_at: 2.days.ago + 1.hour)
+        assert_includes Appointment.unfinished, appointment
+
+        post complete_admin_reports_unfinished_appointment_url(appointment)
+
+        assert_redirected_to admin_reports_unfinished_appointments_url
+        assert appointment.reload.completed?
+        refute_includes Appointment.unfinished, appointment
+      end
+    end
+  end
+end

--- a/test/models/appointment_test.rb
+++ b/test/models/appointment_test.rb
@@ -140,4 +140,38 @@ class AppointmentTest < ActiveSupport::TestCase
 
     refute appointment.dropoff_only?
   end
+
+  test "pulling an appointment protects attached holds from expiring on their own clock" do
+    member = create(:member, :with_user)
+    hold = create(:hold, member: member, creator: member.user, started_at: Time.current, expires_at: 1.day.from_now)
+    appointment = create(:appointment, member: member, holds: [hold])
+
+    appointment.update!(pulled_at: Time.current, staff_updating: true)
+
+    expected = (appointment.pulled_at + Appointment::HOLD_PULL_EXPIRY_BACKSTOP).end_of_day
+    assert_equal expected.to_i, hold.reload.expires_at.to_i
+  end
+
+  test "pulling never shortens a hold that already expires after the backstop" do
+    member = create(:member, :with_user)
+    far_future = 30.days.from_now
+    hold = create(:hold, member: member, creator: member.user, started_at: Time.current, expires_at: far_future)
+    appointment = create(:appointment, member: member, holds: [hold])
+
+    appointment.update!(pulled_at: Time.current, staff_updating: true)
+
+    assert_equal far_future.to_i, hold.reload.expires_at.to_i
+  end
+
+  test "un-pulling an appointment leaves the already-extended hold expiry untouched" do
+    member = create(:member, :with_user)
+    hold = create(:hold, member: member, creator: member.user, started_at: Time.current, expires_at: 1.day.from_now)
+    appointment = create(:appointment, member: member, holds: [hold])
+    appointment.update!(pulled_at: Time.current, staff_updating: true)
+    extended = hold.reload.expires_at
+
+    appointment.update!(pulled_at: nil, staff_updating: true)
+
+    assert_equal extended.to_i, hold.reload.expires_at.to_i
+  end
 end

--- a/test/models/appointment_test.rb
+++ b/test/models/appointment_test.rb
@@ -97,6 +97,38 @@ class AppointmentTest < ActiveSupport::TestCase
     assert_equal not_pulled_appointments, Appointment.all.not_pulled
   end
 
+  test ".unfinished surfaces recent pulled, never-completed appointments with items still not checked out" do
+    unfinished = create(:appointment, holds: [create(:hold)], pulled_at: 2.days.ago,
+      starts_at: 2.days.ago, ends_at: 2.days.ago + 1.hour)
+
+    # completed -> resolved, excluded
+    create(:appointment, holds: [create(:hold)], pulled_at: 2.days.ago, completed_at: 1.day.ago,
+      starts_at: 2.days.ago, ends_at: 2.days.ago + 1.hour)
+    # never pulled -> not in progress, excluded
+    create(:appointment, holds: [create(:hold)], pulled_at: nil,
+      starts_at: 2.days.ago, ends_at: 2.days.ago + 1.hour)
+    # pulled today -> still legitimately in progress, excluded
+    create(:appointment, holds: [create(:hold)], pulled_at: Time.current,
+      starts_at: Time.current, ends_at: 1.hour.from_now)
+    # older than the window -> stale, excluded
+    create(:appointment, holds: [create(:hold)],
+      pulled_at: (Appointment::UNFINISHED_WINDOW + 5.days).ago,
+      starts_at: (Appointment::UNFINISHED_WINDOW + 5.days).ago,
+      ends_at: (Appointment::UNFINISHED_WINDOW + 5.days).ago + 1.hour)
+    # pulled, but every held item was checked out -> nothing dangling, excluded
+    member = create(:member)
+    checked_out = create(:hold, member: member, loan: create(:loan, member: member))
+    create(:appointment, holds: [checked_out], pulled_at: 2.days.ago, member: member,
+      starts_at: 2.days.ago, ends_at: 2.days.ago + 1.hour)
+    # held item resolved by an explicit end (cancelled / retired) -> excluded
+    ended_member = create(:member)
+    ended_hold = create(:hold, :ended, member: ended_member)
+    create(:appointment, holds: [ended_hold], pulled_at: 2.days.ago, member: ended_member,
+      starts_at: 2.days.ago, ends_at: 2.days.ago + 1.hour)
+
+    assert_equal [unfinished], Appointment.unfinished
+  end
+
   test "#cancel_if_no_items!" do
     appointment = create(:appointment_with_holds)
     appointment.holds.destroy_all


### PR DESCRIPTION
> 📚 **Stacked on #2185.** This targets the `appointment-hold-expiry-fixes` branch, so review/merge #2185 first; GitHub will retarget this to `main` once that lands.

# What it does

Adds an **Unfinished Appointments** report (under Reports) and a banner on the Appointments page that links to it. Both surface appointments where staff pulled the items, never marked the appointment complete, and at least one held item never got checked out. Each row can be resolved in place with a **Mark complete** button, and links to the appointment, member, and items for anything that needs a closer look.

"Unfinished" means: pulled, never completed, from the last 30 days, and still holding at least one item that's neither checked out nor explicitly ended (cancelled or retired). Today's and future appointments are never included, so the normal pickup flow doesn't show up here.

# Why it is important

This is the third piece of the "items wandering off member accounts" story that staff have been reporting. The thread started from a real incident: an item showed as checked out to a member, but there was no loan behind it. Digging in, what actually happened was an appointment got pulled (items physically came off the shelf), some items went home and got checked out, one didn't, and the appointment was never closed. Nothing surfaces that half-finished state, so it just scrolls off that day's schedule and is forgotten. Weeks later, when someone goes looking for the item, the system looks like it's lying.

#2180 and #2181 (the stacked-under PR) stop the appointment page from mislabeling timed-out holds and stop holds from expiring mid-appointment. But neither makes the dangling appointments *visible*, which is what lets them rot. This adds the daily worklist: a short, recent list of appointments that need a human to close the loop, with the resolve action right there so it isn't a multi-click safari.

The 30-day window came out of checking prod before shipping. The naive "all pulled-but-never-completed appointments with an un-checked-out item" query returns ~330 rows stretching back over a year, and 70% of those items have been loaned to someone else in just the last 90 days (35% are checked out right now). In other words the old rows are stale records, not lost tools, and dumping 330 of them on staff would train everyone to ignore the list. Scoped to 30 days it's ~50 actionable rows. The report copy says so out loud, so the scoping isn't a silent surprise.

# UI Change Screenshot

_Banner on the Appointments page:_
<img width="2016" height="974" alt="2026-06-05 at 14 41 08@2x" src="https://github.com/user-attachments/assets/8404905b-6b5b-446d-b95d-f306ccc94c8c" />

_Unfinished Appointments report with the Mark complete action:_ 
<img width="2212" height="1468" alt="2026-06-05 at 14 40 50@2x" src="https://github.com/user-attachments/assets/968d58c2-8b22-4085-896c-dbcbf6f0f9fc" />

# Implementation notes

A few decisions worth a look in review:

- **Scope excludes already-ended holds** (`loan_id` nil *and* `ended_at` nil), so holds that were cancelled/retired (or hit the #2183 save-failure bug) don't show as unfinished. Expired-but-not-ended holds still surface, since that's exactly the signal we want.
- **The 30-day window is a constant** (`Appointment::UNFINISHED_WINDOW`), and the report/banner copy is derived from it so they can't drift. The pre-existing backlog is intentionally out of scope here; it's a separate "bulk-complete old pulled appointments" decision we can make deliberately later.
- **Inline resolve** posts to a `complete` action that sets `completed_at` and 303-redirects back to the report, so it plays nicely with Turbo and the row just drops off. Reversible from the appointment page.

Fixes #2182
