### PR TITLE
Don't emit logs while running tests

### DIFF
--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -1,4 +1,4 @@
 require "stripe"
 
 Stripe.max_network_retries = 2
-Stripe.log_level = Stripe::LEVEL_INFO
+Stripe.log_level = Stripe::LEVEL_INFO unless Rails.env.test?


### PR DESCRIPTION
# What it does

This makes it so running tests isn't so noisy. I'm leaving them on in dev/prod while we sort out how things actually work.