### PR TITLE
Don't 500 when the item is already off the appointment

### DIFF
--- a/app/controllers/admin/appointment_holds_controller.rb
+++ b/app/controllers/admin/appointment_holds_controller.rb
@@ -8,18 +8,39 @@ module Admin
     end
 
     def destroy
-      remove_appointment_hold
-      redirect_to admin_appointment_path(appointment), flash: {success: "Item removed from appointment."}, status: :see_other
+      flash_message = if remove_appointment_hold
+        {success: "Item removed from appointment."}
+      else
+        {warning: "That item is no longer on this appointment. The member may have updated it."}
+      end
+
+      redirect_to admin_appointment_path(appointment), flash: flash_message, status: :see_other
     end
 
     private
 
+    # Returns false when the item is already off the appointment. Members can
+    # edit their own appointments and cancel their own holds, so a librarian
+    # working from a page rendered moments earlier can click "Remove Item" for
+    # a hold that is already gone (#2212).
     def remove_appointment_hold
-      @remove_appointment_hold ||= appointment.appointment_holds.find_by(hold_id: params[:id]).destroy
+      appointment_hold = appointment.appointment_holds.find_by(hold_id: params[:id])
+      return false if appointment_hold.nil?
 
-      if params[:cancel_hold].to_s.downcase == "true"
-        Hold.find(params[:id]).destroy
+      # Take the hold from the join row rather than from params[:id], so
+      # cancelling can't reach a hold on someone else's appointment.
+      hold = appointment_hold.hold
+
+      appointment_hold.transaction do
+        appointment_hold.destroy!
+        hold.destroy! if cancel_hold? && hold
       end
+
+      true
+    end
+
+    def cancel_hold?
+      params[:cancel_hold].to_s.downcase == "true"
     end
 
     def add_new_appointment_hold

--- a/test/controllers/admin/appointment_holds_controller_test.rb
+++ b/test/controllers/admin/appointment_holds_controller_test.rb
@@ -40,5 +40,37 @@ module Admin
         end
       end
     end
+
+    test "removing an item the member already took off the appointment" do
+      # Members can edit their own appointments, so the librarian's page can be
+      # stale by the time they click. Removing an item that is already gone
+      # should land them back on the appointment rather than erroring, and it
+      # must not cancel the member's hold instead (#2212).
+      @appointment.appointment_holds.destroy_all
+
+      assert_no_difference("@member.holds.count") do
+        delete admin_appointment_hold_path(@appointment, @hold), params: {cancel_hold: true}
+      end
+
+      assert_redirected_to admin_appointment_path(@appointment)
+      assert_equal "That item is no longer on this appointment. The member may have updated it.", flash[:warning]
+      assert Hold.exists?(@hold.id), "the member's hold should survive"
+    end
+
+    test "cannot cancel a hold belonging to a different appointment" do
+      # params[:id] is only trustworthy once we've confirmed the hold is on
+      # this appointment, otherwise "Cancel Hold" can destroy someone else's.
+      other_appointment = FactoryBot.create(:appointment_with_holds)
+      other_hold = other_appointment.holds.first
+
+      assert_no_difference("Hold.count") do
+        assert_no_difference("AppointmentHold.count") do
+          delete admin_appointment_hold_path(@appointment, other_hold), params: {cancel_hold: true}
+        end
+      end
+
+      assert_redirected_to admin_appointment_path(@appointment)
+      assert Hold.exists?(other_hold.id), "the other appointment's hold should survive"
+    end
   end
 end


### PR DESCRIPTION
# What it does

Staff clicking "Cancel Hold" or "Remove Item" for an item that's no longer on the appointment got a 500. Now they land back on the appointment with a warning instead.

# Why it is important

Fixes #2212. Members can edit their own appointments and cancel their own holds, so a librarian's page goes stale with no warning. This happens in normal use.

# Implementation notes

- The hold comes off the join row rather than `params[:id]`. That matters because `Hold.find(params[:id])` was scoped to the library tenant but not to the appointment or member, so with the crash gone it would have let "Cancel Hold" destroy any hold in the library.
- Both destroys run in a transaction now.
- Both new tests fail against the old code with the same `NoMethodError`.
