### PR TITLE
Add a Blazer link to the admin nav and set its time zone to Central

### DIFF
--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -71,6 +71,9 @@
               <li class="nav-item"><%= link_to "Items in Maintenance", admin_reports_items_in_maintenance_index_path %></li>
               <li class="nav-item"><%= link_to "Missing Items", admin_reports_missing_items_path %></li>
               <li class="nav-item"><%= link_to "Zipcodes", admin_reports_zipcodes_path %></li>
+              <% if current_user.admin? %>
+                <li class="nav-item"><%= link_to "Blazer", blazer_path %></li>
+              <% end %>
             </ul>
           </li>
 
@@ -180,6 +183,9 @@
                 <li class="menu-item"><%= link_to "Items in Maintenance", admin_reports_items_in_maintenance_index_path %></li>
                 <li class="menu-item"><%= link_to "Missing Items", admin_reports_missing_items_path %></li>
                 <li class="menu-item"><%= link_to "Zipcodes", admin_reports_zipcodes_path %></li>
+                <% if current_user.admin? %>
+                  <li class="menu-item"><%= link_to "Blazer", blazer_path %></li>
+                <% end %>
               </ul>
             </div>
             <div class="dropdown">

--- a/config/blazer.yml
+++ b/config/blazer.yml
@@ -36,7 +36,7 @@ data_sources:
 audit: true
 
 # change the time zone
-# time_zone: "Pacific Time (US & Canada)"
+time_zone: "Central Time (US & Canada)"
 
 # class name of the user model
 # user_class: User


### PR DESCRIPTION
# What it does

Adds a Blazer link to the bottom of the Reports menu in the admin nav, and sets Blazer's time zone to Central.

# Why it is important

Closes #2088. Right now the only way into Blazer is typing the URL.

The time zone matters because the app runs in UTC, so Blazer did too, and its date picker was handing queries UTC-midnight boundaries. We're in Chicago. While building a membership export report I found that one membership charge in six shows a different calendar day under UTC than under Central.

# Implementation notes

- Gated on `current_user.admin?` to match the route guard, which uses the exact role rather than `has_role?(:admin)`. That means super_admins can't reach Blazer, but there are none in production, so it changes nothing today.
- The admin nav is duplicated for mobile and desktop, so the link goes in both.
- Setting `time_zone` is enough on its own. The picker builds its values from `Blazer.time_zone`, so it sends a correctly offset instant and handles DST. No query needs a `WHERE` change.
- Only one saved query uses date variables today, so nothing else shifts underneath the time zone change.
