### PR TITLE
Add an oldest item column to overdue items report

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,6 +229,7 @@ GEM
       net-http-persistent (>= 4.0.4, < 5)
     faraday-retry (2.3.2)
       faraday (~> 2.0)
+    ffi (1.17.3-aarch64-linux-gnu)
     ffi (1.17.3-arm64-darwin)
     ffi (1.17.3-x86_64-darwin)
     ffi (1.17.3-x86_64-linux-gnu)
@@ -363,6 +364,8 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
+    nokogiri (1.19.3-aarch64-linux-gnu)
+      racc (~> 1.4)
     nokogiri (1.19.3-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.19.3-x86_64-darwin)
@@ -400,6 +403,7 @@ GEM
     parser (3.3.10.1)
       ast (~> 2.4.1)
       racc
+    pg (1.6.3-aarch64-linux)
     pg (1.6.3-arm64-darwin)
     pg (1.6.3-x86_64-darwin)
     pg (1.6.3-x86_64-linux)
@@ -618,6 +622,7 @@ GEM
     zlib (3.2.3)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-22
   arm64-darwin-23
   arm64-darwin-24

--- a/app/controllers/admin/reports/members_with_overdue_loans_controller.rb
+++ b/app/controllers/admin/reports/members_with_overdue_loans_controller.rb
@@ -42,7 +42,7 @@ module Admin
 
       def build_csv(members)
         CSV.generate(headers: true) do |csv|
-          csv << %w[preferred_name full_name email phone_number overdue_tools]
+          csv << %w[preferred_name full_name email phone_number overdue_tools oldest_item_due_date]
 
           members.find_each do |member|
             csv << [
@@ -50,7 +50,8 @@ module Admin
               member.full_name,
               member.user.email,
               member.phone_number,
-              member.overdue_loans.map { |loan| "#{loan.item.name} (#{time_ago_in_words(loan.due_at)})" }.join(", ")
+              member.overdue_loans.map { |loan| "#{loan.item.name} (#{time_ago_in_words(loan.due_at)})" }.join(", "),
+              member.overdue_loan_min.to_fs(:short_date)
             ]
           end
         end

--- a/app/views/admin/reports/members_with_overdue_loans/index.html.erb
+++ b/app/views/admin/reports/members_with_overdue_loans/index.html.erb
@@ -27,6 +27,7 @@
         <th>Overdue Tools</th>
         <th>Email</th>
         <th>Phone</th>
+        <th>Oldest Item Due Date</th>
       </tr>
       <% @members.each do |member| %>
         <tr>
@@ -44,6 +45,9 @@
           </td>
           <td>
             <%= format_phone_number(member.phone_number) %>
+          </td>
+          <td>
+            <%= member.overdue_loan_min.to_fs(:short_date) %>
           </td>
         </tr>
       <% end %>

--- a/test/system/admin/reports/members_with_overdue_items_test.rb
+++ b/test/system/admin/reports/members_with_overdue_items_test.rb
@@ -44,6 +44,9 @@ class AdminMembersWithOverdueItemsTest < ApplicationSystemTestCase
         assert_text loan.item.name
         assert_text time_ago_in_words(loan.due_at)
       end
+
+      oldest_due_at = member.overdue_loans.map(&:due_at).min
+      assert_text oldest_due_at.to_fs(:short_date)
     end
     assert_equal 3, all("tr").size # 2 for members, 1 for the header
   end


### PR DESCRIPTION
# What it does

Adds a new column to the Members with Overdue Items report that lists the oldest due date for that member's items. This column is also added to the CSV that we export for external analysis.

# Why it is important

Staff feature request to make it easier to sort the exported CSV.