### PR TITLE
Highlight items added after appointments are pulled

### DIFF
--- a/app/assets/stylesheets/partials/_admin_appointments.scss
+++ b/app/assets/stylesheets/partials/_admin_appointments.scss
@@ -6,6 +6,11 @@
     opacity: 0.7;
   }
 
+  div.card.items-added-after-pull {
+    background-color: rgba(variables.$error-color, 0.12);
+    border-color: variables.$error-color;
+  }
+
   .table-header > .column {
     font-weight: bold;
   }
@@ -46,6 +51,14 @@
     background-color: variables.$bg-color-dark;
     td {
       opacity: 0.7;
+    }
+  }
+
+  tr.items-added-after-pull {
+    background-color: rgba(variables.$error-color, 0.12);
+
+    td:first-child {
+      border-left: 0.2rem solid variables.$error-color;
     }
   }
 
@@ -112,6 +125,14 @@ p.appointment-comment {
     background-color: variables.$bg-color-dark;
     td {
       opacity: 0.7;
+    }
+  }
+
+  tr.items-added-after-pull {
+    background-color: rgba(variables.$error-color, 0.12);
+
+    td:first-child {
+      border-left: 0.2rem solid variables.$error-color;
     }
   }
 

--- a/app/controllers/admin/appointments_controller.rb
+++ b/app/controllers/admin/appointments_controller.rb
@@ -8,7 +8,8 @@ module Admin
       @appointments = Appointment
         .where(starts_at: @current_day.all_day)
         .chronologically
-        .includes(:member, loans: {item: :borrow_policy}, holds: {item: :borrow_policy})
+        .includes(:appointment_holds, :appointment_loans, :member,
+          loans: {item: :borrow_policy}, holds: {item: :borrow_policy})
 
       @unfinished_appointments_count = Appointment.unfinished.count
 

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -74,6 +74,29 @@ class Appointment < ApplicationRecord
     holds.select { |hold| hold.loan_id.nil? }
   end
 
+  def hold_added_after_pull?(hold)
+    return false if pulled_at.nil?
+
+    appointment_holds.any? do |appointment_hold|
+      appointment_hold.hold_id == hold.id && appointment_hold.created_at > pulled_at
+    end
+  end
+
+  def loan_added_after_pull?(loan)
+    return false if pulled_at.nil?
+
+    appointment_loans.any? do |appointment_loan|
+      appointment_loan.loan_id == loan.id && appointment_loan.created_at > pulled_at
+    end
+  end
+
+  def items_added_after_pull?
+    return false if pulled_at.nil?
+
+    appointment_holds.any? { |appointment_hold| appointment_hold.created_at > pulled_at } ||
+      appointment_loans.any? { |appointment_loan| appointment_loan.created_at > pulled_at }
+  end
+
   def dropoff_only?
     holds.empty? && !loans.empty?
   end

--- a/app/views/admin/appointments/_appointment.html.erb
+++ b/app/views/admin/appointments/_appointment.html.erb
@@ -1,6 +1,6 @@
 <%= tag.tr(
       id: "#{dom_id(appointment)}-desktop",
-      class: "appointment #{"completed" if appointment.completed?} #{"pulled" if appointment.pulled_at? && !appointment.completed?} #{"pending" unless appointment.pulled_at? || !appointment.completed?}",
+      class: "appointment #{"completed" if appointment.completed?} #{"pulled" if appointment.pulled_at? && !appointment.completed?} #{"pending" unless appointment.pulled_at? || !appointment.completed?} #{"items-added-after-pull" if !appointment.completed? && appointment.items_added_after_pull?}",
       data: {sort_key: appointment_sort_key(appointment), appointment_id: appointment.id}
     ) do %>
   <td class="time"><%= l appointment.starts_at, format: :hour %> - <%= l appointment.ends_at, format: :hour %></td>
@@ -11,13 +11,21 @@
   <td class="items">
     <% appointment.holds.each do |hold| %>
       <span><%= hold.item.complete_number %></span>
-      <%= link_to hold.item.name, admin_item_path(hold.item) %> <br>
+      <%= link_to hold.item.name, admin_item_path(hold.item) %>
+      <% if !appointment.completed? && appointment.hold_added_after_pull?(hold) %>
+        <span class="label label-error">added after pull</span>
+      <% end %>
+      <br>
     <% end %>
   </td>
   <td class="items">
     <% appointment.loans.each do |loan| %>
       <span><%= loan.item.complete_number %></span>
-      <%= link_to loan.item.name, admin_item_path(loan.item) %> <br>
+      <%= link_to loan.item.name, admin_item_path(loan.item) %>
+      <% if !appointment.completed? && appointment.loan_added_after_pull?(loan) %>
+        <span class="label label-error">added after pull</span>
+      <% end %>
+      <br>
     <% end %>
   </td>
   <td class="notes"><%= appointment.comment %></td>
@@ -27,6 +35,10 @@
       <%= button_to "restore", admin_appointment_completion_path(appointment, params: {new: true}),
             method: :delete, class: "btn btn-sm", data: {turbo_stream: true, turbo_disable: "saving"} %>
     <% elsif appointment.pulled_at? %>
+      <% if appointment.items_added_after_pull? %>
+        <%= button_to "mark new items pulled", admin_appointment_pull_path(appointment, params: {new: true}),
+              method: :post, class: "btn btn-sm", data: {turbo_stream: true, turbo_disable: "saving"} %>
+      <% end %>
       <%= button_to "mark as not pulled", admin_appointment_pull_path(appointment, params: {new: true}),
             method: :delete, class: "btn btn-sm", data: {turbo_stream: true, turbo_disable: "saving"} %>
       <%= button_to "complete", admin_appointment_completion_path(appointment, params: {new: true}),

--- a/app/views/admin/appointments/_appointment_mobile.html.erb
+++ b/app/views/admin/appointments/_appointment_mobile.html.erb
@@ -1,4 +1,4 @@
-<div id="<%= dom_id(appointment) %>-mobile" class="card <%= "completed" if appointment.completed? %> <%= "pulled" if appointment.pulled_at? && !appointment.completed? %>">
+<div id="<%= dom_id(appointment) %>-mobile" class="card <%= "completed" if appointment.completed? %> <%= "pulled" if appointment.pulled_at? && !appointment.completed? %> <%= "items-added-after-pull" if !appointment.completed? && appointment.items_added_after_pull? %>">
   <div class="card-header">
     <div class="card-title h5">
       <%= link_to preferred_or_default_name(appointment.member), admin_member_path(appointment.member) %>
@@ -24,6 +24,9 @@
             <div class="columns">
               <div class="column col-8">
                 <%= link_to hold.item.name, admin_item_path(hold.item), title: hold.item.complete_number %>
+                <% if !appointment.completed? && appointment.hold_added_after_pull?(hold) %>
+                  <span class="label label-error">added after pull</span>
+                <% end %>
               </div>
               <div class="column col-4">
                 <%= hold.item.complete_number %>
@@ -43,6 +46,9 @@
             <div class="columns">
               <div class="column col-8">
                 <%= link_to loan.item.name, admin_item_path(loan.item), title: loan.item.complete_number %>
+                <% if !appointment.completed? && appointment.loan_added_after_pull?(loan) %>
+                  <span class="label label-error">added after pull</span>
+                <% end %>
               </div>
               <div class="column col-4">
                 <%= loan.item.complete_number %>
@@ -59,6 +65,10 @@
       <%= button_to "Restore", admin_appointment_completion_path(appointment, new: true),
             method: :delete, class: "btn btn-primary", data: {turbo_stream: true, turbo_disable: "saving"} %>
     <% elsif appointment.pulled_at? %>
+      <% if appointment.items_added_after_pull? %>
+        <%= button_to "Mark New Items Pulled", admin_appointment_pull_path(appointment, params: {new: true}),
+              method: :post, class: "btn btn-primary", data: {turbo_stream: true, turbo_disable: "saving"} %>
+      <% end %>
       <%= button_to "Mark As Not Pulled", admin_appointment_pull_path(appointment, params: {new: true}),
             method: :delete, class: "btn btn-primary", data: {turbo_stream: true, turbo_disable: "saving"} %>
       <%= button_to "Complete", admin_appointment_completion_path(appointment, new: true),

--- a/app/views/admin/appointments/_appointment_orig.html.erb
+++ b/app/views/admin/appointments/_appointment_orig.html.erb
@@ -1,6 +1,6 @@
 <%= tag.tr(
       id: dom_id(appointment),
-      class: "appointment #{"completed" if appointment.completed?} #{"pulled" if appointment.pulled_at? && !appointment.completed?} #{"pending" unless appointment.pulled_at? || !appointment.completed?}",
+      class: "appointment #{"completed" if appointment.completed?} #{"pulled" if appointment.pulled_at? && !appointment.completed?} #{"pending" unless appointment.pulled_at? || !appointment.completed?} #{"items-added-after-pull" if !appointment.completed? && appointment.items_added_after_pull?}",
       data: {sort_key: appointment_sort_key(appointment), appointment_id: appointment.id}
     ) do %>
   <td class="time"><%= l appointment.starts_at, format: :hour %> - <%= l appointment.ends_at, format: :hour %></td>
@@ -11,20 +11,32 @@
   <td class="items">
     <% appointment.holds.take(10).each do |hold| %>
       <span class="label label-primary">pick-up</span>
-      <%= link_to hold.item.name, admin_item_path(hold.item), title: hold.item.complete_number %> <br>
+      <%= link_to hold.item.name, admin_item_path(hold.item), title: hold.item.complete_number %>
+      <% if !appointment.completed? && appointment.hold_added_after_pull?(hold) %>
+        <span class="label label-error">added after pull</span>
+      <% end %>
+      <br>
     <% end %>
     <% if appointment.holds.count > 10 %>
       <details>
         <summary>and <%= appointment.holds.count - 10 %> more</summary>
         <% appointment.holds[10..].each do |hold| %>
           <span class="label label-primary">pick-up</span>
-          <%= link_to hold.item.name, admin_item_path(hold.item), title: hold.item.complete_number %> <br>
+          <%= link_to hold.item.name, admin_item_path(hold.item), title: hold.item.complete_number %>
+          <% if !appointment.completed? && appointment.hold_added_after_pull?(hold) %>
+            <span class="label label-error">added after pull</span>
+          <% end %>
+          <br>
         <% end %>
       </details>
     <% end %>
     <% appointment.loans.each do |loan| %>
       <span class="label label-seondary">drop-off</span>
-      <%= link_to loan.item.name, admin_item_path(loan.item) %> <br>
+      <%= link_to loan.item.name, admin_item_path(loan.item) %>
+      <% if !appointment.completed? && appointment.loan_added_after_pull?(loan) %>
+        <span class="label label-error">added after pull</span>
+      <% end %>
+      <br>
     <% end %>
   </td>
   <td class="notes"><%= appointment.comment %></td>
@@ -34,6 +46,10 @@
       <%= button_to "Restore", admin_appointment_completion_path(appointment), params: {new: false},
             method: :delete, class: "btn btn-sm", data: {turbo_stream: true, turbo_disable: "saving"} %>
     <% elsif appointment.pulled_at? %>
+      <% if appointment.items_added_after_pull? %>
+        <%= button_to "Mark New Items Pulled", admin_appointment_pull_path(appointment, params: {new: false}),
+              method: :post, class: "btn btn-sm", data: {turbo_stream: true, turbo_disable: "saving"} %>
+      <% end %>
       <%= button_to "Mark As Not Pulled", admin_appointment_pull_path(appointment, params: {new: false}),
             method: :delete, class: "btn btn-sm", data: {turbo_stream: true, turbo_disable: "saving"} %>
       <%= button_to "Complete", admin_appointment_completion_path(appointment), params: {new: false},

--- a/app/views/admin/appointments/_checkins.html.erb
+++ b/app/views/admin/appointments/_checkins.html.erb
@@ -21,7 +21,12 @@
         <% end %>
         </div>
         <div class="column col-sm-6 col-4">
-          <p><%= loan.item.name %></p>
+          <p>
+            <%= loan.item.name %>
+            <% if !@appointment.completed? && @appointment.loan_added_after_pull?(loan) %>
+              <span class="label label-error">added after pull</span>
+            <% end %>
+          </p>
           <p><%= link_to full_item_number(loan.item), admin_item_path(loan.item) %></p>
         </div>
         <div class="column col-sm-12 col-4 text-right" data-controller="confirm-item-accessories">

--- a/app/views/admin/appointments/_checkouts.html.erb
+++ b/app/views/admin/appointments/_checkouts.html.erb
@@ -20,7 +20,12 @@
         <div class="divider"></div>
       </div>
       <div class="column col-sm-6 col-4">
-        <p><%= hold.item.name %></p>
+        <p>
+          <%= hold.item.name %>
+          <% if !@appointment.completed? && @appointment.hold_added_after_pull?(hold) %>
+            <span class="label label-error">added after pull</span>
+          <% end %>
+        </p>
         <p><%= link_to full_item_number(hold.item), admin_item_path(hold.item) %></p>
       </div>
       <div class="column col-sm-12 col-4 text-right checkout-button-column" data-controller="confirm-item-accessories">

--- a/test/models/appointment_test.rb
+++ b/test/models/appointment_test.rb
@@ -97,6 +97,47 @@ class AppointmentTest < ActiveSupport::TestCase
     assert_equal not_pulled_appointments, Appointment.all.not_pulled
   end
 
+  test "late-added holds and loans are distinguished from items attached before the appointment was pulled" do
+    original_hold = create(:hold)
+    original_loan = create(:loan)
+    hold_appointment = create(:appointment, holds: [original_hold])
+    loan_appointment = create(:appointment, loans: [original_loan])
+    unchanged_appointment = create(:appointment, holds: [create(:hold)])
+    unpulled_appointment = create(:appointment, holds: [create(:hold)])
+    pulled_at = Time.current
+
+    [hold_appointment, loan_appointment, unchanged_appointment].each do |appointment|
+      appointment.update_column(:pulled_at, pulled_at)
+    end
+
+    late_hold = create(:appointment_hold, appointment: hold_appointment, created_at: 1.minute.from_now).hold
+    late_loan = create(:appointment_loan, appointment: loan_appointment, created_at: 1.minute.from_now).loan
+    create(:appointment_hold, appointment: unpulled_appointment, created_at: 1.minute.from_now)
+
+    [hold_appointment, loan_appointment, unchanged_appointment, unpulled_appointment].each(&:reload)
+
+    assert hold_appointment.hold_added_after_pull?(late_hold)
+    refute hold_appointment.hold_added_after_pull?(original_hold)
+    assert loan_appointment.loan_added_after_pull?(late_loan)
+    refute loan_appointment.loan_added_after_pull?(original_loan)
+    assert hold_appointment.items_added_after_pull?
+    assert loan_appointment.items_added_after_pull?
+    refute unchanged_appointment.items_added_after_pull?
+    refute unpulled_appointment.items_added_after_pull?
+  end
+
+  test "pulling an appointment again resets which items count as late additions" do
+    appointment = create(:appointment, holds: [create(:hold)])
+    appointment.update_column(:pulled_at, Time.current)
+    create(:appointment_hold, appointment: appointment, created_at: 1.minute.from_now)
+
+    assert appointment.reload.items_added_after_pull?
+
+    appointment.update_column(:pulled_at, 2.minutes.from_now)
+
+    refute appointment.reload.items_added_after_pull?
+  end
+
   test ".unfinished surfaces recent pulled, never-completed appointments with items still not checked out" do
     unfinished = create(:appointment, holds: [create(:hold)], pulled_at: 2.days.ago,
       starts_at: 2.days.ago, ends_at: 2.days.ago + 1.hour)

--- a/test/system/admin/appointments_notifications_test.rb
+++ b/test/system/admin/appointments_notifications_test.rb
@@ -38,5 +38,37 @@ module Admin
       assert_text "unpulled appointments"
       Timecop.return
     end
+
+    test "a pulled appointment and its late-added items are highlighted in the schedule" do
+      appointment = create(:appointment, holds: [create(:hold)], starts_at: Time.current, ends_at: 15.minutes.from_now)
+      appointment.appointment_holds.update_all(created_at: 3.minutes.ago)
+      appointment.update_column(:pulled_at, 2.minutes.ago)
+      late_hold = create(:hold, item: create(:item, name: "Circular Saw"))
+      create(:appointment_hold, appointment: appointment, hold: late_hold, created_at: Time.current)
+      original_pulled_at = appointment.pulled_at
+
+      visit admin_appointments_path(day: appointment.starts_at.to_date)
+
+      within "tr.items-added-after-pull" do
+        assert_text "Circular Saw"
+        assert_selector ".label.label-error", text: "added after pull"
+        click_button "Mark New Items Pulled"
+      end
+
+      refute_selector "tr.items-added-after-pull"
+      refute_selector ".label.label-error", text: "added after pull"
+      assert_operator appointment.reload.pulled_at, :>, original_pulled_at
+    end
+
+    test "completed appointments with late-added items are not highlighted" do
+      appointment = create(:appointment, holds: [create(:hold)], starts_at: Time.current, ends_at: 15.minutes.from_now)
+      appointment.update_columns(pulled_at: Time.current, completed_at: Time.current)
+      create(:appointment_hold, appointment: appointment, created_at: 1.minute.from_now)
+
+      visit admin_appointments_path(day: appointment.starts_at.to_date)
+
+      refute_selector "tr.items-added-after-pull"
+      refute_selector ".label.label-error", text: "added after pull"
+    end
   end
 end


### PR DESCRIPTION
# What it does

Highlights pulled appointments directly in the schedule when a member adds pickup or dropoff items afterward. The exact new items are labeled, and staff can use “Mark New Items Pulled” to clear the highlight without unpulling the appointment.

# Why it is important

Once an appointment was pulled, later additions were easy to miss because the schedule still looked ready. Keeping the warning on the affected appointment shows staff both where the problem is and which items remain on the shelf.

Closes #2201

# UI Change Screenshot

<img width="1440" height="1000" alt="issue-2201-demo-one-click-clear" src="https://github.com/user-attachments/assets/a72dcef3-8d9e-4757-981c-becf28960c9c" />

# Implementation notes

The appointment item join timestamps are compared with `pulled_at`, which acts as the most recent shelf-pull watermark. Marking the new items pulled advances that timestamp through the existing pull action, so no migration or additional state is needed.